### PR TITLE
ts-web/core: revert to tweetnacl

### DIFF
--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -14,12 +14,11 @@
     "dependencies": {
         "bech32": "^1.1.4",
         "cborg": "^1.1.2",
-        "elliptic": "^6.5.3",
         "grpc-web": "^1.2.1",
-        "js-sha512": "^0.8.0"
+        "js-sha512": "^0.8.0",
+        "tweetnacl": "^1.0.3"
     },
     "devDependencies": {
-        "@types/elliptic": "^6.4.12",
         "cypress": "^6.6.0",
         "typescript": "^4.1.3",
         "webpack": "^5.21.2",

--- a/client-sdk/ts-web/core/playground/src/index.js
+++ b/client-sdk/ts-web/core/playground/src/index.js
@@ -39,8 +39,8 @@ const nic = new oasis.client.NodeInternal('http://localhost:42280');
 
         // Try sending a transaction.
         {
-            const src = oasis.signature.EllipticSigner.fromRandom('this key is not important');
-            const dst = oasis.signature.EllipticSigner.fromRandom('this key is not important');
+            const src = oasis.signature.NaclSigner.fromRandom('this key is not important');
+            const dst = oasis.signature.NaclSigner.fromRandom('this key is not important');
             console.log('src', src, 'dst', dst);
 
             const genesis = await nic.consensusGetGenesisDocument();

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -20,18 +20,22 @@
             "dependencies": {
                 "bech32": "^1.1.4",
                 "cborg": "^1.1.2",
-                "elliptic": "^6.5.3",
                 "grpc-web": "^1.2.1",
-                "js-sha512": "^0.8.0"
+                "js-sha512": "^0.8.0",
+                "tweetnacl": "^1.0.3"
             },
             "devDependencies": {
-                "@types/elliptic": "^6.4.12",
                 "cypress": "^6.6.0",
                 "typescript": "^4.1.3",
                 "webpack": "^5.21.2",
                 "webpack-cli": "^4.5.0",
                 "webpack-dev-server": "^3.11.1"
             }
+        },
+        "core/node_modules/tweetnacl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
         },
         "node_modules/@babel/runtime": {
             "version": "7.13.0",
@@ -1472,9 +1476,9 @@
             "dev": true
         },
         "node_modules/cborg": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.1.2.tgz",
-            "integrity": "sha512-uDN2IDsf86wuT64nVligc7NhkAqeWrq8hbCf4mxnY9z487v9seJHc/n2acI/uKT3Oo2Rp3MZgyZ7FD9KjWimzg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.2.1.tgz",
+            "integrity": "sha512-eA14hhjU6a9QxCvam/hdRl5LMLfqB1YGG/VA5woI5LxVDjh7kDiRxFp/uSfYQjAGVuk2BvSjx7L60u+B1k3gGw==",
             "bin": {
                 "cborg": "cli.js"
             }
@@ -9086,17 +9090,23 @@
         "@oasisprotocol/client": {
             "version": "file:core",
             "requires": {
-                "@types/elliptic": "^6.4.12",
                 "bech32": "^1.1.4",
                 "cborg": "^1.1.2",
                 "cypress": "^6.6.0",
-                "elliptic": "^6.5.3",
                 "grpc-web": "^1.2.1",
                 "js-sha512": "^0.8.0",
+                "tweetnacl": "^1.0.3",
                 "typescript": "^4.1.3",
                 "webpack": "^5.21.2",
                 "webpack-cli": "^4.5.0",
                 "webpack-dev-server": "^3.11.1"
+            },
+            "dependencies": {
+                "tweetnacl": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+                    "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+                }
             }
         },
         "@oasisprotocol/client-rt": {
@@ -10508,9 +10518,9 @@
             "dev": true
         },
         "cborg": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.1.2.tgz",
-            "integrity": "sha512-uDN2IDsf86wuT64nVligc7NhkAqeWrq8hbCf4mxnY9z487v9seJHc/n2acI/uKT3Oo2Rp3MZgyZ7FD9KjWimzg=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.2.1.tgz",
+            "integrity": "sha512-eA14hhjU6a9QxCvam/hdRl5LMLfqB1YGG/VA5woI5LxVDjh7kDiRxFp/uSfYQjAGVuk2BvSjx7L60u+B1k3gGw=="
         },
         "chalk": {
             "version": "4.1.0",

--- a/client-sdk/ts-web/rt/playground/src/index.js
+++ b/client-sdk/ts-web/rt/playground/src/index.js
@@ -98,7 +98,7 @@ const keyvalueWrapper = new Wrapper(KEYVALUE_RUNTIME_ID);
             const THE_KEY = oasis.misc.fromString('greeting-js');
             const THE_VALUE = oasis.misc.fromString('Hi from JavaScript');
 
-            const alice = oasis.signature.EllipticSigner.fromSecret(await oasis.hash.hash(oasis.misc.fromString('oasis-runtime-sdk/test-keys: alice')), 'this key is not important');
+            const alice = oasis.signature.NaclSigner.fromSeed(await oasis.hash.hash(oasis.misc.fromString('oasis-runtime-sdk/test-keys: alice')), 'this key is not important');
             const csAlice = new oasis.signature.BlindContextSigner(alice);
             // The keyvalue runtime does not use the accounts module, so there
             // is no nonce checking.

--- a/client-sdk/ts-web/signer-ledger/playground/src/index.js
+++ b/client-sdk/ts-web/signer-ledger/playground/src/index.js
@@ -9,7 +9,7 @@ async function play() {
 
         // Try Ledger signing.
         {
-            const dst = oasis.signature.EllipticSigner.fromRandom('this key is not important');
+            const dst = oasis.signature.NaclSigner.fromRandom('this key is not important');
             const dstAddr = await oasis.staking.addressFromPublicKey(dst.public());
             console.log('dst addr', oasis.staking.addressToBech32(dstAddr));
 


### PR DESCRIPTION
Replace the EllipticSigner with NaclSigner

Elliptic is not able to sign using the 64 bytes private key that we will need to use once we support key derivation.
For reference the go package does it right : https://golang.org/pkg/crypto/ed25519/ and allows you to instanciate a keypair from the seed or from the 64 bytes private key.

The whole process is described here : https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/

This is required in order to eventually implement [BIP32-Ed25519](https://github.com/oasisprotocol/oasis-core/pull/3656/) 