### PR TITLE
Add version_from_cargo proc macro

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt # rustfmt is required for macros tests.
 
       - name: Unit tests with coverage
         uses: actions-rs/tarpaulin@v0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arbitrary"
@@ -89,9 +89,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bech32"
@@ -117,9 +117,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
 dependencies = [
  "funty",
  "radium",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
@@ -169,9 +169,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -228,12 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e143857ef5e50b46bba431bb0ed990426912f5eea85d6048214d8196d83efed"
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,7 +250,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -266,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -277,20 +271,19 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
- "memoffset 0.6.1",
+ "memoffset 0.6.3",
  "scopeguard",
 ]
 
@@ -301,7 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -317,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -382,8 +375,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df89dd0d075dea5cc5fdd6d5df6b8a61172a710b3efac1d6bdb9dd8b78f82c1a"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -467,9 +460,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "generic-array"
@@ -521,9 +514,9 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -548,13 +541,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f65a8ecf74feeacdab8d38cb129e550ca871cccaa7d1921d8636ecd75534903"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -580,9 +573,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -607,9 +600,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "log"
@@ -641,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
@@ -736,7 +729,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
- "bech32 0.7.2",
+ "bech32 0.7.3",
  "ed25519-dalek",
  "hex",
  "impl-trait-for-tuples",
@@ -745,16 +738,26 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "oasis-core-runtime",
+ "oasis-runtime-sdk-macros",
  "serde",
  "serde_bytes",
  "thiserror",
 ]
 
 [[package]]
+name = "oasis-runtime-sdk-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.67",
+]
+
+[[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -844,18 +847,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
 
 [[package]]
 name = "radium"
-version = "0.4.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -900,18 +903,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "ring"
@@ -972,9 +975,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -1000,13 +1003,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1027,8 +1030,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1166,12 +1169,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
+ "quote 1.0.9",
  "unicode-xid 0.2.1",
 ]
 
@@ -1182,8 +1185,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
  "unicode-xid 0.2.1",
 ]
 
@@ -1199,22 +1202,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -1268,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-xid"
@@ -1302,9 +1305,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
@@ -1320,9 +1323,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1330,53 +1333,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
- "quote 1.0.8",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1467,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "quote 1.0.9",
+ "syn 1.0.67",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,12 @@ name = "arc-swap"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
+name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -108,6 +123,12 @@ dependencies = [
  "byteorder",
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 
 [[package]]
 name = "bitflags"
@@ -218,7 +239,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -303,7 +333,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -314,7 +344,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -353,9 +383,44 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize 1.2.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06d4a9551359071d1890820e3571252b91229e0712e7c36b08940e603c5a8fc"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b443e5fb0ddd56e0c9bfa47dc060c5306ee500cb731f2b91432dd65589a77684"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "strsim",
+ "syn 1.0.67",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
+dependencies = [
+ "darling_core",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -378,6 +443,12 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.67",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -417,7 +488,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_bytes",
  "sha2",
@@ -436,9 +507,32 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize 1.2.0",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+dependencies = [
+ "log 0.3.9",
+ "regex 0.2.11",
+]
+
+[[package]]
+name = "extprim"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1a357c911c352439b460d7b375b5c85977b9db395b703dfee5a94dfb4d66a2"
+dependencies = [
+ "num-traits",
+ "rand 0.6.5",
+ "rustc_version",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -448,9 +542,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -472,6 +578,15 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -502,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
 ]
 
@@ -538,6 +653,12 @@ dependencies = [
  "lazy_static",
  "memmap",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -593,6 +714,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +737,15 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.14",
+]
+
+[[package]]
+name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
@@ -614,13 +754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
 name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -629,7 +775,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -638,7 +784,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -647,7 +793,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
  "serde",
@@ -659,7 +805,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -669,7 +815,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -693,12 +839,12 @@ dependencies = [
  "intrusive-collections",
  "io-context",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "num-bigint",
  "num-traits",
  "pem",
  "percent-encoding",
- "rand",
+ "rand 0.7.3",
  "rustc-hex",
  "serde",
  "serde_bytes",
@@ -748,8 +894,11 @@ dependencies = [
 name = "oasis-runtime-sdk-macros"
 version = "0.1.0"
 dependencies = [
+ "darling",
+ "diff",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
+ "rustfmt",
  "syn 1.0.67",
 ]
 
@@ -773,7 +922,7 @@ checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
  "base64",
  "once_cell",
- "regex",
+ "regex 1.4.5",
 ]
 
 [[package]]
@@ -862,15 +1011,44 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -880,8 +1058,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -894,11 +1087,95 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.5.6",
+ "thread_local",
+ "utf8-ranges",
 ]
 
 [[package]]
@@ -907,7 +1184,16 @@ version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.23",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+dependencies = [
+ "ucd-util",
 ]
 
 [[package]]
@@ -928,7 +1214,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -944,6 +1230,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfmt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
+dependencies = [
+ "diff",
+ "env_logger",
+ "getopts",
+ "kernel32-sys",
+ "libc",
+ "log 0.3.9",
+ "regex 0.2.11",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "strings",
+ "syntex_errors",
+ "syntex_syntax",
+ "term",
+ "toml",
+ "unicode-segmentation",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -1040,7 +1351,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55adf0940448a33eac98b3c84ab2e567c1fbc086750bcfd72702d6facc39bb77"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -1063,7 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1101,7 +1412,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
 dependencies = [
- "log",
+ "log 0.4.14",
  "slog",
  "slog-scope",
 ]
@@ -1115,8 +1426,8 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand",
- "rand_core",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "ring",
  "rustc_version",
  "sha2",
@@ -1149,6 +1460,21 @@ dependencies = [
  "block-cipher",
  "generic-array",
 ]
+
+[[package]]
+name = "strings"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa481ee1bc42fc3df8195f91f7cb43cf8f2b71b48bac40bf5381cfaf7e481f3c"
+dependencies = [
+ "log 0.3.9",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1191,6 +1517,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntex_errors"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3133289179676c9f5c5b2845bf5a2e127769f4889fcbada43035ef6bd662605e"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_derive",
+ "syntex_pos",
+ "term",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syntex_pos"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ab669fa003d208c681f874bbc76d91cc3d32550d16b5d9d2087cf477316470"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "syntex_syntax"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03815b9f04d95828770d9c974aa39c6e1f6ef3114eb77a3ce09008a0d15dd142"
+dependencies = [
+ "bitflags 0.9.1",
+ "extprim",
+ "log 0.3.9",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syntex_errors",
+ "syntex_pos",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "term"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+dependencies = [
+ "kernel32-sys",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "test-runtime-simple-keyvalue"
 version = "0.1.0"
 dependencies = [
@@ -1221,6 +1598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,7 +1614,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1270,10 +1656,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -1302,6 +1715,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "version_check"
@@ -1339,7 +1758,7 @@ checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.67",
@@ -1397,6 +1816,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1404,6 +1829,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1430,7 +1861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.5.1",
  "zeroize 1.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,15 +55,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,12 +74,6 @@ name = "arc-swap"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -123,12 +108,6 @@ dependencies = [
  "byteorder",
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 
 [[package]]
 name = "bitflags"
@@ -239,16 +218,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.2.1",
+ "winapi",
 ]
 
 [[package]]
@@ -333,7 +303,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -344,7 +314,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -383,7 +353,7 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
  "zeroize 1.2.0",
 ]
@@ -488,7 +458,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
  "serde_bytes",
  "sha2",
@@ -507,32 +477,9 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
  "zeroize 1.2.0",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
-dependencies = [
- "log 0.3.9",
- "regex 0.2.11",
-]
-
-[[package]]
-name = "extprim"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a357c911c352439b460d7b375b5c85977b9db395b703dfee5a94dfb4d66a2"
-dependencies = [
- "num-traits",
- "rand 0.6.5",
- "rustc_version",
- "semver",
- "serde",
 ]
 
 [[package]]
@@ -542,7 +489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
  "bitvec",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
 ]
 
@@ -551,12 +498,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -578,15 +519,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -617,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
 dependencies = [
  "ff",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
 ]
 
@@ -714,16 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,15 +659,6 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.14",
-]
-
-[[package]]
-name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
@@ -754,19 +667,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
 name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -775,7 +682,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -784,7 +691,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -793,7 +700,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
  "serde",
@@ -805,7 +712,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -815,7 +722,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -839,12 +746,12 @@ dependencies = [
  "intrusive-collections",
  "io-context",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "num-bigint",
  "num-traits",
  "pem",
  "percent-encoding",
- "rand 0.7.3",
+ "rand",
  "rustc-hex",
  "serde",
  "serde_bytes",
@@ -898,7 +805,6 @@ dependencies = [
  "diff",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "rustfmt",
  "syn 1.0.67",
 ]
 
@@ -922,7 +828,7 @@ checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
  "base64",
  "once_cell",
- "regex 1.4.5",
+ "regex",
 ]
 
 [[package]]
@@ -1011,44 +917,15 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1058,23 +935,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1087,95 +949,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local",
- "utf8-ranges",
+ "rand_core",
 ]
 
 [[package]]
@@ -1184,16 +962,7 @@ version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
- "regex-syntax 0.6.23",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1214,7 +983,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1230,31 +999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustfmt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
-dependencies = [
- "diff",
- "env_logger",
- "getopts",
- "kernel32-sys",
- "libc",
- "log 0.3.9",
- "regex 0.2.11",
- "serde",
- "serde_derive",
- "serde_json",
- "strings",
- "syntex_errors",
- "syntex_syntax",
- "term",
- "toml",
- "unicode-segmentation",
- "winapi 0.2.8",
 ]
 
 [[package]]
@@ -1351,7 +1095,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55adf0940448a33eac98b3c84ab2e567c1fbc086750bcfd72702d6facc39bb77"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1374,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1412,7 +1156,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
 dependencies = [
- "log 0.4.14",
+ "log",
  "slog",
  "slog-scope",
 ]
@@ -1426,8 +1170,8 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
+ "rand_core",
  "ring",
  "rustc_version",
  "sha2",
@@ -1459,15 +1203,6 @@ checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
 dependencies = [
  "block-cipher",
  "generic-array",
-]
-
-[[package]]
-name = "strings"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa481ee1bc42fc3df8195f91f7cb43cf8f2b71b48bac40bf5381cfaf7e481f3c"
-dependencies = [
- "log 0.3.9",
 ]
 
 [[package]]
@@ -1517,57 +1252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntex_errors"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3133289179676c9f5c5b2845bf5a2e127769f4889fcbada43035ef6bd662605e"
-dependencies = [
- "libc",
- "serde",
- "serde_derive",
- "syntex_pos",
- "term",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syntex_pos"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ab669fa003d208c681f874bbc76d91cc3d32550d16b5d9d2087cf477316470"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "syntex_syntax"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03815b9f04d95828770d9c974aa39c6e1f6ef3114eb77a3ce09008a0d15dd142"
-dependencies = [
- "bitflags 0.9.1",
- "extprim",
- "log 0.3.9",
- "serde",
- "serde_derive",
- "serde_json",
- "syntex_errors",
- "syntex_pos",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
-dependencies = [
- "kernel32-sys",
- "winapi 0.2.8",
-]
-
-[[package]]
 name = "test-runtime-simple-keyvalue"
 version = "0.1.0"
 dependencies = [
@@ -1598,15 +1282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1289,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1656,37 +1331,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
-name = "ucd-util"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -1715,12 +1363,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "version_check"
@@ -1758,7 +1400,7 @@ checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.67",
@@ -1816,12 +1458,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1829,12 +1465,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1861,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.5.1",
+ "rand_core",
  "zeroize 1.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "runtime-sdk",
+    "runtime-sdk-macros",
 
     # Test runtimes.
     "tests/runtimes/simple-keyvalue",

--- a/runtime-sdk-macros/Cargo.toml
+++ b/runtime-sdk-macros/Cargo.toml
@@ -16,5 +16,4 @@ syn = "1.0.62"
 
 [dev-dependencies]
 diff = "0.1.12"
-rustfmt = "0.10"
 syn = { version = "1.0.62", features = ["extra-traits"] }

--- a/runtime-sdk-macros/Cargo.toml
+++ b/runtime-sdk-macros/Cargo.toml
@@ -9,8 +9,12 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
+darling = "0.12.2"
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
+syn = "1.0.62"
 
 [dev-dependencies]
+diff = "0.1.12"
+rustfmt = "0.10"
 syn = { version = "1.0.62", features = ["extra-traits"] }

--- a/runtime-sdk-macros/Cargo.toml
+++ b/runtime-sdk-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oasis-runtime-sdk-macros"
+version = "0.1.0"
+authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.24"
+quote = "1.0.9"
+
+[dev-dependencies]
+syn = { version = "1.0.62", features = ["extra-traits"] }

--- a/runtime-sdk-macros/src/error_derive.rs
+++ b/runtime-sdk-macros/src/error_derive.rs
@@ -1,0 +1,113 @@
+use darling::{util::Flag, FromDeriveInput, FromVariant};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Ident};
+
+use crate::generators::{self as gen, CodedVariant};
+
+#[derive(FromDeriveInput)]
+#[darling(supports(enum_any), attributes(runtime_error))]
+struct Error {
+    ident: Ident,
+
+    data: darling::ast::Data<ErrorVariant, darling::util::Ignored>,
+
+    /// The type ident of the error enum.
+    module: syn::Path,
+
+    /// Whether to sequentially autonumber the error codes.
+    /// This option exists as a convenience for runtimes that
+    /// only append errors or release only breaking changes.
+    #[darling(default)]
+    autonumber: Flag,
+}
+
+#[derive(FromVariant)]
+#[darling(attributes(runtime_error))]
+struct ErrorVariant {
+    ident: Ident,
+
+    /// The explicit ID of the error code. Overrides any autonumber set on the error enum.
+    #[darling(default)]
+    code: Option<u32>,
+}
+
+impl CodedVariant for ErrorVariant {
+    fn ident(&self) -> &Ident {
+        &self.ident
+    }
+
+    fn code(&self) -> Option<u32> {
+        self.code
+    }
+}
+
+pub fn derive_error(input: DeriveInput) -> TokenStream {
+    let error = match Error::from_derive_input(&input) {
+        Ok(error) => error,
+        Err(e) => return e.write_errors(),
+    };
+
+    let error_ty_ident = &error.ident;
+    let module_path = &error.module;
+
+    let code_converter = gen::enum_code_converter(
+        &format_ident!("self"),
+        &error.data.as_ref().take_enum().unwrap(),
+        error.autonumber.is_some(),
+    );
+
+    gen::wrap_in_const(quote! {
+        impl oasis_runtime_sdk::Error for #error_ty_ident {
+            fn module(&self) -> &str {
+                <#module_path as oasis_runtime_sdk::module::Module>::NAME
+            }
+
+            fn code(&self) -> u32 {
+                #code_converter
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn generate_error_impl() {
+        let expected: syn::Stmt = syn::parse_quote!(
+            const _: () = {
+                impl oasis_runtime_sdk::Error for Error {
+                    fn module(&self) -> &str {
+                        <module::TheModule as oasis_runtime_sdk::module::Module>::NAME
+                    }
+                    fn code(&self) -> u32 {
+                        match self {
+                            Self::Error0 { .. } => 0u32,
+                            Self::Error2 { .. } => 2u32,
+                            Self::Error1 { .. } => 1u32,
+                            Self::Error3 { .. } => 3u32,
+                        }
+                    }
+                }
+            };
+        );
+
+        let input: syn::DeriveInput = syn::parse_quote!(
+            #[derive(Error)]
+            #[runtime_error(autonumber, module = "module::TheModule")]
+            pub enum Error {
+                Error0,
+                #[runtime_error(code = 2)]
+                Error2 {
+                    payload: Vec<u8>,
+                },
+                Error1(String),
+                Error3,
+            }
+        );
+        let error_derivation = super::derive_error(input);
+        let actual: syn::Stmt = syn::parse2(error_derivation).unwrap();
+
+        crate::assert_empty_diff!(actual, expected);
+    }
+}

--- a/runtime-sdk-macros/src/event_derive.rs
+++ b/runtime-sdk-macros/src/event_derive.rs
@@ -1,0 +1,154 @@
+use darling::{util::Flag, FromDeriveInput, FromVariant};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Ident};
+
+#[derive(FromDeriveInput)]
+#[darling(supports(enum_any), attributes(event))]
+struct Event {
+    ident: Ident,
+
+    data: darling::ast::Data<EventVariant, darling::util::Ignored>,
+
+    /// The type ident of the event enum.
+    module: syn::Path,
+
+    /// Whether to sequentially autonumber the event codes.
+    /// This option exists as a convenience for runtimes that
+    /// only append events or release only breaking changes.
+    #[darling(default)]
+    autonumber: Flag,
+}
+
+#[derive(FromVariant)]
+#[darling(attributes(event))]
+struct EventVariant {
+    ident: Ident,
+
+    /// The explicit ID of the event code. Overrides any autonumber set on the event enum.
+    #[darling(default)]
+    id: Option<u32>,
+}
+
+pub fn derive_event(input: DeriveInput) -> TokenStream {
+    let event = match Event::from_derive_input(&input) {
+        Ok(event) => event,
+        Err(e) => return e.write_errors(),
+    };
+
+    let event_ty_ident = &event.ident;
+    let wrapper_ident = format_ident!("_IMPL_EVENT_FOR_{}", event_ty_ident);
+    let module_path = &event.module;
+
+    let variants = event.data.as_ref().take_enum().unwrap();
+    let mut next_autonumber = 0u32;
+    let mut reserved_numbers = std::collections::BTreeSet::new();
+    let code_match_arms = variants.iter().map(|variant| {
+        let event_id = match variant.id {
+            Some(id) => {
+                if reserved_numbers.contains(&id) {
+                    variant
+                        .ident
+                        .span()
+                        .unwrap()
+                        .error(format!("id {} already used", id))
+                        .emit();
+                    return quote!({});
+                }
+                reserved_numbers.insert(id);
+                id
+            }
+            None if event.autonumber.is_some() => {
+                let mut reserved_successors = reserved_numbers.range(next_autonumber..);
+                while reserved_successors.next() == Some(&next_autonumber) {
+                    next_autonumber += 1;
+                }
+                let i = next_autonumber;
+                reserved_numbers.insert(i);
+                next_autonumber += 1;
+                i
+            }
+            None => {
+                variant
+                    .ident
+                    .span()
+                    .unwrap()
+                    .error("missing `id` for variant")
+                    .emit();
+                return quote!();
+            }
+        };
+        let variant_ident = &variant.ident;
+        quote! {
+            Self::#variant_ident { .. } => { #event_id }
+        }
+    });
+
+    quote! {
+        const #wrapper_ident: () = {
+            use oasis_runtime_sdk::core::common::cbor;
+
+            impl oasis_runtime_sdk::event::Event for #event_ty_ident {
+                fn module(&self) -> &str {
+                    <#module_path as oasis_runtime_sdk::module::Module>::NAME
+                }
+
+                fn code(&self) -> u32 {
+                    match self {
+                        #(#code_match_arms)*
+                    }
+                }
+
+                fn value(&self) -> cbor::Value {
+                    cbor::to_value(self)
+                }
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn generate_event_impl() {
+        let expected: syn::Stmt = syn::parse_quote!(
+            const _IMPL_EVENT_FOR_MainEvent: () = {
+                use oasis_runtime_sdk::core::common::cbor;
+                impl oasis_runtime_sdk::event::Event for MainEvent {
+                    fn module(&self) -> &str {
+                        <module::TheModule as oasis_runtime_sdk::module::Module>::NAME
+                    }
+                    fn code(&self) -> u32 {
+                        match self {
+                            Self::Event0 { .. } => 0u32,
+                            Self::Event2 { .. } => 2u32,
+                            Self::Event1 { .. } => 1u32,
+                            Self::Event3 { .. } => 3u32,
+                        }
+                    }
+                    fn value(&self) -> cbor::Value {
+                        cbor::to_value(self)
+                    }
+                }
+            };
+        );
+
+        let input: syn::DeriveInput = syn::parse_quote!(
+            #[derive(Event)]
+            #[event(autonumber, module = "module::TheModule")]
+            pub enum MainEvent {
+                Event0,
+                #[event(id = 2)]
+                Event2 {
+                    payload: Vec<u8>,
+                },
+                Event1(String),
+                Event3,
+            }
+        );
+        let event_derivation = super::derive_event(input);
+        let actual: syn::Stmt = syn::parse2(event_derivation).unwrap();
+
+        crate::assert_empty_diff!(actual, expected);
+    }
+}

--- a/runtime-sdk-macros/src/event_derive.rs
+++ b/runtime-sdk-macros/src/event_derive.rs
@@ -12,7 +12,7 @@ struct Event {
 
     data: darling::ast::Data<EventVariant, darling::util::Ignored>,
 
-    /// The type ident of the event enum.
+    /// The path to the module type.
     module: syn::Path,
 
     /// Whether to sequentially autonumber the event codes.
@@ -57,12 +57,14 @@ pub fn derive_event(input: DeriveInput) -> TokenStream {
         event.autonumber.is_some(),
     );
 
-    gen::wrap_in_const(quote! {
-        use oasis_runtime_sdk::core::common::cbor;
+    let sdk_crate = gen::sdk_crate_path();
 
-        impl oasis_runtime_sdk::event::Event for #event_ty_ident {
+    gen::wrap_in_const(quote! {
+        use #sdk_crate::core::common::cbor;
+
+        impl #sdk_crate::event::Event for #event_ty_ident {
             fn module(&self) -> &str {
-                <#module_path as oasis_runtime_sdk::module::Module>::NAME
+                <#module_path as #sdk_crate::module::Module>::NAME
             }
 
             fn code(&self) -> u32 {

--- a/runtime-sdk-macros/src/generators.rs
+++ b/runtime-sdk-macros/src/generators.rs
@@ -10,6 +10,19 @@ pub fn wrap_in_const(tokens: TokenStream) -> TokenStream {
     }
 }
 
+/// Determines what crate name should be used to refer to `oasis_runtime_sdk` types.
+/// Required for use within the SDK itself (crates cannot refer to their own names).
+pub fn sdk_crate_path() -> syn::Path {
+    let is_internal = std::env::var("CARGO_PKG_NAME")
+        .map(|pkg_name| pkg_name == "oasis-runtime-sdk")
+        .unwrap_or_default();
+    if is_internal {
+        syn::parse_quote!(crate)
+    } else {
+        syn::parse_quote!(oasis_runtime_sdk)
+    }
+}
+
 pub trait CodedVariant {
     fn ident(&self) -> &Ident;
 

--- a/runtime-sdk-macros/src/generators.rs
+++ b/runtime-sdk-macros/src/generators.rs
@@ -1,0 +1,95 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+pub fn wrap_in_const(tokens: TokenStream) -> TokenStream {
+    quote! {
+        const _: () = {
+            #tokens
+        };
+    }
+}
+
+pub trait CodedVariant {
+    fn ident(&self) -> &Ident;
+
+    fn code(&self) -> Option<u32>;
+}
+
+pub fn enum_code_converter<V: CodedVariant>(
+    enum_binding: &Ident,
+    variants: &[&V],
+    autonumber: bool,
+) -> TokenStream {
+    if variants.is_empty() {
+        return quote!(0); // Early return with default if there are no variants.
+    }
+
+    let mut next_autonumber = 0u32;
+    let mut reserved_numbers = std::collections::BTreeSet::new();
+    let match_arms = variants.iter().map(|variant| {
+        let variant_ident = variant.ident();
+        let code = match variant.code() {
+            Some(code) => {
+                if reserved_numbers.contains(&code) {
+                    variant_ident
+                        .span()
+                        .unwrap()
+                        .error(format!("code {} already used", code))
+                        .emit();
+                    return quote!({});
+                }
+                reserved_numbers.insert(code);
+                code
+            }
+            None if autonumber => {
+                let mut reserved_successors = reserved_numbers.range(next_autonumber..);
+                while reserved_successors.next() == Some(&next_autonumber) {
+                    next_autonumber += 1;
+                }
+                let code = next_autonumber;
+                reserved_numbers.insert(code);
+                next_autonumber += 1;
+                code
+            }
+            None => {
+                variant_ident
+                    .span()
+                    .unwrap()
+                    .error("missing `code` for variant")
+                    .emit();
+                return quote!();
+            }
+        };
+        quote!(Self::#variant_ident { .. } => { #code })
+    });
+    quote! {
+        match #enum_binding {
+            #(#match_arms)*
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_empty_enum_converter() {
+        struct DummyVariant {}
+        impl CodedVariant for DummyVariant {
+            fn ident(&self) -> &Ident {
+                unimplemented!()
+            }
+            fn code(&self) -> Option<u32> {
+                unimplemented!()
+            }
+        }
+        let variants: &[&DummyVariant] = &[];
+
+        let expected: syn::Expr = syn::parse_quote!(0);
+        let converter = enum_code_converter(&quote::format_ident!("the_enum"), variants, false);
+        let actual: syn::Expr = syn::parse2(converter).unwrap();
+        assert_eq!(expected, actual);
+    }
+}

--- a/runtime-sdk-macros/src/lib.rs
+++ b/runtime-sdk-macros/src/lib.rs
@@ -3,7 +3,9 @@
 
 use proc_macro::TokenStream;
 
+mod error_derive;
 mod event_derive;
+mod generators;
 #[cfg(test)]
 mod test_utils;
 mod version_from_cargo;
@@ -13,6 +15,14 @@ mod version_from_cargo;
 pub fn event_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     event_derive::derive_event(input).into()
+}
+
+/// Derives the `Error` trait on an enum.
+// The helper attribute is `runtime_error` to avoid conflict with `thiserror::Error`.
+#[proc_macro_derive(Error, attributes(runtime_error))]
+pub fn error_derive(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    error_derive::derive_error(input).into()
 }
 
 /// Constructs an `oasis_sdk::core::common::version::Version` from the Cargo.toml version.

--- a/runtime-sdk-macros/src/lib.rs
+++ b/runtime-sdk-macros/src/lib.rs
@@ -1,8 +1,19 @@
+#![feature(proc_macro_diagnostic)]
 #![deny(rust_2018_idioms)]
 
 use proc_macro::TokenStream;
 
+mod event_derive;
+#[cfg(test)]
+mod test_utils;
 mod version_from_cargo;
+
+/// Derives the `Event` trait on an enum.
+#[proc_macro_derive(Event, attributes(event))]
+pub fn event_derive(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    event_derive::derive_event(input).into()
+}
 
 /// Constructs an `oasis_sdk::core::common::version::Version` from the Cargo.toml version.
 #[proc_macro]

--- a/runtime-sdk-macros/src/lib.rs
+++ b/runtime-sdk-macros/src/lib.rs
@@ -1,0 +1,11 @@
+#![deny(rust_2018_idioms)]
+
+use proc_macro::TokenStream;
+
+mod version_from_cargo;
+
+/// Constructs an `oasis_sdk::core::common::version::Version` from the Cargo.toml version.
+#[proc_macro]
+pub fn version_from_cargo(_input: TokenStream) -> TokenStream {
+    version_from_cargo::version_from_cargo().into()
+}

--- a/runtime-sdk-macros/src/lib.rs
+++ b/runtime-sdk-macros/src/lib.rs
@@ -11,7 +11,7 @@ mod test_utils;
 mod version_from_cargo;
 
 /// Derives the `Event` trait on an enum.
-#[proc_macro_derive(Event, attributes(event))]
+#[proc_macro_derive(Event, attributes(sdk_event))]
 pub fn event_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     event_derive::derive_event(input).into()
@@ -19,7 +19,7 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
 
 /// Derives the `Error` trait on an enum.
 // The helper attribute is `runtime_error` to avoid conflict with `thiserror::Error`.
-#[proc_macro_derive(Error, attributes(runtime_error))]
+#[proc_macro_derive(Error, attributes(sdk_error))]
 pub fn error_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     error_derive::derive_error(input).into()

--- a/runtime-sdk-macros/src/test_utils.rs
+++ b/runtime-sdk-macros/src/test_utils.rs
@@ -1,0 +1,46 @@
+pub fn rustfmt(code: String) -> String {
+    let mut formatted = Vec::new();
+    let mut config = rustfmt::config::Config::default();
+    config.set().write_mode(rustfmt::config::WriteMode::Plain);
+    let code = format!("const wrap: () = {{ {} }};", code);
+    let (_summary, _, _) =
+        rustfmt::format_input(rustfmt::Input::Text(code), &config, Some(&mut formatted))
+            .expect("unable to format output");
+    String::from_utf8(formatted).unwrap()
+}
+
+#[macro_export]
+macro_rules! assert_empty_diff {
+    ($actual:expr, $expected:expr) => {{
+        use quote::ToTokens;
+
+        let actual_code = crate::test_utils::rustfmt($actual.to_token_stream().to_string());
+        let expected_code = crate::test_utils::rustfmt($expected.to_token_stream().to_string());
+
+        let diffs = diff::lines(&actual_code, &expected_code);
+
+        let mut has_diff = false;
+        let mut actual_lines = actual_code.split('\n');
+        let mut expected_lines = expected_code.split('\n');
+
+        for (i, diff) in diffs.iter().enumerate() {
+            match diff {
+                diff::Result::Left(l) => {
+                    eprintln!("non-empty diff on line {}", i);
+                    eprintln!("+ {}", l);
+                    eprintln!("- {}", expected_lines.next().unwrap());
+                    has_diff = true;
+                }
+                diff::Result::Right { .. } => {
+                    actual_lines.next();
+                    has_diff = true;
+                }
+                diff::Result::Both { .. } => {
+                    actual_lines.next();
+                    expected_lines.next();
+                }
+            }
+        }
+        assert!(!has_diff);
+    }};
+}

--- a/runtime-sdk-macros/src/version_from_cargo.rs
+++ b/runtime-sdk-macros/src/version_from_cargo.rs
@@ -36,6 +36,6 @@ mod tests {
         );
         let actual: syn::Expr = syn::parse2(super::version_from_cargo()).unwrap();
 
-        assert_eq!(actual, expected);
+        crate::assert_empty_diff!(actual, expected);
     }
 }

--- a/runtime-sdk-macros/src/version_from_cargo.rs
+++ b/runtime-sdk-macros/src/version_from_cargo.rs
@@ -1,0 +1,41 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+macro_rules! parse_cargo_ver {
+    ($ver:literal) => {{
+        let cargo_pkg_version_env_var = if cfg!(test) {
+            concat!("TEST_CARGO_PKG_VERSION_", $ver)
+        } else {
+            concat!("CARGO_PKG_VERSION_", $ver)
+        };
+        std::env::var(cargo_pkg_version_env_var)
+            .unwrap()
+            .parse::<u16>()
+            .unwrap()
+    }};
+}
+
+/// Constructs an `oasis_sdk::core::common::version::Version` from the Cargo.toml version.
+pub fn version_from_cargo() -> TokenStream {
+    let major = parse_cargo_ver!("MAJOR");
+    let minor = parse_cargo_ver!("MINOR");
+    let patch = parse_cargo_ver!("PATCH");
+    quote!(oasis_runtime_sdk::core::common::version::Version::new(#major, #minor, #patch))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn generates_version() {
+        std::env::set_var("TEST_CARGO_PKG_VERSION_MAJOR", "1");
+        std::env::set_var("TEST_CARGO_PKG_VERSION_MINOR", "2");
+        std::env::set_var("TEST_CARGO_PKG_VERSION_PATCH", "3");
+
+        let expected: syn::Expr = syn::parse_quote!(
+            oasis_runtime_sdk::core::common::version::Version::new(1u16, 2u16, 3u16)
+        );
+        let actual: syn::Expr = syn::parse2(super::version_from_cargo()).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.0.1" }
+oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 
 # Third party.
 serde = { version = "1.0.118", features = ["derive"] }
@@ -22,3 +23,6 @@ num-traits = "0.2.14"
 impl-trait-for-tuples = "0.2"
 base64 = "0.13.0"
 lazy_static = "1.4.0"
+
+[features]
+default = ["oasis-runtime-sdk-macros"]

--- a/runtime-sdk/src/crypto/signature/context.rs
+++ b/runtime-sdk/src/crypto/signature/context.rs
@@ -73,7 +73,7 @@ mod test {
     use super::*;
 
     lazy_static! {
-        static ref TEST_GUARD: Mutex<bool> = Mutex::new(false);
+        static ref TEST_GUARD: Mutex<()> = Mutex::new(());
     }
 
     fn reset_chain_context() {

--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -7,6 +7,19 @@ use crate::types::transaction::CallResult;
 ///
 /// It extends `std::error::Error` with module name and error code so that errors can be easily
 /// serialized and transferred between different processes.
+///
+/// This trait can be derived:
+/// ```ignore
+/// # #[cfg(feature = "oasis-runtime-sdk-macros")]
+/// # mod example {
+/// #[derive(Clone, Debug, thiserror::Error, oasis_runtime_sdk::Error)]
+/// #[event(module = "path::to::MyModule", autonumber)] // `module` is required
+/// enum Error {
+///    InvalidArgument,      // autonumbered to 0
+///    #[event(code = 401)]  // manually numbered to 403 (`code` is required if not autonumbering)
+///    Forbidden,
+/// }
+/// # }
 pub trait Error: std::error::Error {
     /// Name of the module that emitted the error.
     fn module(&self) -> &str;

--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -9,17 +9,24 @@ use crate::types::transaction::CallResult;
 /// serialized and transferred between different processes.
 ///
 /// This trait can be derived:
-/// ```ignore
+/// ```
 /// # #[cfg(feature = "oasis-runtime-sdk-macros")]
 /// # mod example {
-/// #[derive(Clone, Debug, thiserror::Error, oasis_runtime_sdk::Error)]
-/// #[event(module = "path::to::MyModule", autonumber)] // `module` is required
+/// # use serde::{Serialize, Deserialize};
+/// # use oasis_runtime_sdk_macros::Error;
+/// # mod path { pub mod to { pub use oasis_runtime_sdk::modules::accounts::Module as MyModule; }}
+/// #[derive(Clone, Debug, Serialize, Deserialize, Error, thiserror::Error)]
+/// #[sdk_error(module = "path::to::MyModule", autonumber)] // `module` is required
 /// enum Error {
-///    InvalidArgument,      // autonumbered to 0
-///    #[event(code = 401)]  // manually numbered to 403 (`code` is required if not autonumbering)
+///    #[error("invalid argument")]
+///    InvalidArgument,          // autonumbered to 0
+///
+///    #[error("forbidden")]
+///    #[sdk_error(code = 401)]  // manually numbered to 403 (`code` or autonumbering is required)
 ///    Forbidden,
 /// }
 /// # }
+/// ```
 pub trait Error: std::error::Error {
     /// Name of the module that emitted the error.
     fn module(&self) -> &str;

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -3,19 +3,18 @@ use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 
 /// An event emitted by the runtime.
 ///
-/// This trait can be derived when using `features = ["oasis-sdk-runtime-macros"]`:
-/// ```no_run
-/// # #[cfg(feature = "oasis-sdk-runtime-macros")]
+/// This trait can be derived:
+/// ```ignore
+/// # #[cfg(feature = "oasis-runtime-sdk-macros")]
 /// # mod example {
 /// # use serde::{Serialize, Deserialize};
-/// # use oasis_sdk_runtime_macros::Event;
-/// #[derive(Clone, Debug, Serialize, Deserialize, Event)]
+/// #[derive(Clone, Debug, Serialize, Deserialize, oasis_runtime_sdk::Event)]
 /// #[event(module = "path::to::MyModule", autonumber)] // `module` is required
 /// enum MyEvent {
-///    Greeting(String),  // autonumbered to id 0
-///    #[event(id = 42)]  // manually numbered to id 42 (`id` is required if not autonumbering)
+///    Greeting(String),    // autonumbered to 0
+///    #[event(code = 42)]  // manually numbered to 42 (`code` is required if not autonumbering)
 ///    DontPanic,
-///    Salutation {       // autonumbered to id 1
+///    Salutation {         // autonumbered to 1
 ///        plural: bool,
 ///    }
 /// }

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -2,6 +2,25 @@
 use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 
 /// An event emitted by the runtime.
+///
+/// This trait can be derived when using `features = ["oasis-sdk-runtime-macros"]`:
+/// ```no_run
+/// # #[cfg(feature = "oasis-sdk-runtime-macros")]
+/// # mod example {
+/// # use serde::{Serialize, Deserialize};
+/// # use oasis_sdk_runtime_macros::Event;
+/// #[derive(Clone, Debug, Serialize, Deserialize, Event)]
+/// #[event(module = "path::to::MyModule", autonumber)] // `module` is required
+/// enum MyEvent {
+///    Greeting(String),  // autonumbered to id 0
+///    #[event(id = 42)]  // manually numbered to id 42 (`id` is required if not autonumbering)
+///    DontPanic,
+///    Salutation {       // autonumbered to id 1
+///        plural: bool,
+///    }
+/// }
+/// # }
+/// ```
 pub trait Event {
     /// Name of the module that emitted the event.
     fn module(&self) -> &str;

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -4,17 +4,19 @@ use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 /// An event emitted by the runtime.
 ///
 /// This trait can be derived:
-/// ```ignore
+/// ```
 /// # #[cfg(feature = "oasis-runtime-sdk-macros")]
 /// # mod example {
 /// # use serde::{Serialize, Deserialize};
-/// #[derive(Clone, Debug, Serialize, Deserialize, oasis_runtime_sdk::Event)]
-/// #[event(module = "path::to::MyModule", autonumber)] // `module` is required
+/// # use oasis_runtime_sdk_macros::Event;
+/// # mod path { pub mod to { pub use oasis_runtime_sdk::modules::accounts::Module as MyModule; }}
+/// #[derive(Clone, Debug, Serialize, Deserialize, Event)]
+/// #[sdk_event(module = "path::to::MyModule", autonumber)] // `module` is required
 /// enum MyEvent {
-///    Greeting(String),    // autonumbered to 0
-///    #[event(code = 42)]  // manually numbered to 42 (`code` is required if not autonumbering)
-///    DontPanic,
-///    Salutation {         // autonumbered to 1
+///    Greeting(String),      // autonumbered to 0
+///    #[sdk_event(code = 2)] // manually numbered to 2 (`code` is required if not autonumbering)
+///    DontPanic,             // autonumbered to 1
+///    Salutation {           // autonumbered to 3
 ///        plural: bool,
 ///    }
 /// }
@@ -34,7 +36,7 @@ pub trait Event {
     ///
     /// # Key
     ///
-    /// ```ignore
+    /// ```text
     /// <module (variable size bytes)> <code (big-endian u32)>
     /// ```
     ///

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -27,3 +27,6 @@ pub use oasis_core_runtime as core;
 // Re-export the SDK support proc-macros.
 #[cfg(feature = "oasis-runtime-sdk-macros")]
 pub use oasis_runtime_sdk_macros::*;
+
+// Required so that proc-macros can refer to items within this crate.
+use crate as oasis_runtime_sdk;

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -23,3 +23,7 @@ pub use crate::{
 
 // Re-export the appropriate version of the oasis-core-runtime library.
 pub use oasis_core_runtime as core;
+
+// Re-export the SDK support proc-macros.
+#[cfg(feature = "oasis-runtime-sdk-macros")]
+pub use oasis_runtime_sdk_macros::*;

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     context::{DispatchContext, TxContext},
     crypto::signature::PublicKey,
     error::{self, Error as _},
-    event, module,
+    module,
     module::{CallableMethodInfo, Module as _, QueryMethodInfo},
     modules, storage,
     types::{
@@ -29,30 +29,21 @@ pub mod types;
 /// Unique module name.
 const MODULE_NAME: &str = "accounts";
 
-// TODO: Add a custom derive macro for easier error derivation (module/error codes).
 /// Errors emitted by the accounts module.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
+#[sdk_error(module = "Module")]
 pub enum Error {
     #[error("invalid argument")]
+    #[sdk_error(code = 1)]
     InvalidArgument,
+
     #[error("insufficient balance")]
+    #[sdk_error(code = 2)]
     InsufficientBalance,
+
     #[error("forbidden by policy")]
+    #[sdk_error(code = 3)]
     Forbidden,
-}
-
-impl error::Error for Error {
-    fn module(&self) -> &str {
-        MODULE_NAME
-    }
-
-    fn code(&self) -> u32 {
-        match self {
-            Error::InvalidArgument => 1,
-            Error::InsufficientBalance => 2,
-            Error::Forbidden => 3,
-        }
-    }
 }
 
 impl From<Error> for error::RuntimeError {
@@ -61,44 +52,29 @@ impl From<Error> for error::RuntimeError {
     }
 }
 
-// TODO: Add a custom derive macro for easier event derivation (tags).
 /// Events emitted by the accounts module.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, oasis_runtime_sdk_macros::Event)]
 #[serde(untagged)]
+#[sdk_event(module = "Module")]
 pub enum Event {
+    #[sdk_event(code = 1)]
     Transfer {
         from: Address,
         to: Address,
         amount: token::BaseUnits,
     },
 
+    #[sdk_event(code = 2)]
     Burn {
         owner: Address,
         amount: token::BaseUnits,
     },
 
+    #[sdk_event(code = 3)]
     Mint {
         owner: Address,
         amount: token::BaseUnits,
     },
-}
-
-impl event::Event for Event {
-    fn module(&self) -> &str {
-        MODULE_NAME
-    }
-
-    fn code(&self) -> u32 {
-        match self {
-            Event::Transfer { .. } => 1,
-            Event::Burn { .. } => 2,
-            Event::Mint { .. } => 3,
-        }
-    }
-
-    fn value(&self) -> cbor::Value {
-        cbor::to_value(self)
-    }
 }
 
 /// Parameters for the accounts module.

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -11,36 +11,29 @@ pub mod types;
 /// Unique module name.
 pub const MODULE_NAME: &str = "core";
 
-// TODO: Add a custom derive macro for easier error derivation (module/error codes).
 /// Errors emitted by the core module.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
+#[sdk_error(module_name_path = "MODULE_NAME")]
 pub enum Error {
     #[error("malformed transaction")]
+    #[sdk_error(code = 1)]
     MalformedTransaction,
+
     #[error("invalid transaction: {0}")]
+    #[sdk_error(code = 2)]
     InvalidTransaction(#[from] transaction::Error),
+
     #[error("invalid method")]
+    #[sdk_error(code = 3)]
     InvalidMethod,
+
     #[error("invalid nonce")]
+    #[sdk_error(code = 4)]
     InvalidNonce,
+
     #[error("insufficient balance to pay fees")]
+    #[sdk_error(code = 5)]
     InsufficientFeeBalance,
-}
-
-impl error::Error for Error {
-    fn module(&self) -> &str {
-        MODULE_NAME
-    }
-
-    fn code(&self) -> u32 {
-        match self {
-            Error::MalformedTransaction => 1,
-            Error::InvalidTransaction(..) => 2,
-            Error::InvalidMethod => 3,
-            Error::InvalidNonce => 4,
-            Error::InsufficientFeeBalance => 5,
-        }
-    }
 }
 
 impl From<Error> for error::RuntimeError {


### PR DESCRIPTION
this PR adds `version_from_cargo` proc macro because in the one in `oasis_core::runtime::common` uses `parse`, which isn't a `const fn`.