### PR TITLE
ts-web/rt: add typed event visitor

### DIFF
--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased changes
+
+Breaking changes:
+
+- `event.toTag` is renamed to `toKey`.
+  It never included the value, so that was only the key all along.
+
 ## v0.1.0-alpha1
 
 Spotlight change:

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -7,6 +7,13 @@ Breaking changes:
 - `event.toTag` is renamed to `toKey`.
   It never included the value, so that was only the key all along.
 
+New features:
+
+- There's a new `event.Visitor` class to help set up event handlers with type
+  help.
+  Construct it with the outputs of modules' new `moduleEventHandler`
+  functions.
+
 ## v0.1.0-alpha1
 
 Spotlight change:

--- a/client-sdk/ts-web/rt/playground/src/index.js
+++ b/client-sdk/ts-web/rt/playground/src/index.js
@@ -69,6 +69,13 @@ class Wrapper extends oasisRT.wrapper.Base {
 
 }
 
+function moduleEventHandler(/** @type {{
+    [EVENT_INSERT_CODE]?: oasisRT.event.Handler<InsertEvent>,
+    [EVENT_REMOVE_CODE]?: oasisRT.event.Handler<RemoveEvent>,
+}} */ codes) {
+    return /** @type {oasisRT.event.ModuleHandler} */ ([MODULE_NAME, codes]);
+}
+
 const nic = new oasis.client.NodeInternal('http://localhost:42280');
 const keyvalueWrapper = new Wrapper(KEYVALUE_RUNTIME_ID);
 
@@ -106,6 +113,36 @@ export const playground = (async function () {
     {
         const THE_KEY = oasis.misc.fromString('greeting-js');
         const THE_VALUE = oasis.misc.fromString('Hi from JavaScript');
+
+        const eventVisitor = new oasisRT.event.Visitor([
+            moduleEventHandler({
+                [EVENT_INSERT_CODE]: (e, insertEvent) => {
+                    console.log('observed insert', insertEvent);
+                },
+                [EVENT_REMOVE_CODE]: (e, removeEvent) => {
+                    console.log('observed remove', removeEvent);
+                },
+            }),
+        ]);
+        const blocks = nic.runtimeClientWatchBlocks(KEYVALUE_RUNTIME_ID);
+        blocks.on('data', (annotatedBlock) => {
+            console.log('observed block', annotatedBlock.block.header.round);
+            (async () => {
+                try {
+                    /** @type oasis.types.RuntimeClientEvent[] */
+                    const events = await nic.runtimeClientGetEvents({
+                        runtime_id: KEYVALUE_RUNTIME_ID,
+                        round: annotatedBlock.block.header.round,
+                    }) || [];
+                    for (const event of events) {
+                        console.log('observed event', event);
+                        eventVisitor.visit(event);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            })();
+        });
 
         const alice = oasis.signature.NaclSigner.fromSeed(await oasis.hash.hash(oasis.misc.fromString('oasis-runtime-sdk/test-keys: alice')), 'this key is not important');
         const csAlice = new oasis.signature.BlindContextSigner(alice);

--- a/client-sdk/ts-web/rt/playground/src/index.js
+++ b/client-sdk/ts-web/rt/playground/src/index.js
@@ -21,7 +21,13 @@ const METHOD_REMOVE = 'keyvalue.Remove';
 // Queries.
 const METHOD_GET = 'keyvalue.Get';
 
-const EVENT_DUMMY_EVENT_CODE = 1;
+const EVENT_INSERT_CODE = 1;
+const EVENT_REMOVE_CODE = 2;
+
+/**
+ * @typedef {object} InsertEvent
+ * @property {KeyValue} kv
+ */
 
 /**
  * @typedef {object} Key
@@ -32,6 +38,11 @@ const EVENT_DUMMY_EVENT_CODE = 1;
  * @typedef {object} KeyValue
  * @property {Uint8Array} key
  * @property {Uint8Array} value
+ */
+
+/**
+ * @typedef {object} RemoveEvent
+ * @property {Key} key
  */
 
 class Wrapper extends oasisRT.wrapper.Base {

--- a/client-sdk/ts-web/rt/src/accounts.ts
+++ b/client-sdk/ts-web/rt/src/accounts.ts
@@ -1,5 +1,6 @@
 import * as oasis from '@oasisprotocol/client';
 
+import * as event from './event';
 import * as types from './types';
 import * as wrapper from './wrapper';
 
@@ -40,4 +41,12 @@ export class Wrapper extends wrapper.Base {
             METHOD_BALANCES,
         );
     }
+}
+
+export function moduleEventHandler(codes: {
+    [EVENT_TRANSFER_CODE]?: event.Handler<types.AccountsTransferEvent>;
+    [EVENT_BURN_CODE]?: event.Handler<types.AccountsBurnEvent>;
+    [EVENT_MINT_CODE]?: event.Handler<types.AccountsMintEvent>;
+}) {
+    return [MODULE_NAME, codes] as event.ModuleHandler;
 }

--- a/client-sdk/ts-web/rt/src/event.ts
+++ b/client-sdk/ts-web/rt/src/event.ts
@@ -1,6 +1,6 @@
 import * as oasis from '@oasisprotocol/client';
 
-export function toTag(module: string, code: number) {
+export function toKey(module: string, code: number) {
     const codeBuf = new ArrayBuffer(4);
     const codeDV = new DataView(codeBuf);
     codeDV.setUint32(0, code, false);

--- a/client-sdk/ts-web/rt/src/event.ts
+++ b/client-sdk/ts-web/rt/src/event.ts
@@ -6,3 +6,27 @@ export function toKey(module: string, code: number) {
     codeDV.setUint32(0, code, false);
     return oasis.misc.concat(oasis.misc.fromString(module), new Uint8Array(codeBuf));
 }
+
+export type Handler<V> = (e: oasis.types.RuntimeClientEvent, value: V) => void;
+export type ModuleHandler = [module: string, codes: {[code: number]: Handler<unknown>}];
+
+export class Visitor {
+    handlers: {[keyHex: string]: Handler<unknown>};
+
+    constructor(modules: ModuleHandler[]) {
+        this.handlers = {};
+        for (const [module, codes] of modules) {
+            for (const code in codes) {
+                this.handlers[oasis.misc.toHex(toKey(module, +code))] = codes[code];
+            }
+        }
+    }
+
+    visit(e: oasis.types.RuntimeClientEvent) {
+        const keyHex = oasis.misc.toHex(e.key);
+        if (keyHex in this.handlers) {
+            const value = oasis.misc.fromCBOR(e.value);
+            this.handlers[keyHex](e, value);
+        }
+    }
+}


### PR DESCRIPTION
I saw a loose TODO in the bridge Go example client that we desired wrappers for working with events. Here's one for the typescript.