### PR TITLE
modules/consensus_accounts: add gas costs for transactions

### DIFF
--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -10,9 +10,25 @@ impl sdk::Runtime for Runtime {
     type Modules = (
         modules::accounts::Module,
         modules::consensus_accounts::Module<modules::accounts::Module, modules::consensus::Module>,
+        modules::core::Module,
     );
 
     fn genesis_state() -> <Self::Modules as sdk::module::MigrationHandler>::Genesis {
-        Default::default()
+        (
+            Default::default(),
+            modules::consensus_accounts::Genesis {
+                parameters: modules::consensus_accounts::Parameters {
+                    gas_costs: modules::consensus_accounts::GasCosts {
+                        tx_deposit: 100,
+                        tx_withdraw: 100,
+                    },
+                },
+            },
+            modules::core::Genesis {
+                parameters: modules::core::Parameters {
+                    max_batch_gas: 10_000,
+                },
+            },
+        )
     }
 }

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -19,8 +19,10 @@ impl sdk::Runtime for Runtime {
             modules::consensus_accounts::Genesis {
                 parameters: modules::consensus_accounts::Parameters {
                     gas_costs: modules::consensus_accounts::GasCosts {
-                        tx_deposit: 100,
-                        tx_withdraw: 100,
+                        // These are free, in order to simplify testing. We do test gas accounting
+                        // with other methods elsewhere though.
+                        tx_deposit: 0,
+                        tx_withdraw: 0,
                     },
                 },
             },


### PR DESCRIPTION
add parameters and use_gas calls. set to 100 for sample runtime