### PR TITLE
runtime-sdk: allow macros to work with generic modules

### DIFF
--- a/runtime-sdk-macros/src/error_derive.rs
+++ b/runtime-sdk-macros/src/error_derive.rs
@@ -68,7 +68,7 @@ pub fn derive_error(input: DeriveInput) -> TokenStream {
         };
 
         impl sdk::error::Error for #error_ty_ident {
-            fn module_name(&self) -> &str {
+            fn module_name() -> &'static str {
                 #module_name
             }
 
@@ -79,7 +79,7 @@ pub fn derive_error(input: DeriveInput) -> TokenStream {
 
         impl From<#error_ty_ident> for RuntimeError {
             fn from(err: #error_ty_ident) -> RuntimeError {
-                RuntimeError::new(err.module_name(), err.code(), &err.to_string())
+                RuntimeError::new(#error_ty_ident::module_name(), err.code(), &err.to_string())
             }
         }
     })
@@ -95,7 +95,7 @@ mod tests {
                     self as sdk, core::types::Error as RuntimeError, error::Error as _,
                 };
                 impl sdk::error::Error for Error {
-                    fn module_name(&self) -> &str {
+                    fn module_name() -> &'static str {
                         MODULE_NAME
                     }
                     fn code(&self) -> u32 {
@@ -109,7 +109,7 @@ mod tests {
                 }
                 impl From<Error> for RuntimeError {
                     fn from(err: Error) -> RuntimeError {
-                        RuntimeError::new(err.module_name(), err.code(), &err.to_string())
+                        RuntimeError::new(Error::module_name(), err.code(), &err.to_string())
                     }
                 }
             };

--- a/runtime-sdk-macros/src/event_derive.rs
+++ b/runtime-sdk-macros/src/event_derive.rs
@@ -12,8 +12,8 @@ struct Event {
 
     data: darling::ast::Data<EventVariant, darling::util::Ignored>,
 
-    /// The path to the module type.
-    module: syn::Path,
+    /// The path to a const set to the module name.
+    module_name: syn::Path,
 
     /// Whether to sequentially autonumber the event codes.
     /// This option exists as a convenience for runtimes that
@@ -51,7 +51,7 @@ pub fn derive_event(input: DeriveInput) -> TokenStream {
     };
 
     let event_ty_ident = &event.ident;
-    let module_path = &event.module;
+    let module_name = &event.module_name;
 
     let code_converter = gen::enum_code_converter(
         &format_ident!("self"),
@@ -65,8 +65,8 @@ pub fn derive_event(input: DeriveInput) -> TokenStream {
         use #sdk_crate::core::common::cbor;
 
         impl #sdk_crate::event::Event for #event_ty_ident {
-            fn module(&self) -> &str {
-                <#module_path as #sdk_crate::module::Module>::NAME
+            fn module_name(&self) -> &str {
+                #module_name
             }
 
             fn code(&self) -> u32 {
@@ -88,8 +88,8 @@ mod tests {
             const _: () = {
                 use oasis_runtime_sdk::core::common::cbor;
                 impl ::oasis_runtime_sdk::event::Event for MainEvent {
-                    fn module(&self) -> &str {
-                        <module::TheModule as ::oasis_runtime_sdk::module::Module>::NAME
+                    fn module_name(&self) -> &str {
+                        MODULE_NAME
                     }
                     fn code(&self) -> u32 {
                         match self {
@@ -108,7 +108,7 @@ mod tests {
 
         let input: syn::DeriveInput = syn::parse_quote!(
             #[derive(Event)]
-            #[sdk_event(autonumber, module = "module::TheModule")]
+            #[sdk_event(autonumber, module_name = "MODULE_NAME")]
             pub enum MainEvent {
                 Event0,
                 #[sdk_event(code = 2)]

--- a/runtime-sdk-macros/src/event_derive.rs
+++ b/runtime-sdk-macros/src/event_derive.rs
@@ -65,7 +65,7 @@ pub fn derive_event(input: DeriveInput) -> TokenStream {
         use #sdk_crate::core::common::cbor;
 
         impl #sdk_crate::event::Event for #event_ty_ident {
-            fn module_name(&self) -> &str {
+            fn module_name() -> &'static str {
                 #module_name
             }
 
@@ -88,7 +88,7 @@ mod tests {
             const _: () = {
                 use oasis_runtime_sdk::core::common::cbor;
                 impl ::oasis_runtime_sdk::event::Event for MainEvent {
-                    fn module_name(&self) -> &str {
+                    fn module_name() -> &'static str {
                         MODULE_NAME
                     }
                     fn code(&self) -> u32 {

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -134,7 +134,7 @@ impl<R: Runtime> Dispatcher<R> {
             Err(err) => {
                 return Ok(CheckTxResult {
                     error: RuntimeError {
-                        module: err.module().to_string(),
+                        module: err.module_name().to_string(),
                         code: err.code(),
                         message: err.to_string(),
                     },

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -134,7 +134,7 @@ impl<R: Runtime> Dispatcher<R> {
             Err(err) => {
                 return Ok(CheckTxResult {
                     error: RuntimeError {
-                        module: err.module_name().to_string(),
+                        module: modules::core::Error::module_name().to_string(),
                         code: err.code(),
                         message: err.to_string(),
                     },

--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -29,7 +29,7 @@ use crate::types::transaction::CallResult;
 /// ```
 pub trait Error: std::error::Error {
     /// Name of the module that emitted the error.
-    fn module_name(&self) -> &str;
+    fn module_name() -> &'static str;
 
     /// Error code uniquely identifying the error.
     fn code(&self) -> u32;
@@ -37,7 +37,7 @@ pub trait Error: std::error::Error {
     /// Converts the error into a call result.
     fn to_call_result(&self) -> CallResult {
         CallResult::Failed {
-            module: self.module_name().to_owned(),
+            module: Self::module_name().to_owned(),
             code: self.code(),
         }
     }

--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -16,7 +16,7 @@ use crate::types::transaction::CallResult;
 /// # use oasis_runtime_sdk_macros::Error;
 /// const MODULE_NAME: &str = "my-module";
 /// #[derive(Clone, Debug, Serialize, Deserialize, Error, thiserror::Error)]
-/// #[sdk_error(module_name = "MODULE_NAME", autonumber)] // `module_name` is required
+/// #[sdk_error(autonumber)] // `module_name` meta is required if `MODULE_NAME` isn't in scope
 /// enum Error {
 ///    #[error("invalid argument")]
 ///    InvalidArgument,          // autonumbered to 0

--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -14,9 +14,9 @@ use crate::types::transaction::CallResult;
 /// # mod example {
 /// # use serde::{Serialize, Deserialize};
 /// # use oasis_runtime_sdk_macros::Error;
-/// # mod path { pub mod to { pub use oasis_runtime_sdk::modules::accounts::Module as MyModule; }}
+/// const MODULE_NAME: &str = "my-module";
 /// #[derive(Clone, Debug, Serialize, Deserialize, Error, thiserror::Error)]
-/// #[sdk_error(module = "path::to::MyModule", autonumber)] // `module` is required
+/// #[sdk_error(module_name = "MODULE_NAME", autonumber)] // `module_name` is required
 /// enum Error {
 ///    #[error("invalid argument")]
 ///    InvalidArgument,          // autonumbered to 0
@@ -29,7 +29,7 @@ use crate::types::transaction::CallResult;
 /// ```
 pub trait Error: std::error::Error {
     /// Name of the module that emitted the error.
-    fn module(&self) -> &str;
+    fn module_name(&self) -> &str;
 
     /// Error code uniquely identifying the error.
     fn code(&self) -> u32;
@@ -37,7 +37,7 @@ pub trait Error: std::error::Error {
     /// Converts the error into a call result.
     fn to_call_result(&self) -> CallResult {
         CallResult::Failed {
-            module: self.module().to_owned(),
+            module: self.module_name().to_owned(),
             code: self.code(),
         }
     }

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -9,9 +9,9 @@ use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 /// # mod example {
 /// # use serde::{Serialize, Deserialize};
 /// # use oasis_runtime_sdk_macros::Event;
-/// # mod path { pub mod to { pub use oasis_runtime_sdk::modules::accounts::Module as MyModule; }}
+/// const MODULE_NAME: &str = "my-module";
 /// #[derive(Clone, Debug, Serialize, Deserialize, Event)]
-/// #[sdk_event(module = "path::to::MyModule", autonumber)] // `module` is required
+/// #[sdk_event(module_name = "MODULE_NAME", autonumber)] // `module_name` is required
 /// enum MyEvent {
 ///    Greeting(String),      // autonumbered to 0
 ///    #[sdk_event(code = 2)] // manually numbered to 2 (`code` is required if not autonumbering)
@@ -24,7 +24,7 @@ use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 /// ```
 pub trait Event {
     /// Name of the module that emitted the event.
-    fn module(&self) -> &str;
+    fn module_name(&self) -> &str;
 
     /// Code uniquely identifying the event.
     fn code(&self) -> u32;
@@ -46,7 +46,7 @@ pub trait Event {
     ///
     fn to_tag(&self) -> Tag {
         Tag::new(
-            [self.module().as_bytes(), &self.code().to_be_bytes()]
+            [self.module_name().as_bytes(), &self.code().to_be_bytes()]
                 .concat()
                 .to_vec(),
             cbor::to_vec(&self.value()),

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -24,7 +24,7 @@ use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 /// ```
 pub trait Event {
     /// Name of the module that emitted the event.
-    fn module_name(&self) -> &str;
+    fn module_name() -> &'static str;
 
     /// Code uniquely identifying the event.
     fn code(&self) -> u32;
@@ -46,7 +46,7 @@ pub trait Event {
     ///
     fn to_tag(&self) -> Tag {
         Tag::new(
-            [self.module_name().as_bytes(), &self.code().to_be_bytes()]
+            [Self::module_name().as_bytes(), &self.code().to_be_bytes()]
                 .concat()
                 .to_vec(),
             cbor::to_vec(&self.value()),

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -11,7 +11,7 @@ use oasis_core_runtime::{common::cbor, transaction::tags::Tag};
 /// # use oasis_runtime_sdk_macros::Event;
 /// const MODULE_NAME: &str = "my-module";
 /// #[derive(Clone, Debug, Serialize, Deserialize, Event)]
-/// #[sdk_event(module_name = "MODULE_NAME", autonumber)] // `module_name` is required
+/// #[sdk_event(autonumber)] // `module_name` meta is required if `MODULE_NAME` isn't in scope
 /// enum MyEvent {
 ///    Greeting(String),      // autonumbered to 0
 ///    #[sdk_event(code = 2)] // manually numbered to 2 (`code` is required if not autonumbering)

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -31,7 +31,6 @@ const MODULE_NAME: &str = "accounts";
 
 /// Errors emitted by the accounts module.
 #[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
-#[sdk_error(module_name = "MODULE_NAME")]
 pub enum Error {
     #[error("invalid argument")]
     #[sdk_error(code = 1)]
@@ -49,7 +48,6 @@ pub enum Error {
 /// Events emitted by the accounts module.
 #[derive(Debug, Serialize, Deserialize, oasis_runtime_sdk_macros::Event)]
 #[serde(untagged)]
-#[sdk_event(module_name = "MODULE_NAME")]
 pub enum Event {
     #[sdk_event(code = 1)]
     Transfer {

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -31,7 +31,7 @@ const MODULE_NAME: &str = "accounts";
 
 /// Errors emitted by the accounts module.
 #[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
-#[sdk_error(module = "Module")]
+#[sdk_error(module_name = "MODULE_NAME")]
 pub enum Error {
     #[error("invalid argument")]
     #[sdk_error(code = 1)]
@@ -49,7 +49,7 @@ pub enum Error {
 /// Events emitted by the accounts module.
 #[derive(Debug, Serialize, Deserialize, oasis_runtime_sdk_macros::Event)]
 #[serde(untagged)]
-#[sdk_event(module = "Module")]
+#[sdk_event(module_name = "MODULE_NAME")]
 pub enum Event {
     #[sdk_event(code = 1)]
     Transfer {

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -10,7 +10,7 @@ pub const MODULE_NAME: &str = "core";
 
 /// Errors emitted by the core module.
 #[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
-#[sdk_error(module_name_path = "MODULE_NAME")]
+#[sdk_error(module_name = "MODULE_NAME")]
 pub enum Error {
     #[error("malformed transaction")]
     #[sdk_error(code = 1)]

--- a/tests/runtimes/simple-keyvalue/src/keyvalue.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue.rs
@@ -17,7 +17,6 @@ const MODULE_NAME: &str = "keyvalue";
 
 /// Errors emitted by the keyvalue module.
 #[derive(Error, Debug, sdk::Error)]
-#[sdk_error(module_name = "MODULE_NAME")]
 pub enum Error {
     #[error("invalid argument")]
     #[sdk_error(code = 1)]
@@ -27,7 +26,6 @@ pub enum Error {
 /// Events emitted by the keyvalue module (none so far).
 #[derive(Debug, Serialize, Deserialize, sdk::Event)]
 #[serde(untagged)]
-#[sdk_event(module_name = "MODULE_NAME")]
 pub enum Event {}
 
 /// Parameters for the keyvalue module (none so far).

--- a/tests/runtimes/simple-keyvalue/src/keyvalue.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue.rs
@@ -17,7 +17,7 @@ const MODULE_NAME: &str = "keyvalue";
 
 /// Errors emitted by the keyvalue module.
 #[derive(Error, Debug, sdk::Error)]
-#[sdk_error(module = "Module")]
+#[sdk_error(module_name = "MODULE_NAME")]
 pub enum Error {
     #[error("invalid argument")]
     #[sdk_error(code = 1)]
@@ -27,7 +27,7 @@ pub enum Error {
 /// Events emitted by the keyvalue module (none so far).
 #[derive(Debug, Serialize, Deserialize, sdk::Event)]
 #[serde(untagged)]
-#[sdk_event(module = "Module")]
+#[sdk_event(module_name = "MODULE_NAME")]
 pub enum Event {}
 
 /// Parameters for the keyvalue module (none so far).


### PR DESCRIPTION
After attempting to use the macros in the bridge, it became evident that the macros would not easily work with generic `Module` types. I can't really think of a good way to get type information in that wouldn't also degrade developer UX or maintainability of this codebase, so this just makes the module name a const parameter.