### PR TITLE
Apply macros to keyvalue example

### DIFF
--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -34,11 +34,6 @@ pub trait Error: std::error::Error {
     /// Error code uniquely identifying the error.
     fn code(&self) -> u32;
 
-    /// Error message.
-    fn msg(&self) -> String {
-        self.to_string()
-    }
-
     /// Converts the error into a call result.
     fn to_call_result(&self) -> CallResult {
         CallResult::Failed {

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -46,12 +46,6 @@ pub enum Error {
     Forbidden,
 }
 
-impl From<Error> for error::RuntimeError {
-    fn from(err: Error) -> error::RuntimeError {
-        error::RuntimeError::new(err.module(), err.code(), &err.msg())
-    }
-}
-
 /// Events emitted by the accounts module.
 #[derive(Debug, Serialize, Deserialize, oasis_runtime_sdk_macros::Event)]
 #[serde(untagged)]

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -1,10 +1,7 @@
 //! Core definitions module.
 use thiserror::Error;
 
-use crate::{
-    error::{self, Error as _},
-    types::transaction,
-};
+use crate::types::transaction;
 
 pub mod types;
 
@@ -34,12 +31,6 @@ pub enum Error {
     #[error("insufficient balance to pay fees")]
     #[sdk_error(code = 5)]
     InsufficientFeeBalance,
-}
-
-impl From<Error> for error::RuntimeError {
-    fn from(err: Error) -> error::RuntimeError {
-        error::RuntimeError::new(err.module(), err.code(), &err.msg())
-    }
 }
 
 /// State schema constants.

--- a/tests/runtimes/simple-keyvalue/src/keyvalue.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue.rs
@@ -16,53 +16,19 @@ pub mod types;
 const MODULE_NAME: &str = "keyvalue";
 
 /// Errors emitted by the keyvalue module.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, sdk::Error)]
+#[sdk_error(module = "Module")]
 pub enum Error {
     #[error("invalid argument")]
+    #[sdk_error(code = 1)]
     InvalidArgument,
 }
 
-impl sdk::error::Error for Error {
-    fn module(&self) -> &str {
-        MODULE_NAME
-    }
-
-    fn code(&self) -> u32 {
-        match self {
-            Error::InvalidArgument => 1,
-        }
-    }
-}
-
-impl From<Error> for sdk::error::RuntimeError {
-    fn from(err: Error) -> sdk::error::RuntimeError {
-        sdk::error::RuntimeError::new(err.module(), err.code(), &err.msg())
-    }
-}
-
 /// Events emitted by the keyvalue module (none so far).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, sdk::Event)]
 #[serde(untagged)]
-pub enum Event {
-    // XXX: What if we don't want to have any events?  The SDK seems to require an implementation anyways :/
-    DummyEvent = 1,
-}
-
-impl sdk::event::Event for Event {
-    fn module(&self) -> &str {
-        MODULE_NAME
-    }
-
-    fn code(&self) -> u32 {
-        match self {
-            Event::DummyEvent { .. } => 1,
-        }
-    }
-
-    fn value(&self) -> cbor::Value {
-        cbor::to_value(self)
-    }
-}
+#[sdk_event(module = "Module")]
+pub enum Event {}
 
 /// Parameters for the keyvalue module (none so far).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
This PR does what it says on the tin. It also removes `sdk::error::Error::msg` because it's a non-standard way of writing `std::error::Error::to_string`.