### PR TITLE
ts-web/signer-ledger: correct u8FromBuf length

### DIFF
--- a/client-sdk/ts-web/signer-ledger/docs/changelog.md
+++ b/client-sdk/ts-web/signer-ledger/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased changes
+
+Bug fixes:
+
+- Corrected an issue in converting internal Buffers to Uint8Array.
+  This should get rid of the extraneous trailing zeros.
+
 ## v0.1.0-alpha1
 
 Spotlight change:

--- a/client-sdk/ts-web/signer-ledger/src/index.ts
+++ b/client-sdk/ts-web/signer-ledger/src/index.ts
@@ -12,7 +12,7 @@ interface Response {
 }
 
 function u8FromBuf(buf: Buffer) {
-    return new Uint8Array(buf.buffer);
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
 function bufFromU8(u8: Uint8Array) {


### PR DESCRIPTION
@Esya could you check if this fixes the `sign` output?

fixes #106 