### PR TITLE
graveyard: generic container types

### DIFF
--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -272,11 +272,11 @@ const methodDescriptorStorageSyncIterate = createMethodDescriptorUnary<
 >('Storage', 'SyncIterate');
 const methodDescriptorStorageApply = createMethodDescriptorUnary<
     types.StorageApplyRequest,
-    types.SignatureSigned[]
+    types.SignatureSigned<types.StorageReceiptBody>[]
 >('Storage', 'Apply');
 const methodDescriptorStorageApplyBatch = createMethodDescriptorUnary<
     types.StorageApplyBatchRequest,
-    types.SignatureSigned[]
+    types.SignatureSigned<types.StorageReceiptBody>[]
 >('Storage', 'ApplyBatch');
 const methodDescriptorStorageGetCheckpoints = createMethodDescriptorUnary<
     types.StorageGetCheckpointsRequest,

--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -329,8 +329,8 @@ const methodDescriptorRuntimeClientGetEvents = createMethodDescriptorUnary<
     types.RuntimeClientEvent[]
 >('RuntimeClient', 'GetEvents');
 const methodDescriptorRuntimeClientQuery = createMethodDescriptorUnary<
-    types.RuntimeClientQueryRequest,
-    types.RuntimeClientQueryResponse
+    types.RuntimeClientQueryRequest<unknown>,
+    types.RuntimeClientQueryResponse<unknown>
 >('RuntimeClient', 'Query');
 const methodDescriptorRuntimeClientQueryTx = createMethodDescriptorUnary<
     types.RuntimeClientQueryTxRequest,
@@ -356,7 +356,7 @@ const methodDescriptorEnclaveRPCCallEnclave = createMethodDescriptorUnary<
 >('EnclaveRPC', 'CallEnclave');
 
 // consensus
-const methodDescriptorConsensusSubmitTx = createMethodDescriptorUnary<types.SignatureSigned, void>(
+const methodDescriptorConsensusSubmitTx = createMethodDescriptorUnary<types.SignatureSigned<types.ConsensusTransaction<unknown>>, void>(
     'Consensus',
     'SubmitTx',
 );
@@ -365,7 +365,7 @@ const methodDescriptorConsensusStateToGenesis = createMethodDescriptorUnary<
     types.GenesisDocument
 >('Consensus', 'StateToGenesis');
 const methodDescriptorConsensusEstimateGas = createMethodDescriptorUnary<
-    types.ConsensusEstimateGasRequest,
+    types.ConsensusEstimateGasRequest<unknown>,
     types.longnum
 >('Consensus', 'EstimateGas');
 const methodDescriptorConsensusGetSignerNonce = createMethodDescriptorUnary<
@@ -421,7 +421,7 @@ const methodDescriptorConsensusLightStateSyncIterate = createMethodDescriptorUna
     types.StorageProofResponse
 >('ConsensusLight', 'StateSyncIterate');
 const methodDescriptorConsensusLightSubmitTxNoWait = createMethodDescriptorUnary<
-    types.SignatureSigned,
+    types.SignatureSigned<types.ConsensusTransaction<unknown>>,
     void
 >('ConsensusLight', 'SubmitTxNoWait');
 const methodDescriptorConsensusLightSubmitEvidence = createMethodDescriptorUnary<
@@ -1077,7 +1077,7 @@ export class NodeInternal extends GRPCWrapper {
     /**
      * Query makes a runtime-specific query.
      */
-    runtimeClientQuery(request: types.RuntimeClientQueryRequest) {
+    runtimeClientQuery(request: types.RuntimeClientQueryRequest<unknown>) {
         return this.callUnary(methodDescriptorRuntimeClientQuery, request);
     }
 

--- a/client-sdk/ts-web/core/src/common.ts
+++ b/client-sdk/ts-web/core/src/common.ts
@@ -72,7 +72,10 @@ export const IDENTITY_MODULE_NAME = 'identity';
  */
 export const IDENTITY_ERR_CERTIFICATE_ROTATION_FORBIDDEN_CODE = 1;
 
-export async function openSignedEntity(context: string, signed: types.SignatureSigned) {
+export async function openSignedEntity(
+    context: string,
+    signed: types.SignatureSigned<types.Entity>,
+) {
     return misc.fromCBOR(await signature.openSigned(context, signed)) as types.Entity;
 }
 
@@ -86,7 +89,7 @@ export async function signSignedEntity(
 
 export async function openMultiSignedNode(
     context: string,
-    multiSigned: types.SignatureMultiSigned,
+    multiSigned: types.SignatureMultiSigned<types.Node>,
 ) {
     return misc.fromCBOR(await signature.openMultiSigned(context, multiSigned)) as types.Node;
 }

--- a/client-sdk/ts-web/core/src/consensus.ts
+++ b/client-sdk/ts-web/core/src/consensus.ts
@@ -84,6 +84,20 @@ export const TRANSACTION_ERR_INSUFFICIENT_FEE_BALANCE_CODE = 2;
  */
 export const TRANSACTION_ERR_GAS_PRICE_TOO_LOW_CODE = 3;
 
+export class Method<BODY> {
+    module: string;
+    method: string;
+
+    constructor(module: string, method: string) {
+        this.module = module;
+        this.method = method;
+    }
+
+    methodName() {
+        return `${this.module}.${this.method}`;
+    }
+}
+
 export async function openSignedTransaction(chainContext: string, signed: types.SignatureSigned) {
     const context = signature.combineChainContext(TRANSACTION_SIGNATURE_CONTEXT, chainContext);
     return misc.fromCBOR(await signature.openSigned(context, signed)) as types.ConsensusTransaction;

--- a/client-sdk/ts-web/core/src/signature.ts
+++ b/client-sdk/ts-web/core/src/signature.ts
@@ -47,11 +47,10 @@ export async function openSigned<T>(context: string, signed: types.SignatureSign
         signed.signature.signature,
     );
     if (!sigOk) throw new Error('signature verification failed');
-    return misc.fromCBOR(signed.untrusted_raw_value) as T;
+    return signed.untrusted_raw_value;
 }
 
-export async function signSigned<T>(signer: ContextSigner, context: string, value: T) {
-    const rawValue = misc.toCBOR(value);
+export async function signSigned<T>(signer: ContextSigner, context: string, rawValue: Uint8Array) {
     return {
         untrusted_raw_value: rawValue,
         signature: {
@@ -74,11 +73,14 @@ export async function openMultiSigned<T>(
         const sigOk = ED25519.verify(signerMessageA, signatureA, publicKeyA);
         if (!sigOk) throw new Error('signature verification failed');
     }
-    return misc.fromCBOR(multiSigned.untrusted_raw_value) as T;
+    return multiSigned.untrusted_raw_value;
 }
 
-export async function signMultiSigned<T>(signers: ContextSigner[], context: string, value: T) {
-    const rawValue = misc.toCBOR(value);
+export async function signMultiSigned<T>(
+    signers: ContextSigner[],
+    context: string,
+    rawValue: Uint8Array,
+) {
     const signatures = [] as types.Signature[];
     for (const signer of signers) {
         signatures.push({

--- a/client-sdk/ts-web/core/src/staking.ts
+++ b/client-sdk/ts-web/core/src/staking.ts
@@ -1,5 +1,8 @@
+import * as client from './client';
 import * as address from './address';
+import * as consensus from './consensus';
 import * as misc from './misc';
+import * as types from './types';
 
 /**
  * AddressV0Context is the unique context for v0 staking account addresses.
@@ -25,33 +28,47 @@ export const ADDRESS_RUNTIME_V0_CONTEXT_VERSION = 0;
 export const ADDRESS_PREFIX = 'oasis';
 
 /**
+ * ModuleName is a unique module name for the staking module.
+ */
+export const MODULE_NAME = 'staking';
+
+/**
  * MethodTransfer is the method name for transfers.
  */
-export const METHOD_TRANSFER = 'staking.Transfer';
+export const METHOD_TRANSFER = new consensus.Method<types.StakingTransfer>(MODULE_NAME, 'Transfer');
 /**
  * MethodBurn is the method name for burns.
  */
-export const METHOD_BURN = 'staking.Burn';
+export const METHOD_BURN = new consensus.Method<types.StakingBurn>(MODULE_NAME, 'Burn');
 /**
  * MethodAddEscrow is the method name for escrows.
  */
-export const METHOD_ADD_ESCROW = 'staking.AddEscrow';
+export const METHOD_ADD_ESCROW = new consensus.Method<types.StakingEscrow>(
+    MODULE_NAME,
+    'AddEscrow',
+);
 /**
  * MethodReclaimEscrow is the method name for escrow reclamations.
  */
-export const METHOD_RECLAIM_ESCROW = 'staking.ReclaimEscrow';
+export const METHOD_RECLAIM_ESCROW = new consensus.Method<types.StakingReclaimEscrow>(
+    MODULE_NAME,
+    'ReclaimEscrow',
+);
 /**
  * MethodAmendCommissionSchedule is the method name for amending commission schedules.
  */
-export const METHOD_AMEND_COMMISSION_SCHEDULE = 'staking.AmendCommissionSchedule';
+export const METHOD_AMEND_COMMISSION_SCHEDULE = new consensus.Method<types.StakingAmendCommissionSchedule>(
+    MODULE_NAME,
+    'AmendCommissionSchedule',
+);
 /**
  * MethodAllow is the method name for setting a beneficiary allowance.
  */
-export const METHOD_ALLOW = 'staking.Allow';
+export const METHOD_ALLOW = new consensus.Method<types.StakingAllow>(MODULE_NAME, 'Allow');
 /**
  * MethodWithdraw is the method name for
  */
-export const METHOD_WITHDRAW = 'staking.Withdraw';
+export const METHOD_WITHDRAW = new consensus.Method<types.StakingWithdraw>(MODULE_NAME, 'Withdraw');
 
 export const KIND_ENTITY = 0;
 export const KIND_NODE_VALIDATOR = 1;
@@ -121,11 +138,6 @@ export const GAS_OP_ALLOW = 'allow';
  * GasOpWithdraw is the gas operation identifier for withdraw.
  */
 export const GAS_OP_WITHDRAW = 'withdraw';
-
-/**
- * ModuleName is a unique module name for the staking module.
- */
-export const MODULE_NAME = 'staking';
 
 /**
  * ErrInvalidArgument is the error returned on malformed arguments.
@@ -221,4 +233,8 @@ export async function governanceDepositsAddress() {
     return await addressFromPublicKey(
         misc.fromHex('1abe11eddeaccfffffffffffffffffffffffffffffffffffffffffffffffffff'),
     );
+}
+
+export async function callTrasnfer(c: client.NodeInternal) {
+    c.consensusSubmitTx();
 }

--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -135,9 +135,9 @@ export interface ConsensusError {
 /**
  * EstimateGasRequest is a EstimateGas request.
  */
-export interface ConsensusEstimateGasRequest {
+export interface ConsensusEstimateGasRequest<BODY> {
     signer: Uint8Array;
-    transaction: ConsensusTransaction;
+    transaction: ConsensusTransaction<BODY>;
 }
 
 /**
@@ -330,7 +330,7 @@ export interface ConsensusStatus {
 /**
  * Transaction is an unsigned consensus transaction.
  */
-export interface ConsensusTransaction {
+export interface ConsensusTransaction<BODY> {
     /**
      * Nonce is a nonce to prevent replay.
      */
@@ -347,7 +347,7 @@ export interface ConsensusTransaction {
     /**
      * Body is the method call body.
      */
-    body?: unknown;
+    body?: BODY;
 }
 
 /**
@@ -1280,7 +1280,7 @@ export interface RegistryGenesis {
     /**
      * Entities is the initial list of entities.
      */
-    entities?: SignatureSigned[];
+    entities?: SignatureSigned<Entity>[];
     /**
      * Runtimes is the initial list of runtimes.
      */
@@ -1292,7 +1292,7 @@ export interface RegistryGenesis {
     /**
      * Nodes is the initial list of nodes.
      */
-    nodes?: SignatureMultiSigned[];
+    nodes?: SignatureMultiSigned<Node>[];
     /**
      * NodeStatuses is a set of node statuses.
      */
@@ -1721,16 +1721,16 @@ export interface RoothashConsensusParameters {
  * EquivocationBatchEvidence is evidence of executor proposed batch equivocation.
  */
 export interface RoothashEquivocationBatchEvidence {
-    batch_a: SignatureSigned;
-    batch_b: SignatureSigned;
+    batch_a: SignatureSigned<RoothashProposedBatch>;
+    batch_b: SignatureSigned<RoothashProposedBatch>;
 }
 
 /**
  * EquivocationExecutorEvidence is evidence of executor commitment equivocation.
  */
 export interface RoothashEquivocationExecutorEvidence {
-    commit_a: SignatureSigned;
-    commit_b: SignatureSigned;
+    commit_a: SignatureSigned<RoothashComputeBody>;
+    commit_b: SignatureSigned<RoothashComputeBody>;
 }
 
 /**
@@ -1770,7 +1770,7 @@ export interface RoothashExecutionDiscrepancyDetectedEvent {
  */
 export interface RoothashExecutorCommit {
     id: Uint8Array;
-    commits: SignatureSigned[];
+    commits: SignatureSigned<RoothashComputeBody>[];
 }
 
 /**
@@ -1780,7 +1780,7 @@ export interface RoothashExecutorCommittedEvent {
     /**
      * Commit is the executor commitment.
      */
-    commit: SignatureSigned;
+    commit: SignatureSigned<RoothashComputeBody>;
 }
 
 /**
@@ -2044,18 +2044,18 @@ export interface RuntimeClientQueryCondition {
 /**
  * QueryRequest is a Query request.
  */
-export interface RuntimeClientQueryRequest {
+export interface RuntimeClientQueryRequest<ARGS> {
     runtime_id: Uint8Array;
     round: longnum;
     method: string;
-    args: unknown;
+    args: ARGS;
 }
 
 /**
  * QueryResponse is a response to the runtime query.
  */
-export interface RuntimeClientQueryResponse {
-    data: unknown;
+export interface RuntimeClientQueryResponse<DATA> {
+    data: DATA;
 }
 
 /**
@@ -2227,7 +2227,7 @@ export interface SGXEnclaveIdentity {
 /**
  * MultiSigned is a blob signed by multiple public keys.
  */
-export interface SignatureMultiSigned {
+export interface SignatureMultiSigned<T> {
     /**
      * Blob is the signed blob.
      */
@@ -2255,7 +2255,7 @@ export interface Signature {
 /**
  * Signed is a signed blob.
  */
-export interface SignatureSigned {
+export interface SignatureSigned<T> {
     /**
      * Blob is the signed blob.
      */


### PR DESCRIPTION
one thing I tried out in the search for typed transaction wrappers was to make container types generic, with a parameter of what they had inside. but in most situations when you have such a structure, you don't know what's inside, and the typed transaction wrapper is rather the exception. so we left them as `unknown` and we added type assertions to the transaction wrappers instead.