### PR TITLE
ts-web/core: use client node for playground grpc

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -139,7 +139,7 @@ jobs:
 
       - name: 'testnet: Wait for node socket'
         run: |
-          while [ ! -e /tmp/oasis-net-runner-sdk-core/net-runner/network/validator-0/internal.sock ]; do
+          while [ ! -e /tmp/oasis-net-runner-sdk-core/net-runner/network/client-0/internal.sock ]; do
             sleep 1
           done
 

--- a/client-sdk/ts-web/core/playground/sample-envoy.yaml
+++ b/client-sdk/ts-web/core/playground/sample-envoy.yaml
@@ -56,7 +56,7 @@ static_resources:
         - endpoint:
             address:
               pipe:
-                path: /tmp/oasis-net-runner-sdk-core/net-runner/network/validator-0/internal.sock
+                path: /tmp/oasis-net-runner-sdk-core/net-runner/network/client-0/internal.sock
     http2_protocol_options: {}
   - name: dev_static
     connect_timeout: 0.25s

--- a/client-sdk/ts-web/core/playground/sample-envoy.yaml
+++ b/client-sdk/ts-web/core/playground/sample-envoy.yaml
@@ -21,7 +21,7 @@ static_resources:
                   safe_regex:
                     google_re2:
                       max_program_size: 1000000
-                    regex: '/oasis-core\.(Registry/(GetNodes)|Staking/(Account|DelegationsTo|GetEvents)|Consensus/(SubmitTx|EstimateGas|GetBlock|GetTransactionsWithResults|GetGenesisDocument|WatchBlocks))'
+                    regex: '/oasis-core\.(Registry/(GetNodes)|Staking/(Account|DelegationsTo|GetEvents)|Consensus/(SubmitTx|EstimateGas|GetBlock|GetTransactionsWithResults|GetGenesisDocument|WatchBlocks)|NodeController/(WaitReady))'
                 route:
                   cluster: oasis_node_grpc
                   timeout: 0s

--- a/client-sdk/ts-web/core/playground/src/index.js
+++ b/client-sdk/ts-web/core/playground/src/index.js
@@ -7,6 +7,15 @@ const nic = new oasis.client.NodeInternal('http://localhost:42280');
 
 (async function () {
     try {
+        // Wait for ready.
+        {
+            console.log('waiting for node to be ready');
+            const waitStart = Date.now();
+            await nic.nodeControllerWaitReady();
+            const waitEnd = Date.now();
+            console.log(`ready ${waitEnd - waitStart} ms`);
+        }
+
         // Get something with addresses.
         {
             console.log('nodes', await nic.registryGetNodes(oasis.consensus.HEIGHT_LATEST));


### PR DESCRIPTION
depends #54 

This seems to need a little something more, with our test hanging when directed at the client node instead of the validator