### PR TITLE
ts-web: bump versions for alpha release

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.0-alpha1
+
+Spotlight change:
+
+- We'll now be putting this on npm.
+
 Note: nonbreaking changes made before v0.1.0 aren't catalogued.
 Ask us directly or see the Git history for what changed.
 

--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -6,6 +6,20 @@ Spotlight change:
 
 - We'll now be putting this on npm.
 
+Breaking changes:
+
+- We're switching back to tweetnacl.
+  Use `signature.NaclSigner` for similar functionality if you previously used
+  `signature.EllipticSigner`.
+  Use `NaclSigner.fromSeed` for similar functionality if you previously used
+  `EllipticSigner.fromSecret`.
+
+New features:
+
+- There are now wrappers for consensus transactions, which help associate the
+  method names with the right transaction body types.
+- Compatibility with oasis-core is updated to 21.0.1.
+
 Note: nonbreaking changes made before v0.1.0 aren't catalogued.
 Ask us directly or see the Git history for what changed.
 

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client",
-    "version": "0.0.2",
+    "version": "0.1.0-alpha1",
     "license": "Apache-2.0",
     "files": [
         "dist"

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -15,7 +15,7 @@
         },
         "core": {
             "name": "@oasisprotocol/client",
-            "version": "0.0.2",
+            "version": "0.1.0-alpha1",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^1.1.4",
@@ -9254,9 +9254,9 @@
         },
         "rt": {
             "name": "@oasisprotocol/client-rt",
-            "version": "0.0.2",
+            "version": "0.1.0-alpha1",
             "dependencies": {
-                "@oasisprotocol/client": "^0.0.2",
+                "@oasisprotocol/client": "^0.1.0-alpha1",
                 "elliptic": "^6.5.3"
             },
             "devDependencies": {
@@ -9270,11 +9270,11 @@
         },
         "signer-ledger": {
             "name": "@oasisprotocol/client-signer-ledger",
-            "version": "0.0.1",
+            "version": "0.1.0-alpha1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^5.41.0",
-                "@oasisprotocol/client": "^0.0.2",
+                "@oasisprotocol/client": "^0.1.0-alpha1",
                 "@oasisprotocol/ledger": "^0.1.0"
             },
             "devDependencies": {
@@ -10151,7 +10151,7 @@
         "@oasisprotocol/client-rt": {
             "version": "file:rt",
             "requires": {
-                "@oasisprotocol/client": "^0.0.2",
+                "@oasisprotocol/client": "^0.1.0-alpha1",
                 "@types/elliptic": "^6.4.12",
                 "cypress": "^6.6.0",
                 "elliptic": "^6.5.3",
@@ -10165,7 +10165,7 @@
             "version": "file:signer-ledger",
             "requires": {
                 "@ledgerhq/hw-transport-webusb": "^5.41.0",
-                "@oasisprotocol/client": "^0.0.2",
+                "@oasisprotocol/client": "^0.1.0-alpha1",
                 "@oasisprotocol/ledger": "^0.1.0",
                 "typescript": "^4.1.3",
                 "webpack": "^4.46.0",

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.0-alpha1
+
+Spotlight change:
+
+- We'll now be putting this on npm.
+
 Note: nonbreaking changes made before v0.1.0 aren't catalogued.
 Ask us directly or see the Git history for what changed.
 

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -6,6 +6,13 @@ Spotlight change:
 
 - We'll now be putting this on npm.
 
+Breaking changes:
+
+- `TransactionWrapper.sign` now computes the signature context.
+  Accordingly, it now takes the consensus chain context as a parameter.
+  You can get this from `oasis.client.NodeInternal.consensusGetChainContext` if
+  you don't already have it.
+
 Note: nonbreaking changes made before v0.1.0 aren't catalogued.
 Ask us directly or see the Git history for what changed.
 

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-rt",
-    "version": "0.0.2",
+    "version": "0.1.0-alpha1",
     "files": [
         "dist"
     ],
@@ -11,7 +11,7 @@
         "playground": "cd playground && webpack s -c webpack.config.js"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.0.2",
+        "@oasisprotocol/client": "^0.1.0-alpha1",
         "elliptic": "^6.5.3"
     },
     "devDependencies": {

--- a/client-sdk/ts-web/signer-ledger/docs/changelog.md
+++ b/client-sdk/ts-web/signer-ledger/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.0-alpha1
+
+Spotlight change:
+
+- We'll now be putting this on npm.
+
 Note: nonbreaking changes made before v0.1.0 aren't catalogued.
 Ask us directly or see the Git history for what changed.
 

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-signer-ledger",
-    "version": "0.0.1",
+    "version": "0.1.0-alpha1",
     "license": "Apache-2.0",
     "files": [
         "dist"
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^5.41.0",
-        "@oasisprotocol/client": "^0.0.2",
+        "@oasisprotocol/client": "^0.1.0-alpha1",
         "@oasisprotocol/ledger": "^0.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
We can put a prerelease version on npm. We discussed this internally, and we didn't come up with anything that should block this.

for #7 