### PR TITLE
ts-web/core: update to oasis-core v21.1.1

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+New features:
+
+- Compatibility with oasis-core is updated to 21.1.1.
+
 ## v0.1.0-alpha1
 
 Spotlight change:

--- a/client-sdk/ts-web/core/src/common.ts
+++ b/client-sdk/ts-web/core/src/common.ts
@@ -40,10 +40,10 @@ export const TEE_HARDWARE_RESERVED = TEE_HARDWARE_INTEL_SGX + 1;
 export const INVALID_VERSION = 65536;
 
 /**
- * LatestEntityDescriptorVersion is the latest entity descriptor version that should be used for
- * all new descriptors. Using earlier versions may be rejected.
+ * LatestDescriptorVersion is the latest descriptor version that should be
+ * used for all new descriptors. Using earlier versions may be rejected.
  */
-export const LATEST_ENTITY_DESCRIPTOR_VERSION = 2;
+export const ENTITY_LATEST_DESCRIPTOR_VERSION = 2;
 /**
  * LatestNodeDescriptorVersion is the latest node descriptor version that should be used for all
  * new descriptors. Using earlier versions may be rejected.

--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -3006,9 +3006,9 @@ export interface Version {
  * ProtocolVersions are the protocol versions.
  */
 export interface VersionProtocolVersions {
+    consensus_protocol: Version;
     runtime_host_protocol: Version;
     runtime_committee_protocol: Version;
-    consensus_protocol: Version;
 }
 
 /**


### PR DESCRIPTION
all I've seen for API changes is the rename of entity.LatestDescriptorVersion and a rearrangement of ProtocolVersions