### PR TITLE
ts-web/core: ADR 0008 implementation for ts-web

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -317,3 +317,26 @@ jobs:
         env:
           TEST_NODE_BINARY: "${{ github.workspace }}/tests/untracked/oasis-node"
           TEST_RUNTIME_LOADER: "${{ github.workspace}}/tests/untracked/oasis-core-runtime-loader"
+
+  jest-ts-web-core:
+    name: jest-ts-web-core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js LTS
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: "14.x"
+
+      - name: Set up npm
+        run: npm install npm@7 -g
+
+      - name: Install Node deps
+        working-directory: client-sdk/ts-web
+        run: npm ci
+
+      - name: Run tests
+        working-directory: client-sdk/ts-web/core
+        run: npm test

--- a/client-sdk/ts-web/core/jest.config.js
+++ b/client-sdk/ts-web/core/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../jest.config');

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -9,7 +9,8 @@
     "scripts": {
         "prepare": "tsc",
         "check-playground": "cd playground && tsc -p jsconfig.json",
-        "playground": "cd playground && webpack s -c webpack.config.js"
+        "playground": "cd playground && webpack s -c webpack.config.js",
+        "test": "jest"
     },
     "dependencies": {
         "bech32": "^1.1.4",

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "bech32": "^1.1.4",
         "cborg": "^1.1.2",
+        "bip39": "^3.0.4",
         "grpc-web": "^1.2.1",
         "js-sha512": "^0.8.0",
         "tweetnacl": "^1.0.3"

--- a/client-sdk/ts-web/core/playground/webpack.config.js
+++ b/client-sdk/ts-web/core/playground/webpack.config.js
@@ -1,5 +1,14 @@
+const webpack = require('webpack');
+
 module.exports = {
     mode: 'development',
+    resolve: { fallback: { stream: require.resolve('stream-browserify') } },
+    plugins: [
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
+            Buffer: ['buffer', 'Buffer'],
+        }),
+    ],
     output: {
         library: {
             name: 'playground',

--- a/client-sdk/ts-web/core/src/hdkey.ts
+++ b/client-sdk/ts-web/core/src/hdkey.ts
@@ -1,0 +1,100 @@
+import {sha512} from 'js-sha512';
+import {SignKeyPair, sign} from 'tweetnacl';
+import {generateMnemonic, mnemonicToSeed, validateMnemonic} from 'bip39';
+import {concat} from './misc';
+
+const ED25519_CURVE = 'ed25519 seed';
+const HARDENED_OFFSET = 0x80000000;
+const pathRegex = new RegExp("^m(\\/[0-9]+')+$");
+
+/**
+ * HDKey handles hierarchical key generation according to ADR 0008
+ * https://github.com/oasisprotocol/oasis-core/blob/master/docs/adr/0008-standard-account-key-generation.md
+ */
+export class HDKey {
+    public readonly keypair: SignKeyPair;
+
+    /**
+     * Generates the keypair matching the supplied parameters
+     * @param mnemonic BIP-0039 Mnemonic
+     * @param index Account index
+     * @param passphrase Optional BIP-0039 passphrase
+     * @returns SignKeyPair for these parameters
+     */
+    public static async getAccountSigner(
+        mnemonic: string,
+        index: number = 0,
+        passphrase?: string,
+    ): Promise<SignKeyPair> {
+        if (index < 0 || index > 0x7fffffff) {
+            throw new Error('Account number must be >= 0 and <= 2147483647');
+        }
+
+        const seed = await mnemonicToSeed(mnemonic, passphrase);
+        const key = HDKey.makeHDKey(ED25519_CURVE, seed);
+        return key.derivePath(`m/44'/474'/${index}'`).keypair;
+    }
+
+    /**
+     * Generates a mnemonic
+     * @param strength Length in bits of the generated mnemonic
+     * @returns Generated BIP-0039 Mnemonic
+     */
+    public static generateMnemonic(strength = 256): string {
+        return generateMnemonic(strength);
+    }
+
+    private constructor(
+        private readonly privateKey: Uint8Array,
+        private readonly chainCode: Uint8Array,
+    ) {
+        this.keypair = sign.keyPair.fromSeed(privateKey);
+    }
+
+    /**
+     * Returns the HDKey for the given derivation path
+     * using SLIP-0010
+     * @param path Derivation path, starting with m/
+     * @returns Instance of HDKey
+     */
+    private derivePath(path: string): HDKey {
+        if (!pathRegex.test(path)) {
+            throw new Error(
+                "Invalid derivation path. Valid paths must use a format similar to : m/44'/474'/0' and all indexes must be hardened",
+            );
+        }
+
+        const segments = path
+            .split('/')
+            .slice(1)
+            .map((val: string): string => val.replace("'", ''))
+            .map((el) => parseInt(el, 10));
+
+        return segments.reduce((parent, segment) => parent.derive(segment + HARDENED_OFFSET), this);
+    }
+
+    /**
+     * Derive the child key at the specified index
+     * @param index
+     * @returns Instance of HDKey
+     */
+    private derive(index: number): HDKey {
+        const buffer = new ArrayBuffer(4);
+        const view = new DataView(buffer);
+        view.setUint32(0, index);
+
+        const data = concat(new Uint8Array([0]), this.privateKey, new Uint8Array(buffer));
+        return HDKey.makeHDKey(this.chainCode, data);
+    }
+
+    private static makeHDKey(hmacKey: string | Uint8Array, data: Uint8Array): HDKey {
+        //@ts-ignore The types of js-sha512 are outdated
+        const hash = sha512.hmac.arrayBuffer(hmacKey, data);
+
+        const I = new Uint8Array(hash);
+        const IL = I.slice(0, 32);
+        const IR = I.slice(32);
+
+        return new HDKey(IL, IR);
+    }
+}

--- a/client-sdk/ts-web/core/src/index.ts
+++ b/client-sdk/ts-web/core/src/index.ts
@@ -7,6 +7,7 @@ export * as control from './control';
 export * as genesis from './genesis';
 export * as governance from './governance';
 export * as hash from './hash';
+export * as hdkey from './hdkey';
 export * as keymanager from './keymanager';
 export * as misc from './misc';
 export * as quantity from './quantity';

--- a/client-sdk/ts-web/core/test/adr-0008-vectors.json
+++ b/client-sdk/ts-web/core/test/adr-0008-vectors.json
@@ -1,0 +1,742 @@
+[
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    "bip39_passphrase": "",
+    "bip39_seed": "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "fb181e94e95cc6bedd2da03e6c4aca9951053f3e9865945dbc8975a6afd217c3ad55bbb7c192b8ecfeb6ad18bbd7681c0923f472d5b0c212fbde33008005ad61",
+        "public_key": "ad55bbb7c192b8ecfeb6ad18bbd7681c0923f472d5b0c212fbde33008005ad61",
+        "address": "oasis1qqx0wgxjwlw3jwatuwqj6582hdm9rjs4pcnvzz66"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "1792482bcb001f45bc8ab15436e62d60fe3eb8c86e8944bfc12da4dc67a5c89b73fd7c51a0f059ea34d8dca305e0fdb21134ca32216ca1681ae1d12b3d350e16",
+        "public_key": "73fd7c51a0f059ea34d8dca305e0fdb21134ca32216ca1681ae1d12b3d350e16",
+        "address": "oasis1qr4xfjmmfx7zuyvskjw9jl3nxcp6a48e8v5e27ty"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "765be01f40c1b78dd807e03a5099220c851cfe55870ab082be2345d63ffb9aa40f85ea84b81abded443be6ab3e16434cdddebca6e12ea27560a6ed65ff1998e0",
+        "public_key": "0f85ea84b81abded443be6ab3e16434cdddebca6e12ea27560a6ed65ff1998e0",
+        "address": "oasis1qqtdpw7jez243dnvmzfrhvgkm8zpndssvuwm346d"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "759b3c2af3d7129072666677b37e9e7b6d22c8bbf634816627e1704f596f60c411ebdac05bfa37b746692733f15a02be9842b29088272354012417a215666b0e",
+        "public_key": "11ebdac05bfa37b746692733f15a02be9842b29088272354012417a215666b0e",
+        "address": "oasis1qqs7wl20gfppe2krdy3tm4298yt9gftxpc9j27z2"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "db77a8a8508fd77083ba63f31b0a348441d4823e6ba73b65f354a93cf789358d8753c5da6085e6dbf5969773d27b08ee05eddcb3e11d570aaadf0f42036e69b1",
+        "public_key": "8753c5da6085e6dbf5969773d27b08ee05eddcb3e11d570aaadf0f42036e69b1",
+        "address": "oasis1qq8neyfkydj874tvs6ksljlmtxgw3plkkgf69j4w"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "318e1fba7d83ca3ea57b0f45377e77391479ec38bfb2236a2842fe1b7a624e8800e1a8016629f2882bca2174f29033ec2a57747cd9d3c27f49cc6e11e38ee7bc",
+        "public_key": "00e1a8016629f2882bca2174f29033ec2a57747cd9d3c27f49cc6e11e38ee7bc",
+        "address": "oasis1qrdjslqdum7wwehz3uaw6t6xkpth0a9n8clsu6xq"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "63a7f716e1994f7a8ab80f8acfae4c28c21af6b2f3084756b09651f4f4ee38606b85d0a8a9747faac85233ad5e4501b2a6862a4c02a46a0b7ea699cf2bd38f98",
+        "public_key": "6b85d0a8a9747faac85233ad5e4501b2a6862a4c02a46a0b7ea699cf2bd38f98",
+        "address": "oasis1qzlt62g85303qcrlm7s2wx2z8mxkr5v0yg5me0z3"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "34af69924c04d75c79bd120e03d667ff6287ab602f9285bb323667ddf9f25c974f49a7672eeadbf78f910928e3d592d17f1e14964693cfa2afd94b79f0d49f48",
+        "public_key": "4f49a7672eeadbf78f910928e3d592d17f1e14964693cfa2afd94b79f0d49f48",
+        "address": "oasis1qzw2gd3qq8nse6648df32zxvsryvljeyyyl3cxma"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "aa5242e7efe8dee05c21192766a11c46531f500ff7c0cc29ed59523c5e618792c0a24bf07953520f21c1c25882d9dbf00d24d0499be443fdcf07f2da9601d3e5",
+        "public_key": "c0a24bf07953520f21c1c25882d9dbf00d24d0499be443fdcf07f2da9601d3e5",
+        "address": "oasis1qqzjkx9u549r87ctv7x7t0un29vww6k6hckeuvtm"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "b661567dcb9b5290889e110b0e9814e72d347c3a3bad2bafe2969637541451e5da8c9830655103c726ff80a4ac2f05a7e0b948a1986734a4f63b3e658da76c66",
+        "public_key": "da8c9830655103c726ff80a4ac2f05a7e0b948a1986734a4f63b3e658da76c66",
+        "address": "oasis1qpawhwugutd48zu4rzjdcgarcucxydedgq0uljkj"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "cc05cca118f3f26f05a0ff8e2bf5e232eede9978b7736ba10c3265870229efb19e7c2b2d03265ce4ea175e3664a678182548a7fc6db04801513cff7c98c8f151",
+        "public_key": "9e7c2b2d03265ce4ea175e3664a678182548a7fc6db04801513cff7c98c8f151",
+        "address": "oasis1qq7895v02vh40yc2dqfxhldww7wxsky0wgfdenrv"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "equip will roof matter pink blind book anxiety banner elbow sun young",
+    "bip39_passphrase": "",
+    "bip39_seed": "ed2f664e65b5ef0dd907ae15a2788cfc98e41970bc9fcb46f5900f6919862075e721f37212304a56505dab99b001cc8907ef093b7c5016a46b50c01cc3ec1cac",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "4e9ca1a4c2ed90c90da93ea181557ef9f465f444c0b7de35daeb218f9390d98545601f761af17dba50243529e629732f1c58d08ffddaa8491238540475729d85",
+        "public_key": "45601f761af17dba50243529e629732f1c58d08ffddaa8491238540475729d85",
+        "address": "oasis1qqjkrr643qv7yzem6g4m8rrtceh42n46usfscpcf"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "2d0d2e75a13fd9dc423a2db8dfc1db6ebacd53f22c8a7eeb269086ec3b443eb627ed04a3c0dcec6591c001e4ea307d65cbd712cb90d85ab7703c35eee07a77dd",
+        "public_key": "27ed04a3c0dcec6591c001e4ea307d65cbd712cb90d85ab7703c35eee07a77dd",
+        "address": "oasis1qp42qp8d5k8pgekvzz0ld47k8ewvppjtmqg7t5kz"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "351749392b02c6b7a5053bc678e71009b4fb07c37a67b44558064dc63b2efd9219456a3f0cf3f4cc5e6ce52def57d92bb3c5a651fa9626b246cfec07abc28724",
+        "public_key": "19456a3f0cf3f4cc5e6ce52def57d92bb3c5a651fa9626b246cfec07abc28724",
+        "address": "oasis1qqnwwhj4qvtap422ck7qjxf7wm89tgjhwczpu0f3"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "ebc13ccb62142ed5b600f398270801f8f80131b225feb278d42982ce314f896292549046214fdb4729bf7a6ee4a3bbd0f463c476acc933b2c7cce084509abee4",
+        "public_key": "92549046214fdb4729bf7a6ee4a3bbd0f463c476acc933b2c7cce084509abee4",
+        "address": "oasis1qp36crawwyk0gnfyf0epcsngnpuwrz0mtu8qzu2f"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "664b95ad8582831fb787afefd0febdddcf03343cc1ca5aa86057477e0f22c93b331288192d442d3a32e239515b4c019071c57ee89f91942923dd4c1535db096c",
+        "public_key": "331288192d442d3a32e239515b4c019071c57ee89f91942923dd4c1535db096c",
+        "address": "oasis1qz8d2zptvf44y049g9dtyqya4g0jcqxmjsf9pqa3"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "257600bfccc21e0bc772f4d1dcfb2834805e07959ad7bd586e7deec4a320bfcecbbfef21f0833744b3504a9860b42cb0bb11e2eb042a8b83e3ceb91fe0fca096",
+        "public_key": "cbbfef21f0833744b3504a9860b42cb0bb11e2eb042a8b83e3ceb91fe0fca096",
+        "address": "oasis1qz0cxkl3mftumy9l4g663fmwg69vmtc675xh8exw"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "10d224fbbac9d6e3084dff75ed1d3ae2ce52bce3345a48bf68d1552ed7d89594defb924439e0c93f3b14f25b3cb4044f9bc9055fa4a14d89f711528e6760133b",
+        "public_key": "defb924439e0c93f3b14f25b3cb4044f9bc9055fa4a14d89f711528e6760133b",
+        "address": "oasis1qz3pjvqnkyj42d0mllgcjd66fkavzywu4y4uhak7"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "517bcc41be16928d32c462ee2a38981ed15b784028eb0914cfe84acf475be342102ad25ab9e1707c477e39da2184f915669791a3a7b87df8fd433f15c926ede2",
+        "public_key": "102ad25ab9e1707c477e39da2184f915669791a3a7b87df8fd433f15c926ede2",
+        "address": "oasis1qr8zs06qtew5gefgs4608a4dzychwkm0ayz36jqg"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "ee7577c5cef5714ba6738635c6d9851c43428ff3f1e8db2fe7f45fb8d8be7c55a6ec8903ca9062910cc780c9b209c7767c2e57d646bbe06901d090ad81dabe8b",
+        "public_key": "a6ec8903ca9062910cc780c9b209c7767c2e57d646bbe06901d090ad81dabe8b",
+        "address": "oasis1qp7w82tmm6srgxqqzragdt3269334pjtlu44qpeu"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "5257b10a5fcfd008824e2216be17be6e47b9db74018f63bb55de4d747cae6d7bba734348f3ec7af939269f62828416091c0d89e14c813ebf5e64e24d6d37e7ab",
+        "public_key": "ba734348f3ec7af939269f62828416091c0d89e14c813ebf5e64e24d6d37e7ab",
+        "address": "oasis1qp9t7zerat3lh2f7xzc58ahqzta5kj4u3gupgxfk"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "e7152f1b69ad6edfc05dccf67dad5305edb224669025c809d89de7e56b2cabe58c348f412819da57361cdbd7dfbe695a05dba7f24b8e7328ff991ffadab6c4d2",
+        "public_key": "8c348f412819da57361cdbd7dfbe695a05dba7f24b8e7328ff991ffadab6c4d2",
+        "address": "oasis1qzajez400yvnzcv8x8gtcxt4z5mkfchuh5ca05hq"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "network want title crash employ twelve elegant unlock arrow marriage cat april",
+    "bip39_passphrase": "",
+    "bip39_seed": "d84a448cc77865e3a14876b0e666249f64670c2a64cf6df65e6b4fc31a29571d13158298fdab07585b3259399c55f08776e1a3b2d2cd6a442a3e6d1e586273c1",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "fc116a9e9e6303e7be65b90a488de3f432eca50f10d606f39b4f37e034301f93747640555044f5c359911c0eda6d5e8cfbd6fe05bc8d94a25acd28e9f1eeb744",
+        "public_key": "747640555044f5c359911c0eda6d5e8cfbd6fe05bc8d94a25acd28e9f1eeb744",
+        "address": "oasis1qphafzljh9tl4wdv2pvhemhemgswh3fpa5cxllf3"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "1171bf40b5544974d91a4b6f5b861aca4dc74d44c904fbef7d6ab0a734f24f3a9e580cf7c838136abbaf2e5ceac9f79fba36e92de5e0991bd9d585d180c583df",
+        "public_key": "9e580cf7c838136abbaf2e5ceac9f79fba36e92de5e0991bd9d585d180c583df",
+        "address": "oasis1qp2w8vfhvzmnzs6pn0e2r864ykgnp3xteylfngdl"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "95c51653e07e3c7ae523955d2d302066e7cc85e56f5445e72492d5038230c9357bb992cae1e93ab284cc4e51347d9fb5f227cd85c8ceb9205ee26c39cadeedc4",
+        "public_key": "7bb992cae1e93ab284cc4e51347d9fb5f227cd85c8ceb9205ee26c39cadeedc4",
+        "address": "oasis1qr20w95fzjtx8s2vdvkh8k0js7hgnqu2muy4cnmv"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "3c15f00dbf5d8202fa7f3e4b755aa76e154ccca3c5504a89018e4afd9e7b74066382ae1c5d5216a6435e036f252ca5cd32453166ac17a6eaf0b25db930b6f28e",
+        "public_key": "6382ae1c5d5216a6435e036f252ca5cd32453166ac17a6eaf0b25db930b6f28e",
+        "address": "oasis1qp4wmhyp8fgxgdvur5awejx4cyfv8w3dzuqq0nm7"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "833b4545289cb1c26f92c8bca24b2f671ddf6f3f506002027d191add1e4826b62149832e017b6fa42f8013540ac273f1de08e59bc509ef6a39d594a9140fb6eb",
+        "public_key": "2149832e017b6fa42f8013540ac273f1de08e59bc509ef6a39d594a9140fb6eb",
+        "address": "oasis1qreq02gllr4mkt467k4vhvzm4mz5wdfsqcfdc042"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "46b6fd6efeed5038214512c4e95fc85be2b4fc26be01bb81adcf5ef1565cd47907dfa107c4a2e562dd9de86c712afed77328b3ccdb797d08dc8247c98865abb3",
+        "public_key": "07dfa107c4a2e562dd9de86c712afed77328b3ccdb797d08dc8247c98865abb3",
+        "address": "oasis1qzvuy6ml54g88nxehk95ypuntpmtpw9lpy4jaqpf"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "6554b127792b928ff63703fc4e45a62bd9e6d483c9e3f53074e139868b2eec191366cf39e3dec1daef59012c6ea1c8469d30a599e9ecec2788a28f4dc60fadaf",
+        "public_key": "1366cf39e3dec1daef59012c6ea1c8469d30a599e9ecec2788a28f4dc60fadaf",
+        "address": "oasis1qrkkzegn5v787e3jrt6ztazk3w7q7lrz0u6gmtfv"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "90816c340fd7ab824fa543128f5f38a5711098676e94d9980900dbc8c9069b0c1f2cbf91e8c864765441367436464ba554c29d24f4d78f6de1953ce421ec6fe9",
+        "public_key": "1f2cbf91e8c864765441367436464ba554c29d24f4d78f6de1953ce421ec6fe9",
+        "address": "oasis1qqzeuzlfauk79ap79m8yycchdqdyy0t2e58zv2vr"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "e0ea4640595bdf9074a49b9db584e2713dca2004fe9155983735e98eb910c0491eebde15e67432f55d10b0bbf413443157a682eabaf8c34e64740d5a82800b51",
+        "public_key": "1eebde15e67432f55d10b0bbf413443157a682eabaf8c34e64740d5a82800b51",
+        "address": "oasis1qq6zrutdukrq244udf333qs884y2azkzrqj23fk6"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "f748156e767d232eec3554c5162c9aad2d64d1c35f13255b339e6fc8768cc4d24dd0b0ec158151b98f5b893627fb43a8a295207acb0e1ca9e048e0aae00f9381",
+        "public_key": "4dd0b0ec158151b98f5b893627fb43a8a295207acb0e1ca9e048e0aae00f9381",
+        "address": "oasis1qq4xwgh0nmkjyl6ykhaq0clatlu7jynxdch4ase2"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "9917380b4b4308e921103ef2b44cf0707c829cb34b6b9226de0d3b0ef18b9afb9d5a0ecc8f0e4ff7bda6b233b82eafca371427a0af0ab381680f1bba24272b8a",
+        "public_key": "9d5a0ecc8f0e4ff7bda6b233b82eafca371427a0af0ab381680f1bba24272b8a",
+        "address": "oasis1qq45l8l6fv955rgc5qyfttzzk7hp58nn75gne68w"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "grape weapon help home entire invest warfare curious advance immense group vintage",
+    "bip39_passphrase": "",
+    "bip39_seed": "9fa385c4e07d2fea0f70c0662a2d65c7cff6ce882e58c399dd01baa15919755342fac1b98a5b80eec15534fa2157ff1d9b1505acf7b43ffcaeb6899da7ad5fa1",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "5f1ea873d36f96f0a9b457b284ee19265b1741bd8051b673e80adbadce0a270b6c6caa571309e7a18ef2c107d34c1515ecab4430f57260a63359c6de60511377",
+        "public_key": "6c6caa571309e7a18ef2c107d34c1515ecab4430f57260a63359c6de60511377",
+        "address": "oasis1qqhxxqjpqddm8dsvvvphfxn8ke8xvll4asg068hy"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "2c7b2e0189450a456e30742b9865e27ebe94e8cc665ea41f67737a82a330b068ff85ff55f0350d7e842228cba34c3d9d1d7731f3aea9e8a60b3568ae89f2013a",
+        "public_key": "ff85ff55f0350d7e842228cba34c3d9d1d7731f3aea9e8a60b3568ae89f2013a",
+        "address": "oasis1qqpq0sa2rr7udz2ghex0p6kmuq72sjgtkcm8493w"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "223226149d24b98ea93f4ea2df762ec92f3d96af1b618936e2cda515e68cd882894d23b87530256bb959adeac5d6432661d6384e1abef110f7fba23229e5be48",
+        "public_key": "894d23b87530256bb959adeac5d6432661d6384e1abef110f7fba23229e5be48",
+        "address": "oasis1qqugy82hf3yu7nq0xfhzftgv7cvns0fm3y2p0265"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "e75d201a44d7394a831cd9140f936aa35c5e50282cafb13966afe5df4ff2cbf3295c94d05dfd817c54d0106a0f31b46b8c8111a97015753bf5ca59562de0f100",
+        "public_key": "295c94d05dfd817c54d0106a0f31b46b8c8111a97015753bf5ca59562de0f100",
+        "address": "oasis1qz92x53ph0k6r6uygz2kkj0m5kah5t0dpqhap948"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "f4e17cd4b20106fb193f2deb39ba07ebe2eee16e05dae5c248f46dbe832e770aa9fcc4ecb3b78898d1ee626e113c39f5ce88c73be3ee756659faaa70df24426c",
+        "public_key": "a9fcc4ecb3b78898d1ee626e113c39f5ce88c73be3ee756659faaa70df24426c",
+        "address": "oasis1qqxkayw89zjtzw9ed4zal7sh2vz7a7s90qch2exq"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "429b2c5ebeba0117b297f2882ae7b9daae00a296c79b57a58685f4e3f141dd05dfd9b56345548f468583f64a36cbc58a2430d6acb31339d644ddcae6401d4f2d",
+        "public_key": "dfd9b56345548f468583f64a36cbc58a2430d6acb31339d644ddcae6401d4f2d",
+        "address": "oasis1qznn2tu9wu0wccqnzkflq9n7ztjvt824pqp06ez3"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "fc8aad885061d544ad607833d51b1c4608222fac33d96bdf36c5fd9e0760b59ec7d4b0b3d668276e28f332d16f966e0fae2361df9986d1f30c8b3124c99e3879",
+        "public_key": "c7d4b0b3d668276e28f332d16f966e0fae2361df9986d1f30c8b3124c99e3879",
+        "address": "oasis1qqhrwek9tny2qvwpsuzlzen6kjyz84y3dc83wx8u"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "1d7f909480e21da10ebb47498d830bd5fd607477523b414f91c1215a995f58f63a6ae20701df22958f31ada407f51cc1945efa72ff5df136b7fb4f7ab1e5daa9",
+        "public_key": "3a6ae20701df22958f31ada407f51cc1945efa72ff5df136b7fb4f7ab1e5daa9",
+        "address": "oasis1qq3ju3ec5dxr3gruqxxgjlhmq9dfuc2d0qqxtlep"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "993bd6878dda2e5819f21da4d41f3947d85c433cb56bc7fd9f600cafb95f7768d4b1210de4f90be8243c596899b00b6a9328db6666a1226d109cda75d1157ff5",
+        "public_key": "d4b1210de4f90be8243c596899b00b6a9328db6666a1226d109cda75d1157ff5",
+        "address": "oasis1qzzm0vp8lqz97kmhdmnnjk7fp239pl767sgee55h"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "46db044ad7c03797cc93b5622bd2972d65757bfb2188de30ef009ba90f417e1d266d91587092d4a854506e3a953960ac7bd54dcddee29660b8c98285be1134e6",
+        "public_key": "266d91587092d4a854506e3a953960ac7bd54dcddee29660b8c98285be1134e6",
+        "address": "oasis1qzul482hhjjrunfru9rd83jcf6c502chm5fdgzl5"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "63942d2cc7ca3d336eb628fc57c8e0b19ea97add015d192202f04ad8d2e1923baaa15c47659890f4273c1f0cab277684e187f91e813500cdd2513884f7298ebc",
+        "public_key": "aaa15c47659890f4273c1f0cab277684e187f91e813500cdd2513884f7298ebc",
+        "address": "oasis1qqw4r4t7p3uhgqm7zmjzc4vh97psapjjhy4uv4qu"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "vibrant length learn peanut garlic boil battle jeans fan cliff alone round setup dove shoe twist dumb trophy imitate coil team grocery when else",
+    "bip39_passphrase": "",
+    "bip39_seed": "47dc8df73b857cadcc2efa0de102d766c5fa013e2ad7744a4525bf9af89653be9e519c2e0852275ec71e4b044bc553a22c3c6e231042a817d02e5723a4c18b88",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "ad5be6620162d9d0a58aa81975e157ca3b2e0c50f9834443d8fcbf4b7573d88e6f9a0bf931842fe6c339d318e82df42deee9edb39d94921756ab5c8f57fba4bc",
+        "public_key": "6f9a0bf931842fe6c339d318e82df42deee9edb39d94921756ab5c8f57fba4bc",
+        "address": "oasis1qrwn7cmvaaas7ec27z4ct224cjk9jv5elyqfde8f"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "f4dcf12e4d6d7df464f61fa2287b0d668fc796e835cf79489dafbb77b169a58e42adefc5a845f0dcef757745e559f9b2b3de1a1279dbf7fed4863d2dfaf59b13",
+        "public_key": "42adefc5a845f0dcef757745e559f9b2b3de1a1279dbf7fed4863d2dfaf59b13",
+        "address": "oasis1qz8kf5qxf7u6l6f7m4f58ry0mavy82lr6u7afk57"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "8b0f6f58e270f7f3701a6f1473da085769aeaa8aaa56a71d8cce9403444ba79f05626acb408621d1472050e3fd78f50a8c3debd796f8b52e2e5c83c638ab4d79",
+        "public_key": "05626acb408621d1472050e3fd78f50a8c3debd796f8b52e2e5c83c638ab4d79",
+        "address": "oasis1qqvppaaazuwse5whrr2dsyx9r2sc3l6skvpw5gw7"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "a319741f725a3c3b8703e435ce1ff5b7d78c80a4d9447451aed536f4e738dc3c5a0380a1ba27cc17f05902aa44856ba3bfe1eb4540056ae9bb27b4941fdbca85",
+        "public_key": "5a0380a1ba27cc17f05902aa44856ba3bfe1eb4540056ae9bb27b4941fdbca85",
+        "address": "oasis1qpkspvtxl7hxqnvy0u3pqfz7gy6ujxnlvynvcp27"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "3d28efb14daf6f0847bc577b643d34012cbac022a0ddf54a0176e9f8a8f1b0900c6e6855499150a0c52adae2cf3d40806da6336bd6df6bb56508ec1b9460d311",
+        "public_key": "0c6e6855499150a0c52adae2cf3d40806da6336bd6df6bb56508ec1b9460d311",
+        "address": "oasis1qq273y2z62s0rp8vlwd40l6rchj6fl3rm5dtrfvk"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "28b40c6618c3b72122cddaf8659d5bd028f6fb2afa6b2ebe20d8ad26b4ae0550900cb701c0dd05b3f9d59954a11ec09fd385f49a38c4018f54c9e2ff50d38061",
+        "public_key": "900cb701c0dd05b3f9d59954a11ec09fd385f49a38c4018f54c9e2ff50d38061",
+        "address": "oasis1qzt6jpg753sgydja3zq7zsxg87jrxwvt456qryez"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "5d211e738d42f439e54f09421881b65ee17ecb8138ba7db7861a24c7b1241a5814a30af69180455f4f77e67552ffbc79f8bc5a035db8a97583018a32598592d9",
+        "public_key": "14a30af69180455f4f77e67552ffbc79f8bc5a035db8a97583018a32598592d9",
+        "address": "oasis1qp5rm47tcvfrnkx27pc6zrr7wcygj3em6gfemkhy"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "e769ca8b37a1a070c71c135984aadcbf65c368f3a8f60d282b84395accf4f12ca390201aba663a0676128e134d5a1ea61600f3b184a56611c5522d31e12c08b9",
+        "public_key": "a390201aba663a0676128e134d5a1ea61600f3b184a56611c5522d31e12c08b9",
+        "address": "oasis1qzlcnlnyd6pm5pq2yvad62k4shl6nye93cuvcpe0"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "a057fc427589f4ddb011a3953e9c08b3c975cc64de3d41b3bf97ce926cd500e107710b7076ee19b6140eb624d79be4baf365f660a1434e0fb17133c3c0ebc852",
+        "public_key": "07710b7076ee19b6140eb624d79be4baf365f660a1434e0fb17133c3c0ebc852",
+        "address": "oasis1qz0x3t8skpvul52e8dlulz3jl2f5w6ggzgxmya8r"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "6a6d4b67d1cf7507a72885a2ebd801a381471aa3e900e34e4a14ebbe74182520713d660d92754e8b7c932305b4aa1a9f20728fd89d4ec34d7966adb0826ae3e5",
+        "public_key": "713d660d92754e8b7c932305b4aa1a9f20728fd89d4ec34d7966adb0826ae3e5",
+        "address": "oasis1qpcungdthc904dx8fg94ggscttel7e2yqy6cxfjn"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "7badd6bc80ccfc22c123c9418d7631fa10b939c0d2e5af79ca21e587886b4b3793b79f23cd00d0a6c5129ab95dabd58a849f6bd1812a1a86af07b69d05d679fd",
+        "public_key": "93b79f23cd00d0a6c5129ab95dabd58a849f6bd1812a1a86af07b69d05d679fd",
+        "address": "oasis1qzaajs5umyrmptse6zshwvz9j2swxyn38ufzq4l8"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    "bip39_passphrase": "p4ssphr4se",
+    "bip39_seed": "98fb88ef0a487468167862c275aac69510b85db5533c5608a148f2c3aa66538346d0163ea24958f8cff21a6bc2825d02197b194098baf1e98732f951aa806551",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "33e9e52acab2f32e6971ad8ff277078c47f7a99182b169f77cbb0525800f1b020d4198772fe327f28f7129505cbaecbaf5b0c6f79e4554021752bb5323c790e4",
+        "public_key": "0d4198772fe327f28f7129505cbaecbaf5b0c6f79e4554021752bb5323c790e4",
+        "address": "oasis1qpdrvurdjllyws9z2e8egv6mrnt5x73frqycrdun"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "8ee48ecbf865b6737780cdff07f5ace4127416ee2f4e0eb886d5a04bb1e3e526ea57d861cbe429f1edbeda50f37ed8c9fc259711db118ba3b0af1a5f3562826a",
+        "public_key": "ea57d861cbe429f1edbeda50f37ed8c9fc259711db118ba3b0af1a5f3562826a",
+        "address": "oasis1qpvafxvdpmumz7t5zyln0823pst37pvwusl905vw"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "7d03bdc79c5e185f215308537634d19366b8332431ea251f3b8ecc5b81ff4af7185f31500097573f64b53382ccc7c265cac74ac70495d3c841c1998d3d8a5409",
+        "public_key": "185f31500097573f64b53382ccc7c265cac74ac70495d3c841c1998d3d8a5409",
+        "address": "oasis1qrzrj82qyk8k8uwf425m8nagwvm68a2exg7na0pg"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "f3433de07df3c4876fe260fe47ce0d1dfa15b453995813625d8d5d2110fc08a45689f1c19845546973b90acd5d53bfeab8654ca8be3e48f97a1003514d93a613",
+        "public_key": "5689f1c19845546973b90acd5d53bfeab8654ca8be3e48f97a1003514d93a613",
+        "address": "oasis1qq9qltg8w54djfg66w7dxt0m0tt5p9num5p0tkwv"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "d21f86c343be1713bc4e3281fe6edfa6d0b0387f4f58c21a2f964af8cf9bdc2f4472afd87d26e8bd0bcc0008e04a038d71969c28ae85cc3cbf817cd8c27a492b",
+        "public_key": "4472afd87d26e8bd0bcc0008e04a038d71969c28ae85cc3cbf817cd8c27a492b",
+        "address": "oasis1qqe9vdfqhgkm3zc89sxzwm0a93987c02agyezm75"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "a2263b74780e0f5928d9a21324c2bf5e631ec10baf7c40493380f7709eed576b5ca8b4d4fc20652ea8e1fd43b058483ae1a7c50af5b6f7ff691a91c79f5a5cbd",
+        "public_key": "5ca8b4d4fc20652ea8e1fd43b058483ae1a7c50af5b6f7ff691a91c79f5a5cbd",
+        "address": "oasis1qrr7p3nsf8tzkc9a87j72eu4f248hunajgc4j2sq"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "94c8d1a921254fba2ea05995cf9a7ee10145716c3141ec76913934ddb94a8dda75dba2952be05ee0eb0e36bff8c23a6fc812c4d02118cf0a4e47b070893d04cc",
+        "public_key": "75dba2952be05ee0eb0e36bff8c23a6fc812c4d02118cf0a4e47b070893d04cc",
+        "address": "oasis1qzma3fahfflauhjq8pfcdu7ssynrfjukvc4yve09"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "371dfa25ab1eb6b3938c4025a234b65bedb29e811714c4e99cc830eaa4fc9236aa83e4c4dca1e7e33727c04c61f60813ab3cc4230af58cceebe0ee5451d8622d",
+        "public_key": "aa83e4c4dca1e7e33727c04c61f60813ab3cc4230af58cceebe0ee5451d8622d",
+        "address": "oasis1qrqav32hesxtgn8zmckxjpq5v7jcywykpvzsungg"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "338b56fca1685883d4e4a0a2ab93552b5e6b03c7e0f5e60844cb51a356b8e31d89f26bb3fae2c7e070ae52e8b71291032c847b5676511d1ccfe6ca047790e33e",
+        "public_key": "89f26bb3fae2c7e070ae52e8b71291032c847b5676511d1ccfe6ca047790e33e",
+        "address": "oasis1qp704da5zeqg8ejcg3z6wtxyem5hxsmjeutcm6e4"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "8faed83ef82383d2c90e0e2ff249abd8bdc9ffb89e836bb948753297732a9c1754623bfd107f522ba45ccedc276e531e2c64eb462d0316de11afbe2338f501be",
+        "public_key": "54623bfd107f522ba45ccedc276e531e2c64eb462d0316de11afbe2338f501be",
+        "address": "oasis1qrs6c4260fa79wmwh8dnjxz6cgvd896spczm7wuu"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "3a190f574625abb7334f954c3358520bf53693aa64b4bb19b44060b7520f18a2b9864e9c2e719913c13d735207a3759d2d8bfc7ea6f20270c13f6d0cdaadc32c",
+        "public_key": "b9864e9c2e719913c13d735207a3759d2d8bfc7ea6f20270c13f6d0cdaadc32c",
+        "address": "oasis1qpjfeqnyr8ha8c6qhqztgwwkumwzkwe6m5j0mwsu"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "equip will roof matter pink blind book anxiety banner elbow sun young",
+    "bip39_passphrase": "p4ssphr4se",
+    "bip39_seed": "3f5dec0c6b0f03f7c641f23cc4d823e8650c2bf6c52e8120f37431f140ce45b894fb1d13a8cd9c2de23f8b4caacb7bfedc32611ddad20ff0de2174aefd2f3515",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "7a1a5c773fe62cf238ccec1c43fa557f764967d9f7430390ea666d1cd298d777814e5cc6e7f3d159455db1b9770abc155350c458fa7c5db2fd252b286efff37d",
+        "public_key": "814e5cc6e7f3d159455db1b9770abc155350c458fa7c5db2fd252b286efff37d",
+        "address": "oasis1qpaxntmll2fzekwsz4gh89qnxz8ppwqlxgdf4jsd"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "d8db2839892b05f250f3755b1b87075f9b0b39c6c9050507eab4f7d63949f217b099f8906467325aa1283590c1bca01e8708d5419557aa7771b826fa02d2abe6",
+        "public_key": "b099f8906467325aa1283590c1bca01e8708d5419557aa7771b826fa02d2abe6",
+        "address": "oasis1qzw5ghwfcxdvck0n5ut9hhj2m3gkxs2jf5t65qps"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "b2460066056886e24b144cdff5c317e1f342c854d2a25c10ea7c84d44a657725d524b5590553ec6bd3a438cec6994cc1c4e8964945b630d0636c35a775c00056",
+        "public_key": "d524b5590553ec6bd3a438cec6994cc1c4e8964945b630d0636c35a775c00056",
+        "address": "oasis1qqh8tfyec95p0p2646sus9hveak392xr2sy4qwam"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "9adac67c640163a71ba14ae6780bc8939295f8b8e7ef832b138b3412f326458b2cf62fe409c13f93981da3777f2683a7f940850475fd6f76c272940889b427e5",
+        "public_key": "2cf62fe409c13f93981da3777f2683a7f940850475fd6f76c272940889b427e5",
+        "address": "oasis1qrun5pn37mkyszpxgn38tay3kv6yjrhvf59gr70k"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "757bfd2bd5559c77845a7afa55dc41f6231e66e069f5aa80045f9069874e68caf7ffb29bfeb36105188826f54d8e85e42f901060330cae85359b9a94aab63e65",
+        "public_key": "f7ffb29bfeb36105188826f54d8e85e42f901060330cae85359b9a94aab63e65",
+        "address": "oasis1qzt6jrazcla48wu8majzus9r9vqn4x6wssj5ss7y"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "ebab27fcd199f6dd36beb21062c516e11b92f03d1196d2f7375fb4a78bafe954298d9c057bea72244343d732bfac36eb5c0dfbc0e03a6b69b8ef1a63e5e5f12a",
+        "public_key": "298d9c057bea72244343d732bfac36eb5c0dfbc0e03a6b69b8ef1a63e5e5f12a",
+        "address": "oasis1qz7kxejj2fm47ghfgtmxvgkk4kvevfhekgu9gr5m"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "3909787a7af3c4c3cd47ec0156f0a48ff579b91b777b9ed0582197523acbf358a8fa27ad5abc2c283666290e25a61c23a3087735891d4a63509e1f7b37d89ea5",
+        "public_key": "a8fa27ad5abc2c283666290e25a61c23a3087735891d4a63509e1f7b37d89ea5",
+        "address": "oasis1qp4capggmtj9td2yetw3swv6fmffkw4ttgcywe5m"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "3aeb30714b70ca44a51158d5b1faed83f2dec888f09cd757c486413305c1ac6c8556caacdcef2eb63fbd080a1e1dc48948f53660903ba16f875dd672742d95a7",
+        "public_key": "8556caacdcef2eb63fbd080a1e1dc48948f53660903ba16f875dd672742d95a7",
+        "address": "oasis1qrmrarvftcxvd9t470rfkcnlnx0kqpvxlyp690t9"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "0cd7066a0d1b9ad1d974c82e0de38c03c48c626f93e21cbab3ef3a4d18b6086d648707cb8d889c0752c2304994acbb63508d058fe18ffe767538dccbe8a1fc3f",
+        "public_key": "648707cb8d889c0752c2304994acbb63508d058fe18ffe767538dccbe8a1fc3f",
+        "address": "oasis1qrc65yakdwgr7puvhstd4j47s30kxzq8mcggw42d"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "9688d0ce8a59b3b735ceb6a2f2ccdbab865ebd689451eee22b245098557f80d9b4916a6a1bda175a5188e86e768dd0e408dc7ccb58c59d7cdf7511c6f9294f8f",
+        "public_key": "b4916a6a1bda175a5188e86e768dd0e408dc7ccb58c59d7cdf7511c6f9294f8f",
+        "address": "oasis1qpl3whvts4dp5ecax8url6eadr38gfuj9s6frzc5"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "58e806502803aa1657cc88b791f16ad135abeba24b0c660eedbbc617ee46c8ea902aa446e1b2275c7c18d1d488fa711c92dec505e40bf3f35ac53ace6c25236c",
+        "public_key": "902aa446e1b2275c7c18d1d488fa711c92dec505e40bf3f35ac53ace6c25236c",
+        "address": "oasis1qrghpg7aqvwuz7ma7yh8fhwpltzx5mqjn5a8f34r"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "network want title crash employ twelve elegant unlock arrow marriage cat april",
+    "bip39_passphrase": "p4ssphr4se",
+    "bip39_seed": "6f07969fbaf653220ffd297a03ee9900ddc7ddfc98cd5c6392f7e1dcddb916e01f01aa243a74a7114901e0b781144f15ff54368ea986cc7da6852168572bf6b7",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "befac6f20823b2bbc0bfdebb044b6b6839ff8c45247091595a005edd88d5d6c13500024147b5956e2d46d4e3c480939eabc63dcf558bd6b94f914a377c5c1026",
+        "public_key": "3500024147b5956e2d46d4e3c480939eabc63dcf558bd6b94f914a377c5c1026",
+        "address": "oasis1qp05zg35p8mscryfxle5fque8kpq4lm5nqx4y73e"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "d3222f84c7d15c882240c4c8b59a058893763e1c060f46017b7a4d38480c6c0e32a2c87b686ad47bb2bab628a76ea42e79ed9594f89333dbcdacc9f374249ba5",
+        "public_key": "32a2c87b686ad47bb2bab628a76ea42e79ed9594f89333dbcdacc9f374249ba5",
+        "address": "oasis1qzvsvgrl75x6qlw0xgwgp65rxdzg6s4h2ycau758"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "1b14aa93821f1c7568f8ad73bcc6f089f6d4b35ef8f656427b4b2002755d83be11bc7d6595a0e03bcbe10b446633de85865f8c664e94c9269cfccf438ad82866",
+        "public_key": "11bc7d6595a0e03bcbe10b446633de85865f8c664e94c9269cfccf438ad82866",
+        "address": "oasis1qqa83va8q0fmgtczam5xfnl7tmzv0eplasw37wmg"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "591e5e7795c128cad060ed0f2a76bd492a0d900ac383f19c7a4bb8e82c8f3c4d2f3976127c2bd1e4431a534170558023d45895dad7242aab542afd9386206dc0",
+        "public_key": "2f3976127c2bd1e4431a534170558023d45895dad7242aab542afd9386206dc0",
+        "address": "oasis1qpw4f5fk7rx5ruj22nlqgll79kfxjuwp2qw3cf9y"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "4d6a14498429c7ac7b7a39cd018012ddfd3a93cd8d99dbfb118ee657d668b02dbf6f90750c384cb77bf4b8c3e19ff76f21ff91720192512f5d8ef37186366533",
+        "public_key": "bf6f90750c384cb77bf4b8c3e19ff76f21ff91720192512f5d8ef37186366533",
+        "address": "oasis1qzcwthn07aw4rrm0p6h03e50j6js5qarev5xk47v"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "0ad8e2e3b8d92359f8b02b3325234ee7495272bda149e63c077a718650deaa457dcc3038acbbcb5474722283f8f6ef8f4946014faf0d5f2410b76dd9e34d11f1",
+        "public_key": "7dcc3038acbbcb5474722283f8f6ef8f4946014faf0d5f2410b76dd9e34d11f1",
+        "address": "oasis1qq4zxkzt9u58zca4rpgtptyadpk0t8vnwup0xa38"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "a782323c48fab3c87bbbe6f547deef00ca68f0f5ba4e63bfa132b726149efc96f8ebc0b4378a9377b6240a869f6c8aec3a33e162c2cb0d458d663d4f4bb2f9ea",
+        "public_key": "f8ebc0b4378a9377b6240a869f6c8aec3a33e162c2cb0d458d663d4f4bb2f9ea",
+        "address": "oasis1qqhkn6uffvngzv5fss8kpdwmwgf2r9h4eqec2767"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "fae3a53f37f82944f0c094f64f1feebb862a0f928e7a4cdbcc36241f6f8e54890d6ebd41a1bcf40e9c42836c86aa0ff47cbb161d8aa8a808acac1ea6d20e1bae",
+        "public_key": "0d6ebd41a1bcf40e9c42836c86aa0ff47cbb161d8aa8a808acac1ea6d20e1bae",
+        "address": "oasis1qply2ag6mcyqfxdmfc2scsdugdrcwfx2aulvpnhq"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "e6ebda0af54610038df09c1d754e6292c16d93af7041d3e2300a3f9f234c70626f66e6db4192834d27c5eeaeb390d6ab458d4b4f20cb31bcb925b94b70abc8f4",
+        "public_key": "6f66e6db4192834d27c5eeaeb390d6ab458d4b4f20cb31bcb925b94b70abc8f4",
+        "address": "oasis1qz566ee6c4atzjk66v8sauzafpwkenwmgs4j458x"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "b062600a49878b0041917cc854145646341d248006d2655e5e45641ce3f01f7a61e8e49b26e2729626262c85001026d8f7db4039506cd81bce0593c174dc80fe",
+        "public_key": "61e8e49b26e2729626262c85001026d8f7db4039506cd81bce0593c174dc80fe",
+        "address": "oasis1qqy4s5xk9zna52k60efl2d0aw579qe3cdcm302xl"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "c59f967704d9fd963f95ab00701750b7030a1948f7778c66d7aa2c8d2ca4a30eb6adab6beb3e6619f6c41a8c3dec2ffc7e393a8c0bfa325e06813d6af4295a82",
+        "public_key": "b6adab6beb3e6619f6c41a8c3dec2ffc7e393a8c0bfa325e06813d6af4295a82",
+        "address": "oasis1qrrukvvgmnvwel5g7q83tagp8ahxyqdaq57p0w7k"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "grape weapon help home entire invest warfare curious advance immense group vintage",
+    "bip39_passphrase": "p4ssphr4se",
+    "bip39_seed": "eb1d21e320f19b8473dc7a71fa23a27394ec55d1fe681b3295db19eba22ef7d84a45903f01454ffb7d4278ab0fda125e91281489a85f74ab3826be9d9cdfffe1",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "5d7232d82024bd42c3a28ea0487fd597c3bae99acacd3cc0c5fc1629b36122b96d7b35aec0678ee46f322d47a5d0fce4405259ddd6e6274ee8c597a2d3f39b9b",
+        "public_key": "6d7b35aec0678ee46f322d47a5d0fce4405259ddd6e6274ee8c597a2d3f39b9b",
+        "address": "oasis1qzkpu4jm7hpa57wua4cfasunp0cvms70wq5tyd8l"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "8139d180dbb525d92805532d29f84f47f062482353954a1d28f61d9d7104de6185e40ac64717bef77d808d7e5c082c37baa4a5199cffe825fb74ed6198dd2079",
+        "public_key": "85e40ac64717bef77d808d7e5c082c37baa4a5199cffe825fb74ed6198dd2079",
+        "address": "oasis1qrj6rr20f9hpvjz4qcazh7muzajk498j9uzfd4t0"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "91d9517ef0538850623b89bbace9c0d34420dba721fe696b675c68302a29bcb69fa4019c7448ba75ee35270906b7379d4add3ec1c9a6799fec3ee92678770ea5",
+        "public_key": "9fa4019c7448ba75ee35270906b7379d4add3ec1c9a6799fec3ee92678770ea5",
+        "address": "oasis1qqeypk7spvexvm44a6dhhfy5mv9mhu3nlum9ycyu"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "d3eca09dd122c14e2900f2fd8930ff527ffbb47ff0c1222d333440fd172d43598de49ff0449fe817a67a3dca6130959e359dfaaaa3e9d9c48e64fe853afdd95b",
+        "public_key": "8de49ff0449fe817a67a3dca6130959e359dfaaaa3e9d9c48e64fe853afdd95b",
+        "address": "oasis1qqq3ta9aa4r5vghql52kj7qcjhl3zjg3fggj937f"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "a84c9d5fc5aaa4eb260a5a420271cd2adbac207af79596e588590fc6a32b26129207b4db721d187f29c3b5a9daa9add0029c3fe6b2908ab8bf7b110c9659a2fd",
+        "public_key": "9207b4db721d187f29c3b5a9daa9add0029c3fe6b2908ab8bf7b110c9659a2fd",
+        "address": "oasis1qpj8kamuqfq26cmsgyh6r935dgsr4llfyugt0p64"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "1d05f0c9773f689351baf89c086731395445462e246cfe24f3a8d4658540ebf1d924e8de6dc493678d890ae2a639e8cd94d25e2468a2d3fed1977b8be60f76eb",
+        "public_key": "d924e8de6dc493678d890ae2a639e8cd94d25e2468a2d3fed1977b8be60f76eb",
+        "address": "oasis1qrs6ux0lrwf6nx07jnk0e9la46h880lq05wlrh2v"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "d0e78bfba4d1026c0eff7fef9d0866094192766f06feae6df987ff02b75b9fcf7073136237c3000af11a3839e74bb45262b5333ac2cf3e591d2b117f5f863c1c",
+        "public_key": "7073136237c3000af11a3839e74bb45262b5333ac2cf3e591d2b117f5f863c1c",
+        "address": "oasis1qrw48zddrx4sdesgy24kt7vqk22t68gst5tjt705"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "19106c6da73c6ddc80b6cede3bacc582852cb676d36a68f370a1189b34a9333225d9d6e38724bb8e1a83e62dd9752d787dbe70529918460e64cddaeb69f208d8",
+        "public_key": "25d9d6e38724bb8e1a83e62dd9752d787dbe70529918460e64cddaeb69f208d8",
+        "address": "oasis1qz4634spf9amrelj7zhukxrd3hr3e3kzl50xpvpd"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "180f67f05914cce651ef756329ef15f7edfa2ba0d3c7a527d343b9f70c916029b733ea965040c38b5cab60da88c0fe20b8a2b84153adb2f0c69f70d3d35885ec",
+        "public_key": "b733ea965040c38b5cab60da88c0fe20b8a2b84153adb2f0c69f70d3d35885ec",
+        "address": "oasis1qqkt9632p78jklyf4r4p56xmdagyxslpnscuwuae"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "73dcb75039c22ff85f697f0d6652c97ecd1e847f350a9d1badaa2a43e9b8cd8dd44289b64c33b695b0d9d0c7d5a16303a7b52df413fbf804c628cf12e354ad99",
+        "public_key": "d44289b64c33b695b0d9d0c7d5a16303a7b52df413fbf804c628cf12e354ad99",
+        "address": "oasis1qq353hejhncaheylwhs42q84al27fx62qud8eqk4"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "e2bf7ae816d18cb35cdbf9bf721aae023b083312c5263dfac420f9cda6e1c1004e3e09e76b2d85228dd885ca5911e225020c4c6bec76ae45f3e9de35ddc181a3",
+        "public_key": "4e3e09e76b2d85228dd885ca5911e225020c4c6bec76ae45f3e9de35ddc181a3",
+        "address": "oasis1qpldleeqf94303w3eu7u3e4lxvxw0pqewcan3zly"
+      }
+    ]
+  },
+  {
+    "kind": "standard account key generation",
+    "bip39_mnemonic": "vibrant length learn peanut garlic boil battle jeans fan cliff alone round setup dove shoe twist dumb trophy imitate coil team grocery when else",
+    "bip39_passphrase": "p4ssphr4se",
+    "bip39_seed": "1bf6034e60e1c7cfd7f96fa911eac95a2dcbffc024eaca96d9b1f3939d8fa7970b8f83f921eb91f8e43730bf46c112c60b10f9e09b0e5da9974461bef1d6d8f3",
+    "oasis_accounts": [
+      {
+        "bip32_path": "m/44'/474'/0'",
+        "private_key": "0e6a362ce4078f319300fb9cf44def3b2f5d82e27c975c8207080195322e531f224108d4087b9ccedf025b14cf03c1de44c384fb7a2a530bccd016c3fcafef61",
+        "public_key": "224108d4087b9ccedf025b14cf03c1de44c384fb7a2a530bccd016c3fcafef61",
+        "address": "oasis1qrd66kaw85yzlm24a9nr9l8runuesnnh4svk2lj7"
+      },
+      {
+        "bip32_path": "m/44'/474'/1'",
+        "private_key": "a2f5868cc24252938f2aa7d4ebc77e72324712918a0d3284c2111226140fc119f6e7c0b074f4be215184c9cbbb3db4196e8e6d63ba4570dadf3ce82582ff253b",
+        "public_key": "f6e7c0b074f4be215184c9cbbb3db4196e8e6d63ba4570dadf3ce82582ff253b",
+        "address": "oasis1qqpx5tld8prlhn7hphhpdkkrw97p4n76pcn2mj0l"
+      },
+      {
+        "bip32_path": "m/44'/474'/2'",
+        "private_key": "0d151eb2c157a4a4e087e77aa2b8aa9000e0650ccd27467a29b24c9aa5dbd301dfc72e454a718b0b548c135b90766b97c1eb6ac97c739252675ce2657ef630e0",
+        "public_key": "dfc72e454a718b0b548c135b90766b97c1eb6ac97c739252675ce2657ef630e0",
+        "address": "oasis1qq7fns29kv6udrf9p65qdapqe39r34r2cqaypfac"
+      },
+      {
+        "bip32_path": "m/44'/474'/3'",
+        "private_key": "865c18d8d2ecdb6a82637b5f32811dab3435b01d5ef95a82ec8bfaf85b6bc189f6c19987c6e229b51ad9fff7ac9d572bc08c847784620c727ad31580b82db8ae",
+        "public_key": "f6c19987c6e229b51ad9fff7ac9d572bc08c847784620c727ad31580b82db8ae",
+        "address": "oasis1qz5cq3gy4qp2vf4ldqcu6x94wwn0659zwq6g6trm"
+      },
+      {
+        "bip32_path": "m/44'/474'/4'",
+        "private_key": "9d39dd5929d32cb7c0b042beccbf794d48cfbd0141d309f509a0d50de52b45ec16d9a71e94398e2de8ef5f53eac57938d296b8b69f579caf595566efd57da8b0",
+        "public_key": "16d9a71e94398e2de8ef5f53eac57938d296b8b69f579caf595566efd57da8b0",
+        "address": "oasis1qq24lvxms0sqkjjel3zezmj5wv9h8ugkkv0ejnqv"
+      },
+      {
+        "bip32_path": "m/44'/474'/5'",
+        "private_key": "b50cc2c5f6250812113eacc59b9ddd9c18b0e5fabcea3f1d58a89aafe79510c1fbd1ac47457e32eb91559e1c05757f1a41f4438ec0dfcec6fd86a2b64cf26d55",
+        "public_key": "fbd1ac47457e32eb91559e1c05757f1a41f4438ec0dfcec6fd86a2b64cf26d55",
+        "address": "oasis1qpj8syp3wmhgcq0gy95mp980uzaw5gkmkyves6c5"
+      },
+      {
+        "bip32_path": "m/44'/474'/6'",
+        "private_key": "c1d8bd74169235f898c5e748ba1d7e41b64e86efd8ec97e1c618477a4becfb2e3cb8af918389e01bf8f56cd5d751368a6499418fe831b064d500f560d302f3a6",
+        "public_key": "3cb8af918389e01bf8f56cd5d751368a6499418fe831b064d500f560d302f3a6",
+        "address": "oasis1qpuyphtzt89j4t0q9lzsrah5nfamprp2z5tlex29"
+      },
+      {
+        "bip32_path": "m/44'/474'/7'",
+        "private_key": "a0713c5423fff078fd5799eaa108a0a30fab728c33d05c1a3cf5f36643fa2585fbb9be43264e4741daf4ff62af1539d6d00fed67d2902f61b6124d53be2e9be8",
+        "public_key": "fbb9be43264e4741daf4ff62af1539d6d00fed67d2902f61b6124d53be2e9be8",
+        "address": "oasis1qqr9q44l0qk653vrec4cnd4545ep9kydhvt5lnrz"
+      },
+      {
+        "bip32_path": "m/44'/474'/8'",
+        "private_key": "4892f22cf6573abb61807e3a3a9037904e3abf934e6982c7e8a9494ca400f616a7c7b0b96b23d13c9e65367717bb1ec418d92eeeeed815f4626e67c82b24f7b2",
+        "public_key": "a7c7b0b96b23d13c9e65367717bb1ec418d92eeeeed815f4626e67c82b24f7b2",
+        "address": "oasis1qzqk49vtue56srk3cyvq4kc0x948a8znvc8k30s2"
+      },
+      {
+        "bip32_path": "m/44'/474'/9'",
+        "private_key": "71ad66ceeb398212741c39a970695eec0f4eee2c01ec40981fa7df7e85f09f9176c7a32ea50c5e8f36ae2223ceb3f24afccbe3f9f50fc144016f359f0af16fd5",
+        "public_key": "76c7a32ea50c5e8f36ae2223ceb3f24afccbe3f9f50fc144016f359f0af16fd5",
+        "address": "oasis1qp2fae4y03rxewq8kqghajsj20arw99xayssmjc7"
+      },
+      {
+        "bip32_path": "m/44'/474'/2147483647'",
+        "private_key": "77b92641cb82440034152f7eccfdefd27e128505c5ec2d77c87c2477a685ea08dbfe5b1467a02d44b9dee5afb21a846f8034ab218c1b30d0db7f6d054bc80dde",
+        "public_key": "dbfe5b1467a02d44b9dee5afb21a846f8034ab218c1b30d0db7f6d054bc80dde",
+        "address": "oasis1qpvytnxhfxeagsfldqpskz4j86mdh2wqccmg0zul"
+      }
+    ]
+  }
+]

--- a/client-sdk/ts-web/core/test/hdkey.test.ts
+++ b/client-sdk/ts-web/core/test/hdkey.test.ts
@@ -1,0 +1,59 @@
+import {HDKey} from '../src/hdkey';
+import * as adr0008VectorsRaw from './adr-0008-vectors.json';
+
+interface Adr0008Vector {
+    kind: string;
+    bip39_mnemonic: string;
+    bip39_passphrase: string;
+    bip39_seed: string;
+    oasis_accounts: {
+        bip32_path: string;
+        private_key: string;
+        public_key: string;
+        address: string;
+    }[];
+}
+
+const adr0008Vectors: Adr0008Vector[] = adr0008VectorsRaw;
+
+const uint2hex = (array: Uint8Array) => Buffer.from(array).toString('hex');
+
+describe('HDKey', () => {
+    describe('getAccountSigner', () => {
+        it('Should reject negative account numbers', async () => {
+            const call = () => HDKey.getAccountSigner('basket actual', -1);
+            expect(call).rejects.toThrow(/^Account number must be.*/);
+        });
+
+        it('Should reject account numbers above max number', async () => {
+            const call = () => HDKey.getAccountSigner('basket actual', 0xffffffff);
+            expect(call).rejects.toThrow(/^Account number must be.*/);
+        });
+    });
+
+    describe('ADR 0008 Vectors', () => {
+        adr0008Vectors.forEach((vector, index) => {
+            it(`Case #${index}`, async () => {
+                // This can be a bit slow on CI servers.
+                jest.setTimeout(10000);
+                const passphrase =
+                    vector.bip39_passphrase && vector.bip39_passphrase !== ''
+                        ? vector.bip39_passphrase
+                        : null;
+
+                for (let account of vector.oasis_accounts) {
+                    expect(account.bip32_path).toMatch(/^m\/44'\/474'\/[0-9]+'/);
+                    const index = Number(account.bip32_path.split('/').pop().replace("'", ''));
+                    const keyPair = await HDKey.getAccountSigner(
+                        vector.bip39_mnemonic,
+                        index,
+                        passphrase,
+                    );
+
+                    expect(uint2hex(keyPair.secretKey)).toEqual(account.private_key);
+                    expect(uint2hex(keyPair.publicKey)).toEqual(account.public_key);
+                }
+            });
+        });
+    });
+});

--- a/client-sdk/ts-web/core/tsconfig.json
+++ b/client-sdk/ts-web/core/tsconfig.json
@@ -4,6 +4,10 @@
         "noImplicitAny": true,
         "module": "CommonJS",
         "target": "ES2020",
-        "declaration": true
-    }
+        "declaration": true,
+        "resolveJsonModule": true
+    },
+    "exclude": [
+        "test"
+    ]
 }

--- a/client-sdk/ts-web/jest.config.js
+++ b/client-sdk/ts-web/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    // We load this file from the packages' jest.config.js files (e.g. see
+    // core/jest.config.js), so it'll be resolved relative to the package's
+    // directory.
+    testMatch: ['**/test/**/*.ts'],
+    testEnvironment: 'node',
+    preset: 'ts-jest'
+};

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -22,6 +22,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^1.1.4",
+                "bip39": "^3.0.4",
                 "cborg": "^1.1.2",
                 "grpc-web": "^1.2.1",
                 "js-sha512": "^0.8.0",
@@ -2807,6 +2808,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/bip39": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
+            "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
+            "dependencies": {
+                "@types/node": "11.11.6",
+                "create-hash": "^1.1.0",
+                "pbkdf2": "^3.0.9",
+                "randombytes": "^2.0.1"
+            }
+        },
+        "node_modules/bip39/node_modules/@types/node": {
+            "version": "11.11.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+            "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        },
         "node_modules/blob-util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -3412,7 +3429,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -3920,7 +3936,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "dev": true,
             "dependencies": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -3933,7 +3948,6 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "dev": true,
             "dependencies": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -6014,7 +6028,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
             "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.6.0",
@@ -6028,7 +6041,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -8576,7 +8588,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-            "dev": true,
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
@@ -9705,7 +9716,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
             "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-            "dev": true,
             "dependencies": {
                 "create-hash": "^1.1.2",
                 "create-hmac": "^1.1.4",
@@ -10072,7 +10082,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -10506,7 +10515,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-            "dev": true,
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -10568,7 +10576,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10987,7 +10994,6 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -11600,7 +11606,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -11608,8 +11613,7 @@
         "node_modules/string_decoder/node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/string-length": {
             "version": "4.0.2",
@@ -12447,8 +12451,7 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "node_modules/util/node_modules/inherits": {
             "version": "2.0.3",
@@ -14534,6 +14537,7 @@
             "version": "file:core",
             "requires": {
                 "bech32": "^1.1.4",
+                "bip39": "^3.0.4",
                 "cborg": "^1.1.2",
                 "cypress": "^6.6.0",
                 "grpc-web": "^1.2.1",
@@ -16174,6 +16178,24 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
+        "bip39": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
+            "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
+            "requires": {
+                "@types/node": "11.11.6",
+                "create-hash": "^1.1.0",
+                "pbkdf2": "^3.0.9",
+                "randombytes": "^2.0.1"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "11.11.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+                    "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+                }
+            }
+        },
         "blob-util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -16698,7 +16720,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -17132,7 +17153,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -17145,7 +17165,6 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -18807,7 +18826,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
             "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.6.0",
@@ -18818,7 +18836,6 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -20777,7 +20794,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-            "dev": true,
             "requires": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
@@ -21676,7 +21692,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
             "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-            "dev": true,
             "requires": {
                 "create-hash": "^1.1.2",
                 "create-hmac": "^1.1.4",
@@ -21960,7 +21975,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
             }
@@ -22306,7 +22320,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-            "dev": true,
             "requires": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -22347,8 +22360,7 @@
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -22691,7 +22703,6 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -23217,7 +23228,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             },
@@ -23225,8 +23235,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 }
             }
         },
@@ -23886,8 +23895,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "utils-merge": {
             "version": "1.0.1",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -10,7 +10,10 @@
                 "signer-ledger"
             ],
             "devDependencies": {
-                "prettier": "^2.2.1"
+                "@types/jest": "^26.0.23",
+                "jest": "^26.6.3",
+                "prettier": "^2.2.1",
+                "ts-jest": "^26.5.5"
             }
         },
         "core": {
@@ -501,12 +504,517 @@
                 }
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/highlight": "^7.12.13"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+            "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
+            "dev": true
+        },
+        "node_modules/@babel/core": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
+            "integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.14.0",
+                "@babel/helper-compilation-targets": "^7.13.16",
+                "@babel/helper-module-transforms": "^7.14.0",
+                "@babel/helpers": "^7.14.0",
+                "@babel/parser": "^7.14.0",
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.14.0",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0",
+                "source-map": "^0.5.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/json5": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.5"
+            },
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/core/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.0.tgz",
+            "integrity": "sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.14.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+            "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/compat-data": "^7.13.15",
+                "@babel/helper-validator-option": "^7.12.17",
+                "browserslist": "^4.14.5",
+                "semver": "^6.3.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-function-name": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+            "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-get-function-arity": "^7.12.13",
+                "@babel/template": "^7.12.13",
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "node_modules/@babel/helper-get-function-arity": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+            "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "node_modules/@babel/helper-member-expression-to-functions": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+            "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+            "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
+            "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.13.12",
+                "@babel/helper-replace-supers": "^7.13.12",
+                "@babel/helper-simple-access": "^7.13.12",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.14.0"
+            }
+        },
+        "node_modules/@babel/helper-optimise-call-expression": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+            "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+            "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+            "dev": true
+        },
+        "node_modules/@babel/helper-replace-supers": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+            "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-member-expression-to-functions": "^7.13.12",
+                "@babel/helper-optimise-call-expression": "^7.12.13",
+                "@babel/traverse": "^7.13.0",
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "node_modules/@babel/helper-simple-access": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+            "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+            "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+            "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+            "dev": true
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.12.17",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+            "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.14.0"
+            }
+        },
+        "node_modules/@babel/highlight": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+            "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.0.tgz",
+            "integrity": "sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-top-level-await": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
+            "integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/runtime": {
             "version": "7.13.0",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.0.tgz",
             "integrity": "sha512-himjPiVq1N4Eqv80uaIMdLYav1LWO51J7PwQkgp3z8N0v8cnaeP5kSgWH4hS6jvjjWAbh5tB5fVw+zuNyyQTYQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+            "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.12.13",
+                "@babel/parser": "^7.12.13",
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
+            "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.14.0",
+                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/parser": "^7.14.0",
+                "@babel/types": "^7.14.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.0.tgz",
+            "integrity": "sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
+        },
+        "node_modules/@cnakazawa/watch": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+            "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+            "dev": true,
+            "dependencies": {
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
+            },
+            "bin": {
+                "watch": "cli.js"
+            },
+            "engines": {
+                "node": ">=0.1.95"
             }
         },
         "node_modules/@cypress/listr-verbose-renderer": {
@@ -624,6 +1132,437 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/console": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+            "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/core": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+            "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^26.6.2",
+                "@jest/reporters": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-changed-files": "^26.6.2",
+                "jest-config": "^26.6.3",
+                "jest-haste-map": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.2",
+                "jest-resolve-dependencies": "^26.6.3",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "jest-watcher": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/core/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@jest/core/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/core/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/core/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/core/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/@jest/core/node_modules/micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/@jest/core/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@jest/core/node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/core/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/@jest/core/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@jest/environment": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+            "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "jest-mock": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/fake-timers": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+            "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "@sinonjs/fake-timers": "^6.0.1",
+                "@types/node": "*",
+                "jest-message-util": "^26.6.2",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/globals": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+            "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "expect": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/reporters": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+            "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+            "dev": true,
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.2.4",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.3",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^4.0.1",
+                "terminal-link": "^2.0.0",
+                "v8-to-istanbul": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            },
+            "optionalDependencies": {
+                "node-notifier": "^8.0.0"
+            }
+        },
+        "node_modules/@jest/source-map": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+            "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+            "dev": true,
+            "dependencies": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.4",
+                "source-map": "^0.6.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/test-result": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+            "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/test-sequencer": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+            "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/test-result": "^26.6.2",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.6.2",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/transform": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+            "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^26.6.2",
+                "babel-plugin-istanbul": "^6.0.0",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-util": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "pirates": "^4.0.1",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/@jest/transform/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/transform/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/transform/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/@jest/transform/node_modules/micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/@jest/transform/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/@jest/types": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
             }
         },
         "node_modules/@ledgerhq/devices": {
@@ -745,6 +1684,65 @@
                 }
             }
         },
+        "node_modules/@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+            "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/@types/babel__core": {
+            "version": "7.1.14",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+            "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+            "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+            "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+            "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.3.0"
+            }
+        },
         "node_modules/@types/bn.js": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -789,6 +1787,15 @@
             "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
             "dev": true
         },
+        "node_modules/@types/graceful-fs": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+            "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/http-proxy": {
             "version": "1.17.5",
             "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
@@ -796,6 +1803,40 @@
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+            "dev": true
+        },
+        "node_modules/@types/istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "node_modules/@types/istanbul-reports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+            "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-report": "*"
+            }
+        },
+        "node_modules/@types/jest": {
+            "version": "26.0.23",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+            "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+            "dev": true,
+            "dependencies": {
+                "jest-diff": "^26.0.0",
+                "pretty-format": "^26.0.0"
             }
         },
         "node_modules/@types/json-schema": {
@@ -808,6 +1849,18 @@
             "version": "14.14.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
             "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+            "dev": true
+        },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "node_modules/@types/prettier": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+            "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
             "dev": true
         },
         "node_modules/@types/retry": {
@@ -826,6 +1879,27 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
             "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+            "dev": true
+        },
+        "node_modules/@types/stack-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+            "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+            "dev": true
+        },
+        "node_modules/@types/yargs": {
+            "version": "15.0.13",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+            "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/yargs-parser": {
+            "version": "20.2.0",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+            "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/ast": {
@@ -1134,6 +2208,12 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "node_modules/abab": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "dev": true
+        },
         "node_modules/accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1148,13 +2228,44 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-            "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.2.tgz",
+            "integrity": "sha512-VrMS8kxT0e7J1EX0p6rI/E0FbfOVcvBpbIqHThFv+f8YrZIlMfVotYcXKVPmTvPW8sW5miJzfUFrrvthUZg8VQ==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-globals": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1"
+            }
+        },
+        "node_modules/acorn-globals/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1313,6 +2424,15 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "node_modules/arr-diff": {
             "version": "4.0.0",
@@ -1500,6 +2620,98 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
+        },
+        "node_modules/babel-jest": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+            "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/babel__core": "^7.1.7",
+                "babel-plugin-istanbul": "^6.0.0",
+                "babel-preset-jest": "^26.6.2",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/babel-plugin-istanbul": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+            "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^4.0.0",
+                "test-exclude": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/babel-plugin-jest-hoist": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+            "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.0.0",
+                "@types/babel__traverse": "^7.0.6"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/babel-preset-current-node-syntax": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+            "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/babel-preset-jest": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+            "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+            "dev": true,
+            "dependencies": {
+                "babel-plugin-jest-hoist": "^26.6.2",
+                "babel-preset-current-node-syntax": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.0",
@@ -1707,6 +2919,12 @@
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
+        "node_modules/browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
+        },
         "node_modules/browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -1807,16 +3025,16 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "dev": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1827,6 +3045,27 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/browserslist"
+            }
+        },
+        "node_modules/bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "dependencies": {
+                "fast-json-stable-stringify": "2.x"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
+            "dependencies": {
+                "node-int64": "^0.4.0"
             }
         },
         "node_modules/buffer": {
@@ -1962,11 +3201,41 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001191",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
-            "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
+            "version": "1.0.30001219",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
+            "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
             "dev": true
+        },
+        "node_modules/capture-exit": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+            "dev": true,
+            "dependencies": {
+                "rsvp": "^4.8.4"
+            },
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
         },
         "node_modules/caseless": {
             "version": "0.12.0",
@@ -2030,6 +3299,15 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
+        },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/check-more-types": {
             "version": "2.24.0",
@@ -2139,6 +3417,12 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+            "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
+            "dev": true
         },
         "node_modules/class-utils": {
             "version": "0.3.6",
@@ -2251,56 +3535,6 @@
                 "colors": "^1.1.2"
             }
         },
-        "node_modules/cli-table3/node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
-        "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/string-width": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/strip-ansi": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cli-truncate": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -2340,6 +3574,38 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -2363,6 +3629,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true,
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
         "node_modules/code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -2371,6 +3647,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/collect-v8-coverage": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+            "dev": true
         },
         "node_modules/collection-visit": {
             "version": "1.0.0",
@@ -2401,9 +3683,9 @@
             "dev": true
         },
         "node_modules/colorette": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-            "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
         "node_modules/combined-stream": {
@@ -2565,6 +3847,21 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "node_modules/convert-source-map/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
         "node_modules/cookie": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
@@ -2681,6 +3978,30 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/cssom": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+            "dev": true
+        },
+        "node_modules/cssstyle": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "dev": true,
+            "dependencies": {
+                "cssom": "~0.3.6"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cssstyle/node_modules/cssom": {
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+            "dev": true
         },
         "node_modules/cyclist": {
             "version": "1.0.1",
@@ -2834,6 +4155,20 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-urls": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+            "dev": true,
+            "dependencies": {
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/date-fns": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
@@ -2863,6 +4198,21 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+            "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+            "dev": true
+        },
         "node_modules/decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -2887,6 +4237,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "node_modules/deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/default-gateway": {
@@ -3012,11 +4377,29 @@
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
         },
+        "node_modules/detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/detect-node": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
             "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
             "dev": true
+        },
+        "node_modules/diff-sequences": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+            "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.14.2"
+            }
         },
         "node_modules/diffie-hellman": {
             "version": "5.0.3",
@@ -3076,6 +4459,27 @@
                 "npm": ">=1.2"
             }
         },
+        "node_modules/domexception": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+            "dev": true,
+            "dependencies": {
+                "webidl-conversions": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/domexception/node_modules/webidl-conversions": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+            "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -3105,9 +4509,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.672",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.672.tgz",
-            "integrity": "sha512-gFQe7HBb0lbOMqK2GAS5/1F+B0IMdYiAgB9OT/w1F4M7lgJK2aNOMNOM622aEax+nS1cTMytkiT0uMOkbtFmHw==",
+            "version": "1.3.725",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.725.tgz",
+            "integrity": "sha512-2BbeAESz7kc6KBzs7WVrMc1BY5waUphk4D4DX5dSQXJhsc3tP5ZFaiyuL0AB7vUKzDYpIeYwTYlEfxyjsGUrhw==",
             "dev": true
         },
         "node_modules/elegant-spinner": {
@@ -3132,6 +4536,24 @@
                 "minimalistic-assert": "^1.0.1",
                 "minimalistic-crypto-utils": "^1.0.1"
             }
+        },
+        "node_modules/emittery": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+            "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/emojis-list": {
             "version": "3.0.0",
@@ -3207,6 +4629,15 @@
             },
             "bin": {
                 "errno": "cli.js"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-abstract": {
@@ -3286,6 +4717,37 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/escodegen": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "dev": true,
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/escodegen/node_modules/estraverse": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3297,6 +4759,19 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/esrecurse": {
@@ -3327,6 +4802,15 @@
             "dev": true,
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/etag": {
@@ -3380,6 +4864,12 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "node_modules/exec-sh": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
+            "integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==",
+            "dev": true
+        },
         "node_modules/execa": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
@@ -3422,6 +4912,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/exit-hook": {
@@ -3523,6 +5022,56 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/expect": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+            "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "ansi-styles": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-regex-util": "^26.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/expect/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/expect/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/expect/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
         "node_modules/express": {
@@ -3768,6 +5317,12 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -3793,6 +5348,15 @@
             },
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fb-watchman": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+            "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+            "dev": true,
+            "dependencies": {
+                "bser": "2.1.1"
             }
         },
         "node_modules/fd-slicer": {
@@ -4118,11 +5682,43 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
         },
         "node_modules/get-intrinsic": {
             "version": "1.1.1",
@@ -4136,6 +5732,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/get-stream": {
@@ -4236,6 +5841,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/globby": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
@@ -4261,6 +5875,13 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
+        },
+        "node_modules/growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true,
+            "optional": true
         },
         "node_modules/grpc-web": {
             "version": "1.2.1",
@@ -4436,6 +6057,12 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
+        "node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
+        },
         "node_modules/hpack.js": {
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -4448,10 +6075,28 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-encoding": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/html-entities": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.1.1.tgz",
             "integrity": "sha512-HjNLgm9Ba8zKd6NDMkXa0mMPn3eDUxOUnEIm/qy2Rm6rnqRHgI9DpMYIv1Fndu8haUmfMQHNYNrlNKmdU8GMnQ==",
+            "dev": true
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
         "node_modules/http-deceiver": {
@@ -4801,6 +6446,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
         "node_modules/is-bigint": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
@@ -4977,6 +6628,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/is-generator-function": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
@@ -5116,6 +6776,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true
+        },
         "node_modules/is-promise": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -5244,6 +6910,944 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+            "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-instrument": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-instrument/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+            "dev": true,
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^3.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/istanbul-lib-report/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/istanbul-lib-source-maps": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+            "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+            "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+            "dev": true,
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+            "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
+            "dev": true,
+            "dependencies": {
+                "@jest/core": "^26.6.3",
+                "import-local": "^3.0.2",
+                "jest-cli": "^26.6.3"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-changed-files": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+            "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "execa": "^4.0.0",
+                "throat": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/execa": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dev": true,
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.12.0"
+            }
+        },
+        "node_modules/jest-cli": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+            "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/core": "^26.6.3",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "import-local": "^3.0.2",
+                "is-ci": "^2.0.0",
+                "jest-config": "^26.6.3",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "prompts": "^2.0.1",
+                "yargs": "^15.4.1"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-config": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+            "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^26.6.3",
+                "@jest/types": "^26.6.2",
+                "babel-jest": "^26.6.3",
+                "chalk": "^4.0.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.2.4",
+                "jest-environment-jsdom": "^26.6.2",
+                "jest-environment-node": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "jest-jasmine2": "^26.6.3",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            },
+            "peerDependencies": {
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-config/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-config/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-config/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/jest-config/node_modules/micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/jest-config/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/jest-diff": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+            "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-docblock": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+            "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+            "dev": true,
+            "dependencies": {
+                "detect-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-each": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+            "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-environment-jsdom": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+            "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jsdom": "^16.4.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-environment-node": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+            "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-get-type": {
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-haste-map": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+            "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "@types/graceful-fs": "^4.1.2",
+                "@types/node": "*",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-regex-util": "^26.0.0",
+                "jest-serializer": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.1.2"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/jest-jasmine2": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+            "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^26.6.2",
+                "@jest/source-map": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "expect": "^26.6.2",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2",
+                "throat": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-leak-detector": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+            "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
+            "dev": true,
+            "dependencies": {
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-matcher-utils": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+            "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-message-util": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+            "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "@jest/types": "^26.6.2",
+                "@types/stack-utils": "^2.0.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.6.2",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/jest-mock": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+            "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "@types/node": "*"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-pnp-resolver": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependencies": {
+                "jest-resolve": "*"
+            },
+            "peerDependenciesMeta": {
+                "jest-resolve": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-regex-util": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+            "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-resolve": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+            "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^26.6.2",
+                "read-pkg-up": "^7.0.1",
+                "resolve": "^1.18.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-resolve-dependencies": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+            "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-snapshot": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-runner": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+            "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^26.6.2",
+                "@jest/environment": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.7.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.6.3",
+                "jest-docblock": "^26.0.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-leak-detector": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "jest-runtime": "^26.6.3",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
+                "source-map-support": "^0.5.6",
+                "throat": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-runtime": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+            "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^26.6.2",
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/globals": "^26.6.2",
+                "@jest/source-map": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0",
+                "cjs-module-lexer": "^0.6.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.6.3",
+                "jest-haste-map": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-mock": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.2",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0",
+                "yargs": "^15.4.1"
+            },
+            "bin": {
+                "jest-runtime": "bin/jest-runtime.js"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-serializer": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+            "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "graceful-fs": "^4.2.4"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-snapshot": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+            "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^26.6.2",
+                "@types/babel__traverse": "^7.0.4",
+                "@types/prettier": "^2.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^26.6.2",
+                "graceful-fs": "^4.2.4",
+                "jest-diff": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^26.6.2",
+                "semver": "^7.3.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-util": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+            "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "is-ci": "^2.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-util/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-util/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-util/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/jest-util/node_modules/micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/jest-util/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/jest-validate": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+            "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "camelcase": "^6.0.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "leven": "^3.1.0",
+                "pretty-format": "^26.6.2"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-validate/node_modules/camelcase": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-watcher": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+            "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "jest-util": "^26.6.2",
+                "string-length": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 10.14.2"
+            }
+        },
+        "node_modules/jest-watcher/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-watcher/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/jest-worker": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
@@ -5263,16 +7867,121 @@
             "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
             "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
         },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "dev": true
         },
+        "node_modules/jsdom": {
+            "version": "16.5.3",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
+            "integrity": "sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==",
+            "dev": true,
+            "dependencies": {
+                "abab": "^2.0.5",
+                "acorn": "^8.1.0",
+                "acorn-globals": "^6.0.0",
+                "cssom": "^0.4.4",
+                "cssstyle": "^2.3.0",
+                "data-urls": "^2.0.0",
+                "decimal.js": "^10.2.1",
+                "domexception": "^2.0.1",
+                "escodegen": "^2.0.0",
+                "html-encoding-sniffer": "^2.0.1",
+                "is-potential-custom-element-name": "^1.0.0",
+                "nwsapi": "^2.2.0",
+                "parse5": "6.0.1",
+                "request": "^2.88.2",
+                "request-promise-native": "^1.0.9",
+                "saxes": "^5.0.1",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^4.0.0",
+                "w3c-hr-time": "^1.0.2",
+                "w3c-xmlserializer": "^2.0.0",
+                "webidl-conversions": "^6.1.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.5.0",
+                "ws": "^7.4.4",
+                "xml-name-validator": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "canvas": "^2.5.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/tough-cookie": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+            "dev": true,
+            "dependencies": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/jsdom/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "node_modules/json-schema": {
@@ -5356,6 +8065,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/lazy-ass": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -5364,6 +8082,34 @@
             "engines": {
                 "node": "> 0.8"
             }
+        },
+        "node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
         },
         "node_modules/listr": {
             "version": "0.14.3",
@@ -5776,6 +8522,21 @@
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
+        "node_modules/makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "dependencies": {
+                "tmpl": "1.0.x"
             }
         },
         "node_modules/map-age-cleaner": {
@@ -6211,6 +8972,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
         "node_modules/negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -6226,6 +8993,12 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "node_modules/nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
         "node_modules/node-forge": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -6234,6 +9007,12 @@
             "engines": {
                 "node": ">= 6.0.0"
             }
+        },
+        "node_modules/node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
         },
         "node_modules/node-libs-browser": {
             "version": "2.2.1",
@@ -6272,11 +9051,79 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "node_modules/node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-notifier": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz",
+            "integrity": "sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "growly": "^1.3.0",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.2",
+                "shellwords": "^0.1.1",
+                "uuid": "^8.3.0",
+                "which": "^2.0.2"
+            }
+        },
+        "node_modules/node-notifier/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/node-notifier/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/node-releases": {
-            "version": "1.1.70",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
-            "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
+            "version": "1.1.71",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
             "dev": true
+        },
+        "node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/normalize-package-data/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -6307,6 +9154,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
         },
         "node_modules/oauth-sign": {
             "version": "0.9.0",
@@ -6554,6 +9407,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dev": true,
+            "dependencies": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/original": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -6582,6 +9452,18 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/p-each-series": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-event": {
@@ -6723,6 +9605,30 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "dev": true
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6824,9 +9730,9 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true,
             "engines": {
                 "node": ">=8.6"
@@ -6842,6 +9748,18 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pirates": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+            "dev": true,
+            "dependencies": {
+                "node-modules-regexp": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/pkg-dir": {
@@ -6888,6 +9806,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/prettier": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
@@ -6912,6 +9839,63 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pretty-format": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^26.6.2",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -6932,6 +9916,19 @@
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
+        },
+        "node_modules/prompts": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+            "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+            "dev": true,
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/proxy-addr": {
             "version": "2.0.6",
@@ -7123,6 +10120,53 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true
+        },
+        "node_modules/read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "dev": true,
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/readable-stream": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -7227,6 +10271,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
         "node_modules/repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -7245,6 +10295,38 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+            "dev": true,
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/request-progress": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -7253,6 +10335,63 @@
             "dependencies": {
                 "throttleit": "^1.0.0"
             }
+        },
+        "node_modules/request-promise-core": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.19"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "peerDependencies": {
+                "request": "^2.34"
+            }
+        },
+        "node_modules/request-promise-native": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+            "dev": true,
+            "dependencies": {
+                "request-promise-core": "1.1.4",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=0.12.0"
+            },
+            "peerDependencies": {
+                "request": "^2.34"
+            }
+        },
+        "node_modules/request/node_modules/qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
@@ -7373,6 +10512,15 @@
                 "inherits": "^2.0.1"
             }
         },
+        "node_modules/rsvp": {
+            "version": "4.8.5",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+            "dev": true,
+            "engines": {
+                "node": "6.* || >= 7.*"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7450,6 +10598,181 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "node_modules/sane": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+            "dev": true,
+            "dependencies": {
+                "@cnakazawa/watch": "^1.0.3",
+                "anymatch": "^2.0.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
+                "fb-watchman": "^2.0.0",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5"
+            },
+            "bin": {
+                "sane": "src/cli.js"
+            },
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/sane/node_modules/anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "dependencies": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+            }
+        },
+        "node_modules/sane/node_modules/cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "dependencies": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "engines": {
+                "node": ">=4.8"
+            }
+        },
+        "node_modules/sane/node_modules/execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/sane/node_modules/get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/sane/node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sane/node_modules/normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "dependencies": {
+                "remove-trailing-separator": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sane/node_modules/npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/sane/node_modules/path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/sane/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/sane/node_modules/shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sane/node_modules/shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sane/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+            "dev": true,
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/schema-utils": {
             "version": "3.0.0",
@@ -7627,6 +10950,12 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
         "node_modules/set-value": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -7709,10 +11038,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true,
+            "optional": true
+        },
         "node_modules/signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
+        },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "dev": true
         },
         "node_modules/slash": {
@@ -7951,6 +11293,38 @@
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
             "dev": true
         },
+        "node_modules/spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dev": true,
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+            "dev": true
+        },
         "node_modules/spdy": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -8032,6 +11406,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "node_modules/sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -8064,6 +11444,27 @@
             "dev": true,
             "dependencies": {
                 "figgy-pudding": "^3.5.1"
+            }
+        },
+        "node_modules/stack-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/stack-utils/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/static-extend": {
@@ -8147,6 +11548,15 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -8201,6 +11611,84 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
+        "node_modules/string-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+            "dev": true,
+            "dependencies": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/string-length/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-length/node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -8239,6 +11727,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -8260,6 +11766,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/supports-hyperlinks": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+            "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/symbol-observable": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -8269,6 +11788,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
         "node_modules/tapable": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
@@ -8276,6 +11801,49 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/terminal-link": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+            "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "supports-hyperlinks": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/terser": {
@@ -8327,6 +11895,26 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/throat": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+            "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+            "dev": true
         },
         "node_modules/throttleit": {
             "version": "1.0.0",
@@ -8389,11 +11977,26 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
         "node_modules/to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
+        },
+        "node_modules/to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/to-object-path": {
             "version": "0.3.0",
@@ -8482,6 +12085,82 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/tr46": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+            "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ts-jest": {
+            "version": "26.5.5",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.5.tgz",
+            "integrity": "sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==",
+            "dev": true,
+            "dependencies": {
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^26.1.0",
+                "json5": "2.x",
+                "lodash": "4.x",
+                "make-error": "1.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
+            },
+            "bin": {
+                "ts-jest": "cli.js"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "peerDependencies": {
+                "jest": ">=26 <27",
+                "typescript": ">=3.8 <5.0"
+            }
+        },
+        "node_modules/ts-jest/node_modules/json5": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.5"
+            },
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ts-jest/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-jest/node_modules/yargs-parser": {
+            "version": "20.2.7",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+            "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -8511,6 +12190,36 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "node_modules/type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -8529,6 +12238,15 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "node_modules/typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "dependencies": {
+                "is-typedarray": "^1.0.0"
+            }
         },
         "node_modules/typescript": {
             "version": "4.1.5",
@@ -8762,6 +12480,39 @@
             "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
             "dev": true
         },
+        "node_modules/v8-to-istanbul": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz",
+            "integrity": "sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^1.6.0",
+                "source-map": "^0.7.3"
+            },
+            "engines": {
+                "node": ">=10.10.0"
+            }
+        },
+        "node_modules/v8-to-istanbul/node_modules/source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -8791,6 +12542,36 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
         },
+        "node_modules/w3c-hr-time": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
+            "dependencies": {
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+            "dev": true,
+            "dependencies": {
+                "xml-name-validator": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "dependencies": {
+                "makeerror": "1.0.x"
+            }
+        },
         "node_modules/watchpack": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
@@ -8811,6 +12592,15 @@
             "dev": true,
             "dependencies": {
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.4"
             }
         },
         "node_modules/webpack": {
@@ -9116,6 +12906,35 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "dependencies": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+            "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.7.0",
+                "tr46": "^2.0.2",
+                "webidl-conversions": "^6.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9147,6 +12966,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
         "node_modules/which-typed-array": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
@@ -9174,6 +12999,15 @@
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
         },
+        "node_modules/word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/worker-farm": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -9183,11 +13017,91 @@
                 "errno": "~0.1.7"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
+        },
+        "node_modules/write-file-atomic": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "dev": true,
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
+            }
         },
         "node_modules/ws": {
             "version": "7.4.4",
@@ -9210,6 +13124,18 @@
                 }
             }
         },
+        "node_modules/xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
+        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -9229,6 +13155,41 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/yauzl": {
             "version": "2.10.0",
@@ -9623,12 +13584,440 @@
         }
     },
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.12.13"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+            "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
+            "dev": true
+        },
+        "@babel/core": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
+            "integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.14.0",
+                "@babel/helper-compilation-targets": "^7.13.16",
+                "@babel/helper-module-transforms": "^7.14.0",
+                "@babel/helpers": "^7.14.0",
+                "@babel/parser": "^7.14.0",
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.14.0",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+                    "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.0.tgz",
+            "integrity": "sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+            "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.13.15",
+                "@babel/helper-validator-option": "^7.12.17",
+                "browserslist": "^4.14.5",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+            "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.12.13",
+                "@babel/template": "^7.12.13",
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+            "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+            "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+            "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
+            "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.13.12",
+                "@babel/helper-replace-supers": "^7.13.12",
+                "@babel/helper-simple-access": "^7.13.12",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.14.0"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+            "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+            "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+            "dev": true
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+            "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.13.12",
+                "@babel/helper-optimise-call-expression": "^7.12.13",
+                "@babel/traverse": "^7.13.0",
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+            "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.13.12"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+            "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+            "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+            "dev": true
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.12.17",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
+        },
+        "@babel/helpers": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+            "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.14.0",
+                "@babel/types": "^7.14.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+            "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.0.tgz",
+            "integrity": "sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==",
+            "dev": true
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            }
+        },
+        "@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
+            "integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            }
+        },
         "@babel/runtime": {
             "version": "7.13.0",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.0.tgz",
             "integrity": "sha512-himjPiVq1N4Eqv80uaIMdLYav1LWO51J7PwQkgp3z8N0v8cnaeP5kSgWH4hS6jvjjWAbh5tB5fVw+zuNyyQTYQ==",
             "requires": {
                 "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@babel/template": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+            "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.12.13",
+                "@babel/parser": "^7.12.13",
+                "@babel/types": "^7.12.13"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
+            "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.14.0",
+                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/parser": "^7.14.0",
+                "@babel/types": "^7.14.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/types": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.0.tgz",
+            "integrity": "sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.14.0",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
+        },
+        "@cnakazawa/watch": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+            "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+            "dev": true,
+            "requires": {
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
             }
         },
         "@cypress/listr-verbose-renderer": {
@@ -9732,6 +14121,346 @@
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
             "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
             "dev": true
+        },
+        "@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            }
+        },
+        "@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true
+        },
+        "@jest/console": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+            "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "slash": "^3.0.0"
+            }
+        },
+        "@jest/core": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+            "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.2",
+                "@jest/reporters": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-changed-files": "^26.6.2",
+                "jest-config": "^26.6.3",
+                "jest-haste-map": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.2",
+                "jest-resolve-dependencies": "^26.6.3",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "jest-watcher": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.2.3"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/environment": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+            "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+            "dev": true,
+            "requires": {
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "jest-mock": "^26.6.2"
+            }
+        },
+        "@jest/fake-timers": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+            "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "@sinonjs/fake-timers": "^6.0.1",
+                "@types/node": "*",
+                "jest-message-util": "^26.6.2",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2"
+            }
+        },
+        "@jest/globals": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+            "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "expect": "^26.6.2"
+            }
+        },
+        "@jest/reporters": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+            "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+            "dev": true,
+            "requires": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.2.4",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.3",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
+                "node-notifier": "^8.0.0",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^4.0.1",
+                "terminal-link": "^2.0.0",
+                "v8-to-istanbul": "^7.0.0"
+            }
+        },
+        "@jest/source-map": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+            "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.4",
+                "source-map": "^0.6.0"
+            }
+        },
+        "@jest/test-result": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+            "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            }
+        },
+        "@jest/test-sequencer": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+            "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^26.6.2",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.6.2",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3"
+            }
+        },
+        "@jest/transform": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+            "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^26.6.2",
+                "babel-plugin-istanbul": "^6.0.0",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-util": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "pirates": "^4.0.1",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "^3.0.0"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.2.3"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/types": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0"
+            }
         },
         "@ledgerhq/devices": {
             "version": "5.43.0",
@@ -10477,6 +15206,65 @@
                 "any-observable": "^0.3.0"
             }
         },
+        "@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+            "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@types/babel__core": {
+            "version": "7.1.14",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+            "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+            "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+            "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+            "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0"
+            }
+        },
         "@types/bn.js": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -10521,6 +15309,15 @@
             "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
             "dev": true
         },
+        "@types/graceful-fs": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+            "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/http-proxy": {
             "version": "1.17.5",
             "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
@@ -10528,6 +15325,40 @@
             "dev": true,
             "requires": {
                 "@types/node": "*"
+            }
+        },
+        "@types/istanbul-lib-coverage": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+            "dev": true
+        },
+        "@types/istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "@types/istanbul-reports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+            "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-report": "*"
+            }
+        },
+        "@types/jest": {
+            "version": "26.0.23",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+            "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+            "dev": true,
+            "requires": {
+                "jest-diff": "^26.0.0",
+                "pretty-format": "^26.0.0"
             }
         },
         "@types/json-schema": {
@@ -10540,6 +15371,18 @@
             "version": "14.14.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
             "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+            "dev": true
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "@types/prettier": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+            "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
             "dev": true
         },
         "@types/retry": {
@@ -10558,6 +15401,27 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
             "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+            "dev": true
+        },
+        "@types/stack-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+            "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+            "dev": true
+        },
+        "@types/yargs": {
+            "version": "15.0.13",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+            "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+            "dev": true,
+            "requires": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "@types/yargs-parser": {
+            "version": "20.2.0",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+            "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
             "dev": true
         },
         "@webassemblyjs/ast": {
@@ -10859,6 +15723,12 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "abab": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "dev": true
+        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -10870,9 +15740,33 @@
             }
         },
         "acorn": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-            "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.2.tgz",
+            "integrity": "sha512-VrMS8kxT0e7J1EX0p6rI/E0FbfOVcvBpbIqHThFv+f8YrZIlMfVotYcXKVPmTvPW8sW5miJzfUFrrvthUZg8VQ==",
+            "dev": true
+        },
+        "acorn-globals": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
             "dev": true
         },
         "aggregate-error": {
@@ -10979,6 +15873,15 @@
             "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
             "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
             "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "arr-diff": {
             "version": "4.0.0",
@@ -11129,6 +16032,77 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
+        },
+        "babel-jest": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+            "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+            "dev": true,
+            "requires": {
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/babel__core": "^7.1.7",
+                "babel-plugin-istanbul": "^6.0.0",
+                "babel-preset-jest": "^26.6.2",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "slash": "^3.0.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+            "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^4.0.0",
+                "test-exclude": "^6.0.0"
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+            "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.0.0",
+                "@types/babel__traverse": "^7.0.6"
+            }
+        },
+        "babel-preset-current-node-syntax": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+            "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3"
+            }
+        },
+        "babel-preset-jest": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+            "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-jest-hoist": "^26.6.2",
+                "babel-preset-current-node-syntax": "^1.0.0"
+            }
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -11305,6 +16279,12 @@
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
+        "browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
+        },
         "browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -11406,16 +16386,34 @@
             }
         },
         "browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
+            }
+        },
+        "bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "requires": {
+                "fast-json-stable-stringify": "2.x"
+            }
+        },
+        "bser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
+            "requires": {
+                "node-int64": "^0.4.0"
             }
         },
         "buffer": {
@@ -11538,11 +16536,32 @@
                 "get-intrinsic": "^1.0.2"
             }
         },
-        "caniuse-lite": {
-            "version": "1.0.30001191",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
-            "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001219",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
+            "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
+            "dev": true
+        },
+        "capture-exit": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+            "dev": true,
+            "requires": {
+                "rsvp": "^4.8.4"
+            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -11590,6 +16609,12 @@
                     "dev": true
                 }
             }
+        },
+        "char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
         },
         "check-more-types": {
             "version": "2.24.0",
@@ -11679,6 +16704,12 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "cjs-module-lexer": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+            "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
+            "dev": true
+        },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -11763,46 +16794,6 @@
                 "colors": "^1.1.2",
                 "object-assign": "^4.1.0",
                 "string-width": "^4.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
-                },
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-                    "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                }
             }
         },
         "cli-truncate": {
@@ -11837,6 +16828,34 @@
                 }
             }
         },
+        "cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dev": true,
+            "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
         "clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -11856,10 +16875,22 @@
                 }
             }
         },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "collect-v8-coverage": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
             "dev": true
         },
         "collection-visit": {
@@ -11888,9 +16919,9 @@
             "dev": true
         },
         "colorette": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-            "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
         "combined-stream": {
@@ -12032,6 +17063,23 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
+            }
+        },
         "cookie": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
@@ -12135,6 +17183,29 @@
                 "public-encrypt": "^4.0.0",
                 "randombytes": "^2.0.0",
                 "randomfill": "^1.0.3"
+            }
+        },
+        "cssom": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "dev": true,
+            "requires": {
+                "cssom": "~0.3.6"
+            },
+            "dependencies": {
+                "cssom": {
+                    "version": "0.3.8",
+                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "dev": true
+                }
             }
         },
         "cyclist": {
@@ -12255,6 +17326,17 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "data-urls": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
+            }
+        },
         "date-fns": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
@@ -12276,6 +17358,18 @@
                 "ms": "2.1.2"
             }
         },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decimal.js": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+            "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+            "dev": true
+        },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -12295,6 +17389,18 @@
                 "object-keys": "^1.1.1",
                 "regexp.prototype.flags": "^1.2.0"
             }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true
         },
         "default-gateway": {
             "version": "6.0.3",
@@ -12388,10 +17494,22 @@
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
         },
+        "detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true
+        },
         "detect-node": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
             "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+            "dev": true
+        },
+        "diff-sequences": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+            "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
             "dev": true
         },
         "diffie-hellman": {
@@ -12445,6 +17563,23 @@
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
         },
+        "domexception": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^5.0.0"
+            },
+            "dependencies": {
+                "webidl-conversions": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+                    "dev": true
+                }
+            }
+        },
         "duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -12474,9 +17609,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.672",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.672.tgz",
-            "integrity": "sha512-gFQe7HBb0lbOMqK2GAS5/1F+B0IMdYiAgB9OT/w1F4M7lgJK2aNOMNOM622aEax+nS1cTMytkiT0uMOkbtFmHw==",
+            "version": "1.3.725",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.725.tgz",
+            "integrity": "sha512-2BbeAESz7kc6KBzs7WVrMc1BY5waUphk4D4DX5dSQXJhsc3tP5ZFaiyuL0AB7vUKzDYpIeYwTYlEfxyjsGUrhw==",
             "dev": true
         },
         "elegant-spinner": {
@@ -12498,6 +17633,18 @@
                 "minimalistic-assert": "^1.0.1",
                 "minimalistic-crypto-utils": "^1.0.1"
             }
+        },
+        "emittery": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+            "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+            "dev": true
+        },
+        "emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "emojis-list": {
             "version": "3.0.0",
@@ -12552,6 +17699,15 @@
             "dev": true,
             "requires": {
                 "prr": "~1.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -12613,6 +17769,27 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
+        "escodegen": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
+            }
+        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -12622,6 +17799,12 @@
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
             }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
         },
         "esrecurse": {
             "version": "4.3.0",
@@ -12644,6 +17827,12 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
         "etag": {
@@ -12688,6 +17877,12 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "exec-sh": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
+            "integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==",
+            "dev": true
+        },
         "execa": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
@@ -12721,6 +17916,12 @@
                     "dev": true
                 }
             }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
         },
         "exit-hook": {
             "version": "1.1.1",
@@ -12802,6 +18003,46 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "expect": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+            "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "ansi-styles": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-regex-util": "^26.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 }
             }
@@ -13021,6 +18262,12 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
         "fastest-levenshtein": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -13043,6 +18290,15 @@
             "dev": true,
             "requires": {
                 "websocket-driver": ">=0.5.1"
+            }
+        },
+        "fb-watchman": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+            "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+            "dev": true,
+            "requires": {
+                "bser": "2.1.1"
             }
         },
         "fd-slicer": {
@@ -13301,10 +18557,29 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
         "get-intrinsic": {
@@ -13317,6 +18592,12 @@
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
             }
+        },
+        "get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "dev": true
         },
         "get-stream": {
             "version": "6.0.0",
@@ -13394,6 +18675,12 @@
                 "ini": "1.3.7"
             }
         },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
         "globby": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
@@ -13413,6 +18700,13 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
+        },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true,
+            "optional": true
         },
         "grpc-web": {
             "version": "1.2.1",
@@ -13552,6 +18846,12 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
+        "hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
+        },
         "hpack.js": {
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -13564,10 +18864,25 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "html-encoding-sniffer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.5"
+            }
+        },
         "html-entities": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.1.1.tgz",
             "integrity": "sha512-HjNLgm9Ba8zKd6NDMkXa0mMPn3eDUxOUnEIm/qy2Rm6rnqRHgI9DpMYIv1Fndu8haUmfMQHNYNrlNKmdU8GMnQ==",
+            "dev": true
+        },
+        "html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
         "http-deceiver": {
@@ -13833,6 +19148,12 @@
                 "call-bind": "^1.0.0"
             }
         },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
         "is-bigint": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
@@ -13953,6 +19274,12 @@
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
+        "is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true
+        },
         "is-generator-function": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
@@ -14046,6 +19373,12 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true
+        },
         "is-promise": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -14138,6 +19471,735 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
+        "istanbul-lib-coverage": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+            "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^3.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+            "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            }
+        },
+        "istanbul-reports": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+            "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+            "dev": true,
+            "requires": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            }
+        },
+        "jest": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+            "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
+            "dev": true,
+            "requires": {
+                "@jest/core": "^26.6.3",
+                "import-local": "^3.0.2",
+                "jest-cli": "^26.6.3"
+            }
+        },
+        "jest-changed-files": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+            "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "execa": "^4.0.0",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+                    "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "human-signals": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+                    "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-cli": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+            "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+            "dev": true,
+            "requires": {
+                "@jest/core": "^26.6.3",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "import-local": "^3.0.2",
+                "is-ci": "^2.0.0",
+                "jest-config": "^26.6.3",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "prompts": "^2.0.1",
+                "yargs": "^15.4.1"
+            }
+        },
+        "jest-config": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+            "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^26.6.3",
+                "@jest/types": "^26.6.2",
+                "babel-jest": "^26.6.3",
+                "chalk": "^4.0.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.2.4",
+                "jest-environment-jsdom": "^26.6.2",
+                "jest-environment-node": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "jest-jasmine2": "^26.6.3",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.6.2"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.2.3"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-diff": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+            "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
+            }
+        },
+        "jest-docblock": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+            "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+            "dev": true,
+            "requires": {
+                "detect-newline": "^3.0.0"
+            }
+        },
+        "jest-each": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+            "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2"
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+            "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jsdom": "^16.4.0"
+            }
+        },
+        "jest-environment-node": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+            "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2"
+            }
+        },
+        "jest-get-type": {
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+            "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "@types/graceful-fs": "^4.1.2",
+                "@types/node": "*",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-regex-util": "^26.0.0",
+                "jest-serializer": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
+                "micromatch": "^4.0.2",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.2.3"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-jasmine2": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+            "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^26.6.2",
+                "@jest/source-map": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "expect": "^26.6.2",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2",
+                "throat": "^5.0.0"
+            }
+        },
+        "jest-leak-detector": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+            "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
+            "dev": true,
+            "requires": {
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+            "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
+            }
+        },
+        "jest-message-util": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+            "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@jest/types": "^26.6.2",
+                "@types/stack-utils": "^2.0.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.6.2",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.2"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.2.3"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-mock": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+            "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "@types/node": "*"
+            }
+        },
+        "jest-pnp-resolver": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "dev": true,
+            "requires": {}
+        },
+        "jest-regex-util": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+            "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+            "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^26.6.2",
+                "read-pkg-up": "^7.0.1",
+                "resolve": "^1.18.1",
+                "slash": "^3.0.0"
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+            "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-snapshot": "^26.6.2"
+            }
+        },
+        "jest-runner": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+            "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.2",
+                "@jest/environment": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.7.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.6.3",
+                "jest-docblock": "^26.0.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-leak-detector": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "jest-runtime": "^26.6.3",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
+                "source-map-support": "^0.5.6",
+                "throat": "^5.0.0"
+            }
+        },
+        "jest-runtime": {
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+            "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.2",
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/globals": "^26.6.2",
+                "@jest/source-map": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0",
+                "cjs-module-lexer": "^0.6.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.6.3",
+                "jest-haste-map": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-mock": "^26.6.2",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.2",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0",
+                "yargs": "^15.4.1"
+            }
+        },
+        "jest-serializer": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+            "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "graceful-fs": "^4.2.4"
+            }
+        },
+        "jest-snapshot": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+            "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^26.6.2",
+                "@types/babel__traverse": "^7.0.4",
+                "@types/prettier": "^2.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^26.6.2",
+                "graceful-fs": "^4.2.4",
+                "jest-diff": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^26.6.2",
+                "semver": "^7.3.2"
+            }
+        },
+        "jest-util": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+            "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "is-ci": "^2.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.2.3"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "jest-validate": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+            "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "camelcase": "^6.0.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "leven": "^3.1.0",
+                "pretty-format": "^26.6.2"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+                    "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-watcher": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+            "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "jest-util": "^26.6.2",
+                "string-length": "^4.0.1"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
+                }
+            }
+        },
         "jest-worker": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
@@ -14154,16 +20216,97 @@
             "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
             "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
         },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "dev": true
         },
+        "jsdom": {
+            "version": "16.5.3",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
+            "integrity": "sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.5",
+                "acorn": "^8.1.0",
+                "acorn-globals": "^6.0.0",
+                "cssom": "^0.4.4",
+                "cssstyle": "^2.3.0",
+                "data-urls": "^2.0.0",
+                "decimal.js": "^10.2.1",
+                "domexception": "^2.0.1",
+                "escodegen": "^2.0.0",
+                "html-encoding-sniffer": "^2.0.1",
+                "is-potential-custom-element-name": "^1.0.0",
+                "nwsapi": "^2.2.0",
+                "parse5": "6.0.1",
+                "request": "^2.88.2",
+                "request-promise-native": "^1.0.9",
+                "saxes": "^5.0.1",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^4.0.0",
+                "w3c-hr-time": "^1.0.2",
+                "w3c-xmlserializer": "^2.0.0",
+                "webidl-conversions": "^6.1.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.5.0",
+                "ws": "^7.4.4",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "tough-cookie": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+                    "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.33",
+                        "punycode": "^2.1.1",
+                        "universalify": "^0.1.2"
+                    }
+                },
+                "universalify": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+                    "dev": true
+                }
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "json-schema": {
@@ -14236,10 +20379,38 @@
                 "is-buffer": "^1.1.5"
             }
         },
+        "kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true
+        },
         "lazy-ass": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
             "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+            "dev": true
+        },
+        "leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
         "listr": {
@@ -14561,6 +20732,21 @@
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
+            }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.x"
             }
         },
         "map-age-cleaner": {
@@ -14911,6 +21097,12 @@
                 }
             }
         },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -14923,10 +21115,22 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
         "node-forge": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
             "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+            "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
             "dev": true
         },
         "node-libs-browser": {
@@ -14968,11 +21172,71 @@
                 }
             }
         },
-        "node-releases": {
-            "version": "1.1.70",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
-            "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
             "dev": true
+        },
+        "node-notifier": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz",
+            "integrity": "sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "growly": "^1.3.0",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.2",
+                "shellwords": "^0.1.1",
+                "uuid": "^8.3.0",
+                "which": "^2.0.2"
+            },
+            "dependencies": {
+                "is-wsl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+                    "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-docker": "^2.0.0"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "node-releases": {
+            "version": "1.1.71",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -14993,6 +21257,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
         },
         "oauth-sign": {
@@ -15178,6 +21448,20 @@
                 }
             }
         },
+        "optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            }
+        },
         "original": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -15203,6 +21487,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
             "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-each-series": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
             "dev": true
         },
         "p-event": {
@@ -15310,6 +21600,24 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            }
+        },
+        "parse5": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "dev": true
+        },
         "parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -15390,9 +21698,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true
         },
         "pify": {
@@ -15400,6 +21708,15 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true
+        },
+        "pirates": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+            "dev": true,
+            "requires": {
+                "node-modules-regexp": "^1.0.0"
+            }
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -15438,6 +21755,12 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
         "prettier": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
@@ -15449,6 +21772,50 @@
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
             "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
             "dev": true
+        },
+        "pretty-format": {
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.2",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^17.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                }
+            }
         },
         "process": {
             "version": "0.11.10",
@@ -15467,6 +21834,16 @@
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
+        },
+        "prompts": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+            "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+            "dev": true,
+            "requires": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            }
         },
         "proxy-addr": {
             "version": "2.0.6",
@@ -15624,6 +22001,43 @@
                 }
             }
         },
+        "react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "dev": true,
+            "requires": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            }
+        },
         "readable-stream": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -15711,6 +22125,12 @@
                 "define-properties": "^1.1.3"
             }
         },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -15723,6 +22143,42 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                }
+            }
+        },
         "request-progress": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -15731,6 +22187,38 @@
             "requires": {
                 "throttleit": "^1.0.0"
             }
+        },
+        "request-promise-core": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.19"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.4",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
         },
         "requires-port": {
             "version": "1.0.0",
@@ -15824,6 +22312,12 @@
                 "inherits": "^2.0.1"
             }
         },
+        "rsvp": {
+            "version": "4.8.5",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+            "dev": true
+        },
         "run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15870,6 +22364,141 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "sane": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+            "dev": true,
+            "requires": {
+                "@cnakazawa/watch": "^1.0.3",
+                "anymatch": "^2.0.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
+                "fb-watchman": "^2.0.0",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                    "dev": true
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "saxes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^2.2.0"
+            }
         },
         "schema-utils": {
             "version": "3.0.0",
@@ -16028,6 +22657,12 @@
                 "send": "0.17.1"
             }
         },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
         "set-value": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -16094,10 +22729,23 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true,
+            "optional": true
+        },
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
+        },
+        "sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "dev": true
         },
         "slash": {
@@ -16305,6 +22953,38 @@
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
             "dev": true
         },
+        "spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+            "dev": true
+        },
         "spdy": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -16375,6 +23055,12 @@
                 }
             }
         },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -16399,6 +23085,23 @@
             "dev": true,
             "requires": {
                 "figgy-pudding": "^3.5.1"
+            }
+        },
+        "stack-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                }
             }
         },
         "static-extend": {
@@ -16465,6 +23168,12 @@
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
             "dev": true
         },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
         "stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -16521,6 +23230,67 @@
                 }
             }
         },
+        "string-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+            "dev": true,
+            "requires": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
+        "string-width": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "dev": true,
+            "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
         "string.prototype.trimend": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -16550,6 +23320,18 @@
                 "ansi-regex": "^2.0.0"
             }
         },
+        "strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -16565,10 +23347,26 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "supports-hyperlinks": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+            "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            }
+        },
         "symbol-observable": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
             "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+            "dev": true
+        },
+        "symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
         "tapable": {
@@ -16576,6 +23374,33 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
             "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
             "dev": true
+        },
+        "terminal-link": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+            "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "supports-hyperlinks": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
+                }
+            }
         },
         "terser": {
             "version": "5.6.0",
@@ -16609,6 +23434,23 @@
                 "source-map": "^0.6.1",
                 "terser": "^5.5.1"
             }
+        },
+        "test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "requires": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            }
+        },
+        "throat": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+            "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+            "dev": true
         },
         "throttleit": {
             "version": "1.0.0",
@@ -16661,10 +23503,22 @@
                 }
             }
         },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "to-object-path": {
@@ -16735,6 +23589,56 @@
                 "punycode": "^2.1.1"
             }
         },
+        "tr46": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+            "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.1"
+            }
+        },
+        "ts-jest": {
+            "version": "26.5.5",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.5.tgz",
+            "integrity": "sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==",
+            "dev": true,
+            "requires": {
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^26.1.0",
+                "json5": "2.x",
+                "lodash": "4.x",
+                "make-error": "1.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+                    "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "yargs-parser": {
+                    "version": "20.2.7",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+                    "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+                    "dev": true
+                }
+            }
+        },
         "tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -16761,6 +23665,27 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
+        "type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true
+        },
         "type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -16776,6 +23701,15 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
         },
         "typescript": {
             "version": "4.1.5",
@@ -16973,6 +23907,35 @@
             "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
             "dev": true
         },
+        "v8-to-istanbul": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz",
+            "integrity": "sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^1.6.0",
+                "source-map": "^0.7.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                }
+            }
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16996,6 +23959,33 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
         },
+        "w3c-hr-time": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "w3c-xmlserializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+            "dev": true,
+            "requires": {
+                "xml-name-validator": "^3.0.0"
+            }
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.x"
+            }
+        },
         "watchpack": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
@@ -17014,6 +24004,12 @@
             "requires": {
                 "minimalistic-assert": "^1.0.0"
             }
+        },
+        "webidl-conversions": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+            "dev": true
         },
         "webpack": {
             "version": "5.24.0",
@@ -17221,6 +24217,32 @@
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true
         },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+            "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.7.0",
+                "tr46": "^2.0.2",
+                "webidl-conversions": "^6.1.0"
+            }
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -17243,6 +24265,12 @@
                 "is-symbol": "^1.0.3"
             }
         },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
         "which-typed-array": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
@@ -17264,6 +24292,12 @@
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
         },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
+        },
         "worker-farm": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -17273,11 +24307,75 @@
                 "errno": "~0.1.7"
             }
         },
+        "wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
+        },
+        "write-file-atomic": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
+            }
         },
         "ws": {
             "version": "7.4.4",
@@ -17285,6 +24383,18 @@
             "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
             "dev": true,
             "requires": {}
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
         },
         "xtend": {
             "version": "4.0.2",
@@ -17302,6 +24412,35 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
+            "requires": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            }
+        },
+        "yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
         },
         "yauzl": {
             "version": "2.10.0",

--- a/client-sdk/ts-web/package.json
+++ b/client-sdk/ts-web/package.json
@@ -5,10 +5,13 @@
         "signer-ledger"
     ],
     "scripts": {
-        "lint": "prettier --check '**/src/**.ts'",
-        "fmt": "prettier --write '**/src/**.ts'"
+        "lint": "prettier --check '**/src/**.ts' '**/test/**.ts'",
+        "fmt": "prettier --write '**/src/**.ts' '**/test/**.ts'"
     },
     "devDependencies": {
-        "prettier": "^2.2.1"
+        "@types/jest": "^26.0.23",
+        "jest": "^26.6.3",
+        "prettier": "^2.2.1",
+        "ts-jest": "^26.5.5"
     }
 }

--- a/client-sdk/ts-web/rt/playground/webpack.config.js
+++ b/client-sdk/ts-web/rt/playground/webpack.config.js
@@ -1,6 +1,15 @@
+const webpack = require('webpack');
+
 module.exports = [
     {
         mode: 'development',
+        resolve: {fallback: {stream: require.resolve('stream-browserify')}},
+        plugins: [
+            new webpack.ProvidePlugin({
+                process: 'process/browser',
+                Buffer: ['buffer', 'Buffer'],
+            }),
+        ],
         output: {
             library: {
                 name: 'playground',
@@ -11,6 +20,13 @@ module.exports = [
     },
     {
         mode: 'development',
+        resolve: {fallback: {stream: require.resolve('stream-browserify')}},
+        plugins: [
+            new webpack.ProvidePlugin({
+                process: 'process/browser',
+                Buffer: ['buffer', 'Buffer'],
+            }),
+        ],
         entry: './src/consensus.js',
         output: {
             library: {

--- a/client-sdk/ts-web/signer-ledger/playground/webpack.config.js
+++ b/client-sdk/ts-web/signer-ledger/playground/webpack.config.js
@@ -1,3 +1,12 @@
+const webpack = require('webpack');
+
 module.exports = {
     mode: 'development',
+    resolve: { fallback: { stream: require.resolve('stream-browserify') } },
+    plugins: [
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
+            Buffer: ['buffer', 'Buffer'],
+        }),
+    ],
 };


### PR DESCRIPTION
Rework of #65 to use SLIP-0010 instead of BIP32-ED25519

# Summary

Implements [ADR 0008: Standard Account Key Generation](https://github.com/oasisprotocol/oasis-core/pull/3656/) in ts-web/core, standardizing the key generation process using [BIP-0039] to generate the seed, and [SLIP-0010] for hierarchical deterministic key generation. 

The value proposition mentioned in [ADR 0008] is as follows : 

> Adopting these standards will allow the Oasis ecosystem to:
> 
> - Make key derivation the same across different applications (i.e. wallets).
> - Allow users to hold keys in hardware wallets.
> - Allow users to hold keys in cold storage more reliably (i.e. using the
  familiar 24 word mnemonics).
> - Define how users can generate multiple keys from a single seed (i.e.
  the 24 or 12 word mnemonic).

# Usage

## Mnemonic and derivation
We add a new class `HDKey` inside `ts-web/core` that allows hierarchical deterministic keys to be generated from [BIP-0039] mnemonics and derived using [SLIP-0010], such as : 

```typescript
const HDKey = oasis.hdkey.HDKey;

// From existing mnemonic
const root = await HDKey.fromMnemonic('practice acoustic taxi');
const key = root.derivePath("m/44'/474'/0''");

// Generating a secure mnemonic
const mnemonic = await HDKey.generateMnemonic();
const root = await HDKey.fromMnemonic(mnemonic);
const key = root.derivePath("m/44'/474'/0'");
```

## Signing with HDKey

```typescript
const root = HDKey.fromMnemonic('practice acoustic taxi');
const key = root.derivePath("m/44'/474'/0'");

const tw = oasis.staking.transferWrapper();

// ... Build transaction ...

const signer = new NaclSigner(key.keyPair, 'this key is not important');
await tw.sign(new oasis.signature.BlindContextSigner(signer), chainContext);
```

# Other changes to ts-web
## Jest support

This pull request adds `jest` as a framework for unit and integration tests, since the only existing tool was cypress that is more suited for e2e tests. While we should keep cypress for when testing browser integration, I propose this becomes standard for unit & integration tests and added a sane and simple `jest.config.js` in `ts-web` that can then be extended or reused by the underlying packages. 

This PR also adds a github action job to run the jest tests for `core`

## Unified webpack configurations

The webpack configuration files from the various playgrounds (`core`, `rt` and `signer-ledger`) were changed to use a main one in `ts-web` .

Webpack 5 does not automatically include polyfills anymore and they must now be explicitly listed - so we polyfill `stream` (needed for crypto/cipher-base part of bip39) for the browser.

[ADR 0008]: https://github.com/oasisprotocol/oasis-core/pull/3656/
[BIP-0032]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
[BIP-0039]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
[SLIP-0010]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md