### PR TITLE
runtime-sdk: Properly handle error chains

### DIFF
--- a/runtime-sdk-macros/src/lib.rs
+++ b/runtime-sdk-macros/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(proc_macro_diagnostic)]
+#![feature(bool_to_option)]
 #![deny(rust_2018_idioms)]
 
 use proc_macro::TokenStream;
@@ -18,8 +19,8 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
 }
 
 /// Derives the `Error` trait on an enum.
-// The helper attribute is `runtime_error` to avoid conflict with `thiserror::Error`.
-#[proc_macro_derive(Error, attributes(sdk_error))]
+// The helper attribute is `sdk_error` to avoid conflict with `thiserror::Error`.
+#[proc_macro_derive(Error, attributes(sdk_error, source, from))]
 pub fn error_derive(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     error_derive::derive_error(input).into()

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -134,7 +134,7 @@ impl<R: Runtime> Dispatcher<R> {
             Err(err) => {
                 return Ok(CheckTxResult {
                     error: RuntimeError {
-                        module: modules::core::Error::module_name().to_string(),
+                        module: err.module_name().to_string(),
                         code: err.code(),
                         message: err.to_string(),
                     },


### PR DESCRIPTION
SDK errors can now implement the source method which is taken into account when
converting an error into a call result. This makes it possible to nest errors
and make sure that module and code from the most inner error are used.

Seems like it could be useful in #92 and #94 where we started to nest errors.