### PR TITLE
e2e: Add tests for accounts

### DIFF
--- a/tests/e2e/runtime.go
+++ b/tests/e2e/runtime.go
@@ -129,15 +129,15 @@ func (sc *runtimeScenario) Fixture() (*oasis.NetworkFixture, error) {
 				Executor: registry.ExecutorParameters{
 					GroupSize:       2,
 					GroupBackupSize: 1,
-					RoundTimeout:    20,
-					MaxMessages:     128,
+					RoundTimeout:    30,
+					MaxMessages:     256,
 				},
 				TxnScheduler: registry.TxnSchedulerParameters{
 					Algorithm:         registry.TxnSchedulerSimple,
-					MaxBatchSize:      1,
-					MaxBatchSizeBytes: 1024,
+					MaxBatchSize:      10,
+					MaxBatchSizeBytes: 16 * 1024 * 1024, // 16 MB.
 					BatchFlushTimeout: 1 * time.Second,
-					ProposerTimeout:   20,
+					ProposerTimeout:   30,
 				},
 				Storage: registry.StorageParameters{
 					GroupSize:               2,

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// SimpleKVRuntime is the basic network + client test case with runtime support.
-	SimpleKVRuntime scenario.Scenario = NewRuntimeScenario("test-runtime-simple-keyvalue", []RunTestFunction{SimpleKVTest, KVEventTest})
+	SimpleKVRuntime scenario.Scenario = NewRuntimeScenario("test-runtime-simple-keyvalue", []RunTestFunction{SimpleKVTest, KVEventTest, KVBalanceTest, KVTransferTest})
 )
 
 // RegisterScenarios registers all oasis-sdk end-to-end runtime tests.

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -1,5 +1,9 @@
 //! Simple keyvalue runtime.
-use oasis_runtime_sdk::{self as sdk, core::common::version::Version};
+use std::collections::BTreeMap;
+
+use oasis_runtime_sdk::{
+    self as sdk, core::common::version::Version, modules, types::token::Denomination,
+};
 
 pub mod keyvalue;
 
@@ -9,11 +13,43 @@ pub struct Runtime;
 impl sdk::Runtime for Runtime {
     const VERSION: Version = Version::new(0, 1, 0);
 
-    type Modules = keyvalue::Module;
+    type Modules = (keyvalue::Module, modules::accounts::Module);
 
     fn genesis_state() -> <Self::Modules as sdk::module::MigrationHandler>::Genesis {
-        keyvalue::Genesis {
-            parameters: Default::default(),
-        }
+        (
+            keyvalue::Genesis {
+                parameters: Default::default(),
+            },
+            modules::accounts::Genesis {
+                balances: {
+                    let mut b = BTreeMap::new();
+                    // Alice.
+                    b.insert(sdk::testing::keys::alice::address(), {
+                        let mut d = BTreeMap::new();
+                        d.insert(Denomination::NATIVE, 3_000.into());
+                        d
+                    });
+                    // Bob.
+                    b.insert(sdk::testing::keys::bob::address(), {
+                        let mut d = BTreeMap::new();
+                        d.insert(Denomination::NATIVE, 2_000.into());
+                        d
+                    });
+                    // Charlie.
+                    b.insert(sdk::testing::keys::charlie::address(), {
+                        let mut d = BTreeMap::new();
+                        d.insert(Denomination::NATIVE, 1_000.into());
+                        d
+                    });
+                    b
+                },
+                total_supplies: {
+                    let mut ts = BTreeMap::new();
+                    ts.insert(Denomination::NATIVE, 6_000.into());
+                    ts
+                },
+                ..Default::default()
+            },
+        )
     }
 }


### PR DESCRIPTION
Part of #21.  Adds accounts to the simple-keyvalue runtime and two new end-to-end tests for accounts, also correctly handles account nonces in `kvInsert` and `kvRemove`.