### PR TITLE
ts-web/signer-ledger: preserve original return code

### DIFF
--- a/client-sdk/ts-web/signer-ledger/docs/changelog.md
+++ b/client-sdk/ts-web/signer-ledger/docs/changelog.md
@@ -5,6 +5,7 @@
 New features:
 
 - The new `LedgerContextSigner.fromTransport` lets you bring your own transport object.
+- Errors from Ledger now come as `LedgerCodeError` with a `returnCode` property.
 
 Bug fixes:
 

--- a/client-sdk/ts-web/signer-ledger/src/index.ts
+++ b/client-sdk/ts-web/signer-ledger/src/index.ts
@@ -21,9 +21,21 @@ function bufFromU8(u8: Uint8Array) {
     return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
 }
 
+export class LedgerCodeError extends Error {
+    returnCode: number;
+    errorMessage: string;
+
+    constructor(message: string, return_code: number, error_message: string) {
+        super(`${message}: ${return_code} ${error_message}`);
+        this.returnCode = return_code;
+        this.errorMessage = error_message;
+    }
+}
+
 function successOrThrow(response: Response, message: string) {
-    if (response.return_code !== 0x9000)
-        throw new Error(`${message}: ${response.return_code} ${response.error_message}`);
+    if (response.return_code !== 0x9000) {
+        throw new LedgerCodeError(message, response.return_code, response.error_message);
+    }
     return response;
 }
 


### PR DESCRIPTION
So no more message string parsing! Unless you're into that kind of thing.