### PR TITLE
Deny some rust lints

### DIFF
--- a/runtime-sdk/src/context.rs
+++ b/runtime-sdk/src/context.rs
@@ -53,7 +53,7 @@ pub struct DispatchContext<'a> {
 
 impl<'a> DispatchContext<'a> {
     /// Create a new dispatch context from the low-level runtime context.
-    pub(crate) fn from_runtime(ctx: &'a RuntimeContext, mkvs: &'a mut dyn mkvs::MKVS) -> Self {
+    pub(crate) fn from_runtime(ctx: &'a RuntimeContext<'_>, mkvs: &'a mut dyn mkvs::MKVS) -> Self {
         Self {
             mode: if ctx.check_only {
                 Mode::CheckTx
@@ -129,7 +129,7 @@ impl<'a> DispatchContext<'a> {
     /// Executes a function with the transaction-specific context set.
     pub fn with_tx<F, R>(&mut self, tx: transaction::Transaction, f: F) -> R
     where
-        F: FnOnce(TxContext, transaction::Call) -> R,
+        F: FnOnce(TxContext<'_, '_>, transaction::Call) -> R,
     {
         // Create a store wrapped by an overlay store so we can either rollback or commit.
         let store = storage::MKVSStore::new(self.io_ctx.clone(), &mut self.runtime_storage);

--- a/runtime-sdk/src/crypto/signature/secp256k1.rs
+++ b/runtime-sdk/src/crypto/signature/secp256k1.rs
@@ -77,7 +77,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
         impl<'de> serde::de::Visitor<'de> for BytesVisitor {
             type Value = PublicKey;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("bytes expected")
             }
 

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -92,7 +92,7 @@ impl<R: Runtime> Dispatcher<R> {
 
     fn dispatch_tx(
         &self,
-        ctx: &mut DispatchContext,
+        ctx: &mut DispatchContext<'_>,
         tx: types::transaction::Transaction,
     ) -> Result<DispatchResult, Error> {
         // Run pre-processing hooks.
@@ -128,7 +128,7 @@ impl<R: Runtime> Dispatcher<R> {
         Ok(result)
     }
 
-    fn check_tx(&self, ctx: &mut DispatchContext, tx: &[u8]) -> Result<CheckTxResult, Error> {
+    fn check_tx(&self, ctx: &mut DispatchContext<'_>, tx: &[u8]) -> Result<CheckTxResult, Error> {
         let tx = match self.decode_tx(&tx) {
             Ok(tx) => tx,
             Err(err) => {
@@ -160,7 +160,11 @@ impl<R: Runtime> Dispatcher<R> {
         }
     }
 
-    fn execute_tx(&self, ctx: &mut DispatchContext, tx: &[u8]) -> Result<ExecuteTxResult, Error> {
+    fn execute_tx(
+        &self,
+        ctx: &mut DispatchContext<'_>,
+        tx: &[u8],
+    ) -> Result<ExecuteTxResult, Error> {
         let tx = match self.decode_tx(&tx) {
             Ok(tx) => tx,
             Err(err) => {
@@ -179,7 +183,7 @@ impl<R: Runtime> Dispatcher<R> {
         })
     }
 
-    fn maybe_init_state(&self, ctx: &mut DispatchContext) {
+    fn maybe_init_state(&self, ctx: &mut DispatchContext<'_>) {
         R::migrate(ctx)
     }
 }
@@ -187,7 +191,7 @@ impl<R: Runtime> Dispatcher<R> {
 impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
     fn execute_batch(
         &self,
-        ctx: transaction::Context,
+        ctx: transaction::Context<'_>,
         batch: &TxnBatch,
     ) -> Result<ExecuteBatchResult, RuntimeError> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
@@ -218,7 +222,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
 
     fn check_batch(
         &self,
-        ctx: transaction::Context,
+        ctx: transaction::Context<'_>,
         batch: &TxnBatch,
     ) -> Result<Vec<CheckTxResult>, RuntimeError> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
@@ -244,7 +248,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
 
     fn query(
         &self,
-        ctx: transaction::Context,
+        ctx: transaction::Context<'_>,
         method: &str,
         args: cbor::Value,
     ) -> Result<cbor::Value, RuntimeError> {

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -1,5 +1,7 @@
 //! Oasis runtime SDK.
 #![feature(const_fn)]
+#![deny(rust_2018_idioms, unreachable_pub)]
+#![forbid(unsafe_code)]
 
 pub mod context;
 pub mod crypto;

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -19,7 +19,7 @@ pub struct CallableMethodInfo {
     pub name: &'static str,
 
     /// Method handler function.
-    pub handler: fn(&CallableMethodInfo, &mut TxContext, cbor::Value) -> CallResult,
+    pub handler: fn(&CallableMethodInfo, &mut TxContext<'_, '_>, cbor::Value) -> CallResult,
 }
 
 /// Metadata of a query method.
@@ -30,7 +30,7 @@ pub struct QueryMethodInfo {
     /// Method handler function.
     pub handler: fn(
         &QueryMethodInfo,
-        &mut DispatchContext,
+        &mut DispatchContext<'_>,
         cbor::Value,
     ) -> Result<cbor::Value, error::RuntimeError>,
 }
@@ -101,7 +101,7 @@ pub trait AuthHandler {
     ///
     /// Note that any signatures have already been verified.
     fn authenticate_tx(
-        _ctx: &mut DispatchContext,
+        _ctx: &mut DispatchContext<'_>,
         _tx: &Transaction,
     ) -> Result<(), modules::core::Error> {
         // Default implementation doesn't do any checks.
@@ -112,7 +112,7 @@ pub trait AuthHandler {
 #[impl_for_tuples(30)]
 impl AuthHandler for Tuple {
     fn authenticate_tx(
-        ctx: &mut DispatchContext,
+        ctx: &mut DispatchContext<'_>,
         tx: &Transaction,
     ) -> Result<(), modules::core::Error> {
         for_tuples!( #( Tuple::authenticate_tx(ctx, tx)?; )* );
@@ -129,7 +129,7 @@ pub trait MigrationHandler {
     ///
     /// Should return true in case metadata has been changed.
     fn init_or_migrate(
-        ctx: &mut DispatchContext,
+        ctx: &mut DispatchContext<'_>,
         meta: &mut modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool;
@@ -141,7 +141,7 @@ impl MigrationHandler for Tuple {
     for_tuples!( type Genesis = ( #( Tuple::Genesis ),* ); );
 
     fn init_or_migrate(
-        ctx: &mut DispatchContext,
+        ctx: &mut DispatchContext<'_>,
         meta: &mut modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {
@@ -156,13 +156,13 @@ impl MigrationHandler for Tuple {
 pub trait BlockHandler {
     /// Perform any common actions at the start of the block (before any transactions have been
     /// executed).
-    fn begin_block(_ctx: &mut DispatchContext) {
+    fn begin_block(_ctx: &mut DispatchContext<'_>) {
         // Default implementation doesn't do anything.
     }
 
     /// Perform any common actions at the end of the block (after all transactions have been
     /// executed).
-    fn end_block(_ctx: &mut DispatchContext) {
+    fn end_block(_ctx: &mut DispatchContext<'_>) {
         // Default implementation doesn't do anything.
     }
 }

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -140,7 +140,7 @@ fn test_init_2() {
     );
 }
 
-fn init_accounts(ctx: &mut DispatchContext) {
+fn init_accounts(ctx: &mut DispatchContext<'_>) {
     Accounts::init(
         ctx,
         &Genesis {

--- a/runtime-sdk/src/runtime.rs
+++ b/runtime-sdk/src/runtime.rs
@@ -25,7 +25,7 @@ pub trait Runtime {
     fn genesis_state() -> <Self::Modules as MigrationHandler>::Genesis;
 
     /// Perform state migrations if required.
-    fn migrate(ctx: &mut DispatchContext) {
+    fn migrate(ctx: &mut DispatchContext<'_>) {
         let store = storage::TypedStore::new(storage::PrefixStore::new(
             ctx.runtime_state(),
             &modules::core::MODULE_NAME,

--- a/runtime-sdk/src/storage/overlay.rs
+++ b/runtime-sdk/src/storage/overlay.rs
@@ -70,7 +70,7 @@ impl<S: Store> Store for OverlayStore<S> {
 }
 
 /// An iterator over the `OverlayStore`.
-pub struct OverlayStoreIterator<'store, S: Store> {
+pub(crate) struct OverlayStoreIterator<'store, S: Store> {
     store: &'store OverlayStore<S>,
 
     parent: Box<dyn mkvs::Iterator + 'store>,

--- a/runtime-sdk/src/storage/prefix.rs
+++ b/runtime-sdk/src/storage/prefix.rs
@@ -39,7 +39,7 @@ impl<'store, S: Store> Store for PrefixStore<'store, S> {
 }
 
 /// An iterator over the `PrefixStore`.
-pub struct PrefixStoreIterator<'store> {
+pub(crate) struct PrefixStoreIterator<'store> {
     inner: Box<dyn mkvs::Iterator + 'store>,
     prefix: &'store [u8],
 }

--- a/runtime-sdk/src/storage/typed.rs
+++ b/runtime-sdk/src/storage/typed.rs
@@ -34,7 +34,7 @@ impl<S: Store> TypedStore<S> {
         self.parent.remove(key)
     }
 
-    pub fn iter<K: DecodableStoreKey, V: DeserializeOwned>(&self) -> TypedStoreIterator<K, V> {
+    pub fn iter<K: DecodableStoreKey, V: DeserializeOwned>(&self) -> TypedStoreIterator<'_, K, V> {
         TypedStoreIterator::new(self.parent.iter())
     }
 }

--- a/runtime-sdk/src/testing/mock.rs
+++ b/runtime-sdk/src/testing/mock.rs
@@ -21,7 +21,7 @@ pub struct Mock {
 
 impl Mock {
     /// Create a new mock dispatch context.
-    pub fn create_ctx(&mut self) -> DispatchContext {
+    pub fn create_ctx(&mut self) -> DispatchContext<'_> {
         DispatchContext {
             mode: Mode::ExecuteTx,
             runtime_header: &self.runtime_header,

--- a/runtime-sdk/src/types/address.rs
+++ b/runtime-sdk/src/types/address.rs
@@ -109,7 +109,7 @@ impl From<&'static str> for Address {
 }
 
 impl fmt::LowerHex for Address {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for i in &self.0[..] {
             write!(f, "{:02x}", i)?;
         }
@@ -118,14 +118,14 @@ impl fmt::LowerHex for Address {
 }
 
 impl fmt::Debug for Address {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_bech32())?;
         Ok(())
     }
 }
 
 impl fmt::Display for Address {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_bech32())?;
         Ok(())
     }
@@ -155,7 +155,7 @@ impl<'de> serde::Deserialize<'de> for Address {
         impl<'de> serde::de::Visitor<'de> for BytesVisitor {
             type Value = Address;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("bytes or string expected")
             }
 

--- a/runtime-sdk/src/types/token.rs
+++ b/runtime-sdk/src/types/token.rs
@@ -27,7 +27,7 @@ impl Denomination {
 }
 
 impl fmt::Display for Denomination {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_native() {
             write!(f, "<native>")?;
         } else {
@@ -87,7 +87,7 @@ impl BaseUnits {
 }
 
 impl fmt::Display for BaseUnits {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.0, self.1)?;
         Ok(())
     }


### PR DESCRIPTION
This PR denies the following lints
* `unsafe_code` - for obvious reasons
*  `unreachable_pub` - to make sure everything `pub` is intentionally exported
* `rust_2018_idoms` - being current is nice