### PR TITLE
Go 1.16

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -56,10 +56,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15.x"
+          go-version: "1.16.x"
 
       - name: Unit tests with coverage
         working-directory: client-sdk/go

--- a/client-sdk/go/go.mod
+++ b/client-sdk/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/oasisprotocol/oasis-sdk/client-sdk/go
 
-go 1.15
+go 1.16
 
 // Should be synced with Oasis Core as replace directives are not propagated.
 replace (

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/oasisprotocol/oasis-sdk/tests/e2e
 
-go 1.15
+go 1.16
 
 // Should be synced with Oasis Core as replace directives are not propagated.
 replace (


### PR DESCRIPTION
oasis-core is moving over to go 1.16. Let's see if it works here too.