### PR TITLE
tests/e2e: Add transaction generator

### DIFF
--- a/.github/workflows/ci-longtest.yaml
+++ b/.github/workflows/ci-longtest.yaml
@@ -1,0 +1,48 @@
+# NOTE: This name appears in GitHub's Checks API and in workflow's status badge.
+name: ci-longtest
+
+# Trigger the workflow when:
+on:
+  # Every day at 00:00 UTC.
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+
+  e2e-rt-long:
+    # NOTE: This name appears in GitHub's Checks API.
+    name: e2e-rt-long
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: "1.16.x"
+
+      - name: Install Oasis dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install bubblewrap build-essential libseccomp-dev libssl-dev protobuf-compiler
+
+      - name: Download artifacts
+        working-directory: tests/
+        run: ./download-artifacts.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run long end-to-end tests
+        run: |
+          ./tests/run-e2e.sh \
+            --e2e/test-runtime-simple-keyvalue.txgen.coins_per_acct=100000 \
+            --e2e/test-runtime-simple-keyvalue.txgen.num_accounts=100 \
+            --e2e/test-runtime-simple-keyvalue.txgen.duration=15m
+        env:
+          TEST_NODE_BINARY: "${{ github.workspace }}/tests/untracked/oasis-node"
+          TEST_RUNTIME_LOADER: "${{ github.workspace}}/tests/untracked/oasis-core-runtime-loader"
+

--- a/tests/consts.sh
+++ b/tests/consts.sh
@@ -1,5 +1,7 @@
 OASIS_CORE_VERSION=21.1-dev
-# To download a pre-released version of oasis-core built by oasis-core/release-dev action
-# set artifact ID to use here.
-# To download a released version of oasis-core unset this variable.
+# To download a pre-released version of oasis-core built by
+# oasis-core/release-dev action, set the artifact ID to use here.
+# You must set GITHUB_TOKEN as well, if it is unset, the release version
+# specified above will be downloaded.
 GITHUB_ARTIFACT=58512799 # 5214f87
+

--- a/tests/download-artifacts.sh
+++ b/tests/download-artifacts.sh
@@ -1,16 +1,21 @@
-#!/bin/sh -eux
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+# Get the configuration from the current working directory.
 . ./consts.sh
 
 mkdir -p untracked
 if [ ! -e "untracked/oasis-node" ]; then
     (
         cd untracked
-        if [ ! -z "${GITHUB_ARTIFACT:-}" ]; then
+        if [ ! -z "${GITHUB_ARTIFACT:-}" ] && [ ! -z "${GITHUB_TOKEN:-}" ]; then
             # Authentication is required to download the artifacts, although those are public.
+            echo "### Downloading github artifact ${GITHUB_ARTIFACT}..."
             curl -fL -o oasis-core.zip -H "Authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/oasisprotocol/oasis-core/actions/artifacts/${GITHUB_ARTIFACT}/zip"
             unzip oasis-core.zip
         else
-            curl -fLO "https://github.com/oasisprotocol/oasis-core/releases/download/v$OASIS_CORE_VERSION/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
+            echo "### Downloading release ${OASIS_CORE_VERSION}..."
+            curl -fLO "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
         fi
 
         tar -xf "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -16,6 +16,7 @@ replace (
 )
 
 require (
+	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/oasisprotocol/oasis-core/go v0.2101.1-0.20210517160830-c287752b61b7
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210328195842-4de788c1c6f7
 	google.golang.org/grpc v1.37.0

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -1,13 +1,22 @@
 package main
 
 import (
+	"time"
+
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/cmd"
 	"github.com/oasisprotocol/oasis-core/go/oasis-test-runner/scenario"
 )
 
+// Transaction generator e2e test option names.
+const (
+	CfgTxGenNumAccounts  = "txgen.num_accounts"
+	CfgTxGenCoinsPerAcct = "txgen.coins_per_acct"
+	CfgTxGenDuration     = "txgen.duration"
+)
+
 var (
 	// SimpleKVRuntime is the basic network + client test case with runtime support.
-	SimpleKVRuntime scenario.Scenario = NewRuntimeScenario("test-runtime-simple-keyvalue", []RunTestFunction{
+	SimpleKVRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-keyvalue", []RunTestFunction{
 		SimpleKVTest,
 		KVEventTest,
 		KVBalanceTest,
@@ -15,15 +24,21 @@ var (
 		KVDaveTest,
 		KVMultisigTest,
 		KVRewardsTest,
+		KVTxGenTest,
 	})
+
 	// SimpleConsensusRuntime is the simple-consensus runtime test.
-	SimpleConsensusRuntime scenario.Scenario = NewRuntimeScenario("test-runtime-simple-consensus", []RunTestFunction{SimpleConsensusTest})
+	SimpleConsensusRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-consensus", []RunTestFunction{SimpleConsensusTest})
 )
 
 // RegisterScenarios registers all oasis-sdk end-to-end runtime tests.
 func RegisterScenarios() error {
 	// Register non-scenario-specific parameters.
 	cmd.RegisterScenarioParams(RuntimeParamsDummy.Name(), RuntimeParamsDummy.Parameters())
+
+	SimpleKVRuntime.Flags.Int(CfgTxGenNumAccounts, 10, "number of accounts to use in txgen test")
+	SimpleKVRuntime.Flags.Uint64(CfgTxGenCoinsPerAcct, 200, "number of coins to allocate to each account in txgen test")
+	SimpleKVRuntime.Flags.Duration(CfgTxGenDuration, 60*time.Second, "duration of txgen test")
 
 	for _, s := range []scenario.Scenario{
 		SimpleKVRuntime,

--- a/tests/e2e/simple_consensus.go
+++ b/tests/e2e/simple_consensus.go
@@ -38,7 +38,7 @@ func ensureStakingEvent(log *logging.Logger, ch <-chan *staking.Event, check fun
 	}
 }
 
-func SimpleConsensusTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	ctx := context.Background()
 
 	cons := consensus.NewConsensusClient(conn)

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -3,12 +3,16 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"google.golang.org/grpc"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/drbg"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/mathrand"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 
@@ -19,10 +23,15 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+	"github.com/oasisprotocol/oasis-sdk/tests/e2e/txgen"
 )
 
 // EventWaitTimeout specifies how long to wait for an event.
 const EventWaitTimeout = 20 * time.Second
+
+// defaultGasAmount is the default amount of gas to specify.
+const defaultGasAmount = 100
 
 // The kvKey type must match the Key type from the simple-keyvalue runtime
 // in ../runtimes/simple-keyvalue/src/keyvalue/types.rs.
@@ -76,7 +85,7 @@ func kvInsert(rtc client.RuntimeClient, signer signature.Signer, key, value []by
 	}
 
 	tx := types.NewTransaction(&types.Fee{
-		Gas: 200,
+		Gas: 2 * defaultGasAmount,
 	}, "keyvalue.Insert", kvKeyValue{
 		Key:   key,
 		Value: value,
@@ -107,7 +116,7 @@ func kvRemove(rtc client.RuntimeClient, signer signature.Signer, key []byte) err
 	}
 
 	tx := types.NewTransaction(&types.Fee{
-		Gas: 100,
+		Gas: defaultGasAmount,
 	}, "keyvalue.Remove", kvKey{
 		Key: key,
 	})
@@ -134,7 +143,8 @@ func kvGet(rtc client.RuntimeClient, key []byte) ([]byte, error) {
 	return resp.Value, nil
 }
 
-func SimpleKVTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+// SimpleKVTest does a simple key insert/fetch/remove test.
+func SimpleKVTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	signer := testing.Alice.Signer
 
 	testKey := []byte("test_key")
@@ -168,7 +178,8 @@ func SimpleKVTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runtime
 	return nil
 }
 
-func KVEventTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+// KVEventTest tests key insert/remove events.
+func KVEventTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	signer := testing.Alice.Signer
 
 	testKey := []byte("event_test_key")
@@ -291,7 +302,8 @@ WaitRemoveLoop:
 	return nil
 }
 
-func KVBalanceTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+// KVBalanceTest checks test accounts' default balances.
+func KVBalanceTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	ctx := context.Background()
 	ac := accounts.NewV1(rtc)
 
@@ -301,8 +313,8 @@ func KVBalanceTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runtim
 		return err
 	}
 	if q, ok := ab.Balances[types.NativeDenomination]; ok {
-		if q.Cmp(quantity.NewFromUint64(3000)) != 0 {
-			return fmt.Errorf("Alice's account balance is wrong (expected 3000, got %s)", q.String()) //nolint: stylecheck
+		if q.Cmp(quantity.NewFromUint64(10003000)) != 0 {
+			return fmt.Errorf("Alice's account balance is wrong (expected 10003000, got %s)", q.String()) //nolint: stylecheck
 		}
 	} else {
 		return fmt.Errorf("Alice's account is missing native denomination balance") //nolint: stylecheck
@@ -350,7 +362,8 @@ func KVBalanceTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runtim
 	return nil
 }
 
-func KVTransferTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error { // nolint: dupl
+// KVTransferTest does a transfer test and verifies balances.
+func KVTransferTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error { // nolint: dupl
 	ctx := context.Background()
 	ac := accounts.NewV1(rtc)
 
@@ -366,7 +379,7 @@ func KVTransferTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runti
 
 	log.Info("transferring 100 units from Alice to Bob")
 	tx := types.NewTransaction(&types.Fee{
-		Gas: 100,
+		Gas: defaultGasAmount,
 	}, "accounts.Transfer", struct {
 		To     types.Address   `json:"to"`
 		Amount types.BaseUnits `json:"amount"`
@@ -390,8 +403,8 @@ func KVTransferTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runti
 		return err
 	}
 	if q, ok := ab.Balances[types.NativeDenomination]; ok {
-		if q.Cmp(quantity.NewFromUint64(2900)) != 0 {
-			return fmt.Errorf("Alice's account balance is wrong (expected 2900, got %s)", q.String()) //nolint: stylecheck
+		if q.Cmp(quantity.NewFromUint64(10002900)) != 0 {
+			return fmt.Errorf("Alice's account balance is wrong (expected 10002900, got %s)", q.String()) //nolint: stylecheck
 		}
 	} else {
 		return fmt.Errorf("Alice's account is missing native denomination balance") //nolint: stylecheck
@@ -413,7 +426,8 @@ func KVTransferTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runti
 	return nil
 }
 
-func KVDaveTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error { // nolint: dupl
+// KVDaveTest does a tx signing test using the secp256k1 signer.
+func KVDaveTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error { // nolint: dupl
 	ctx := context.Background()
 	ac := accounts.NewV1(rtc)
 
@@ -429,7 +443,7 @@ func KVDaveTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeCl
 
 	log.Info("transferring 10 units from Dave to Alice")
 	tx := types.NewTransaction(&types.Fee{
-		Gas: 100,
+		Gas: defaultGasAmount,
 	}, "accounts.Transfer", struct {
 		To     types.Address   `json:"to"`
 		Amount types.BaseUnits `json:"amount"`
@@ -466,7 +480,7 @@ func KVDaveTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeCl
 		return err
 	}
 	if q, ok := ab.Balances[types.NativeDenomination]; ok {
-		if q.Cmp(quantity.NewFromUint64(2910)) != 0 {
+		if q.Cmp(quantity.NewFromUint64(10002910)) != 0 {
 			return fmt.Errorf("Alice's account balance is wrong (expected 2910, got %s)", q.String()) //nolint: stylecheck
 		}
 	} else {
@@ -476,7 +490,7 @@ func KVDaveTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeCl
 	return nil
 }
 
-func KVMultisigTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+func KVMultisigTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	signerA := testing.Alice.Signer
 	signerB := testing.Bob.Signer
 	config := types.MultisigConfig{
@@ -531,7 +545,7 @@ func KVMultisigTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runti
 	return nil
 }
 
-func KVRewardsTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+func KVRewardsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	ctx := context.Background()
 	rw := rewards.NewV1(rtc)
 
@@ -551,5 +565,95 @@ func KVRewardsTest(log *logging.Logger, conn *grpc.ClientConn, rtc client.Runtim
 		return fmt.Errorf("unexpected number of reward schedule steps (expected: %d got: %d)", 1, l)
 	}
 
+	return nil
+}
+
+// KVTxGenTest generates random transactions.
+func KVTxGenTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+	ctx := context.Background()
+	ac := accounts.NewV1(rtc)
+
+	log.Info("getting Alice's account balance")
+	ab, err := ac.Balances(ctx, client.RoundLatest, testing.Alice.Address)
+	if err != nil {
+		return err
+	}
+	var balance uint64
+	if q, ok := ab.Balances[types.NativeDenomination]; ok {
+		// We can do this only because the account's balance fits into an uint64.
+		balance = q.ToBigInt().Uint64()
+	} else {
+		return fmt.Errorf("Alice's account is missing native denomination balance") //nolint: stylecheck
+	}
+
+	testDuration, err := sc.Flags.GetDuration(CfgTxGenDuration)
+	if err != nil {
+		log.Error("malformed CfgTxGenDuration flag, using default")
+		testDuration = 60 * time.Second
+	}
+
+	numAccounts, err := sc.Flags.GetInt(CfgTxGenNumAccounts)
+	if err != nil {
+		log.Error("malformed CfgTxGenNumAccounts flag, using default")
+		numAccounts = 10
+	}
+	coinsPerAccount, err := sc.Flags.GetUint64(CfgTxGenCoinsPerAcct)
+	if err != nil {
+		log.Error("malformed CfgTxGenCoinsPerAcct flag, using default")
+		coinsPerAccount = uint64(200)
+	}
+
+	minBalanceRequired := coinsPerAccount * uint64(numAccounts)
+	if balance < minBalanceRequired {
+		return fmt.Errorf("Alice is too broke to fund accounts (balance is %d, need %d)", balance, minBalanceRequired) //nolint: stylecheck
+	}
+
+	// Create RNG.
+	seed := time.Now().UnixNano()
+	rngSrc, err := drbg.New(crypto.SHA512, []byte(fmt.Sprintf("%d%d%d%d", seed, seed, seed, seed)), nil, []byte("KVTxGenTest1min"))
+	if err != nil {
+		return err
+	}
+	rng := rand.New(mathrand.New(rngSrc)) //nolint: gosec
+
+	// Generate accounts.
+	log.Info("generating accounts", "num_accounts", numAccounts, "coins_per_account", coinsPerAccount, "rng_seed", seed)
+	var accts []signature.Signer
+	numT := make(map[string]uint64)
+	for i := 0; i < numAccounts; i++ {
+		// Create account.
+		at := txgen.AccountType(uint8(rng.Intn(int(txgen.AccountTypeMax) + 1)))
+		numT[at.String()]++
+		sig, grr := txgen.CreateAndFundAccount(ctx, rtc, testing.Alice.Signer, i, at, coinsPerAccount)
+		if grr != nil {
+			return grr
+		}
+
+		accts = append(accts, sig)
+	}
+	log.Info("accounts generated", "num_accts_per_type", numT)
+
+	// Generate random transactions for the specified amount of time.
+	log.Info("generating transactions", "duration", testDuration)
+	txgenCtx, cancel := context.WithTimeout(ctx, testDuration)
+	defer cancel()
+
+	// Generate a new random tx every 250ms until txgenCtx timeouts.
+	gens := append([]txgen.GenerateTx{}, txgen.DefaultTxGenerators...)
+	gens = append(gens, DefaultKVTxGenerators...)
+	genErrs, subErrs, ok, err := txgen.Generate(txgenCtx, rtc, rng, accts, gens, 250*time.Millisecond)
+	if err != nil {
+		return err
+	}
+
+	if ok == 0 {
+		return fmt.Errorf("no generated transactions were submitted successfully")
+	}
+
+	// Note that submission errors are fine here, since we're going to get
+	// invalid nonce errors a lot, because the txs are generated in parallel.
+	// Transaction generation errors are also fine, since queries can fail
+	// due to yet nonexisting keys in the keyvalue storage, etc.
+	log.Info("finished", "num_ok_submitted_txs", ok, "num_gen_errs", genErrs, "num_sub_errs", subErrs)
 	return nil
 }

--- a/tests/e2e/simplekvtest_txgens.go
+++ b/tests/e2e/simplekvtest_txgens.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+	"github.com/oasisprotocol/oasis-sdk/tests/e2e/txgen"
+)
+
+// DefaultKVTxGenerators is the default set of transaction generators for
+// the simple keyvalue runtime.
+var DefaultKVTxGenerators = []txgen.GenerateTx{
+	GenKVInsert1,
+	GenKVInsert2,
+	GenKVGet1,
+	GenKVGet2,
+	GenKVRemove1,
+	GenKVRemove2,
+}
+
+// randBytes is a helper that generates n random bytes for runtime keys and
+// values.  Obviously don't use this for any crypto purposes.
+func randBytes(rng *rand.Rand, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(rng.Intn(256))
+	}
+	return b
+}
+
+// GenKVInsert1 generates an Insert transaction for the keyvalue runtime.
+// The account's public key is used as the key and the value is random.
+func GenKVInsert1(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	return types.NewTransaction(nil, "keyvalue.Insert", kvKeyValue{
+		Key:   []byte(acct.Public().String()),
+		Value: randBytes(rng, 64),
+	}), nil
+}
+
+// GenKVInsert2 generates an Insert transaction for the keyvalue runtime.
+// The key and value are random.
+func GenKVInsert2(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	return types.NewTransaction(nil, "keyvalue.Insert", kvKeyValue{
+		Key:   randBytes(rng, 32),
+		Value: randBytes(rng, 64),
+	}), nil
+}
+
+// GenKVGet1 generates a Get query for the keyvalue runtime.
+// The account's public key is used as the key.
+func GenKVGet1(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	var resp kvKeyValue
+	if err := rtc.Query(ctx, client.RoundLatest, "keyvalue.Get", kvKey{Key: []byte(acct.Public().String())}, &resp); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// GenKVGet2 generates a Get query for the keyvalue runtime.
+// The key is random.
+func GenKVGet2(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	var resp kvKeyValue
+	if err := rtc.Query(ctx, client.RoundLatest, "keyvalue.Get", kvKey{Key: randBytes(rng, 32)}, &resp); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// GenKVRemove1 generates a Remove transaction for the keyvalue runtime.
+// The account's public key is used as the key.
+func GenKVRemove1(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	return types.NewTransaction(nil, "keyvalue.Remove", kvKey{
+		Key: []byte(acct.Public().String()),
+	}), nil
+}
+
+// GenKVRemove2 generates a Remove transaction for the keyvalue runtime.
+// The key is random.
+func GenKVRemove2(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	return types.NewTransaction(nil, "keyvalue.Remove", kvKey{
+		Key: randBytes(rng, 32),
+	}), nil
+}

--- a/tests/e2e/txgen/generators.go
+++ b/tests/e2e/txgen/generators.go
@@ -1,0 +1,62 @@
+package txgen
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+// GenerateTx is a function that generates a random transaction or performs a
+// random query (in which case the returned transaction can be nil).
+type GenerateTx func(context.Context, client.RuntimeClient, *rand.Rand, signature.Signer, []signature.Signer) (*types.Transaction, error)
+
+// DefaultTxGenerators is the default set of transaction generators, which can
+// be used as the txGens argument to Generate().
+var DefaultTxGenerators = []GenerateTx{GenTransfer, GenNonce}
+
+// GenTransfer generates transfer transactions.
+func GenTransfer(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	// First, query account balance.
+	var balance uint64
+	ac := accounts.NewV1(rtc)
+	b, err := ac.Balances(ctx, client.RoundLatest, types.NewAddress(acct.Public()))
+	if err != nil {
+		return nil, err
+	}
+	if q, ok := b.Balances[types.NativeDenomination]; ok {
+		if q.Cmp(quantity.NewFromUint64(1)) != 1 {
+			return nil, fmt.Errorf("account is broke")
+		}
+		balance = q.ToBigInt().Uint64()
+	} else {
+		return nil, fmt.Errorf("account is missing the native denomination balance")
+	}
+
+	// Create a transfer transaction.
+	tx := types.NewTransaction(nil, "accounts.Transfer", struct {
+		To     types.Address   `json:"to"`
+		Amount types.BaseUnits `json:"amount"`
+	}{
+		To:     types.NewAddress(accts[rng.Intn(len(accts))].Public()),
+		Amount: types.NewBaseUnits(*quantity.NewFromUint64(uint64(rng.Int63n(int64(balance)))), types.NativeDenomination),
+	})
+	return tx, nil
+}
+
+// GenNonce just queries the account's nonce.
+func GenNonce(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acct signature.Signer, accts []signature.Signer) (*types.Transaction, error) {
+	// We already have a helper for this, but do it manually here just to
+	// illustrate the concept.
+	var nonce uint64
+	if err := rtc.Query(ctx, client.RoundLatest, "accounts.Nonce", accounts.NonceQuery{Address: types.NewAddress(acct.Public())}, &nonce); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/tests/e2e/txgen/txgen.go
+++ b/tests/e2e/txgen/txgen.go
@@ -1,0 +1,201 @@
+package txgen
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"github.com/btcsuite/btcd/btcec"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	coreMemSig "github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/ed25519"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/secp256k1"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+const highGasAmount = 1000000
+
+// AccountType is the type of account to create.
+type AccountType uint8
+
+// Supported account types.
+const (
+	AccountEd25519   AccountType = 0
+	AccountSecp256k1 AccountType = 1
+	AccountTypeMax               = AccountSecp256k1
+)
+
+func (at AccountType) String() string {
+	return [...]string{"ed25519", "secp256k1"}[at]
+}
+
+// NewClient creates a new runtime client.
+func NewClient(clientNodeUnixSocketPath string, runtimeID common.Namespace) (client.RuntimeClient, error) {
+	conn, err := cmnGrpc.Dial("unix:"+clientNodeUnixSocketPath, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	return client.New(conn, runtimeID), nil
+}
+
+// GetChainContext returns the chain context.
+func GetChainContext(ctx context.Context, rtc client.RuntimeClient) (signature.Context, error) {
+	info, err := rtc.GetInfo(ctx)
+	if err != nil {
+		return "", err
+	}
+	return info.ChainContext, nil
+}
+
+// EstimateGas estimates the amount of gas the transaction will use.
+// Returns modified transaction that has just the right amount of gas.
+func EstimateGas(ctx context.Context, rtc client.RuntimeClient, tx types.Transaction) types.Transaction {
+	var gas uint64
+	oldGas := tx.AuthInfo.Fee.Gas
+	// Set the starting gas to something high, so we don't run out.
+	tx.AuthInfo.Fee.Gas = highGasAmount
+	// Estimate gas usage.
+	if err := rtc.Query(ctx, client.RoundLatest, "core.EstimateGas", tx, &gas); err != nil {
+		tx.AuthInfo.Fee.Gas = oldGas
+		return tx
+	}
+	// Specify only as much gas as was estimated.
+	tx.AuthInfo.Fee.Gas = gas
+	return tx
+}
+
+// SignAndSubmitTx signs and submits the given transaction.
+// Gas estimation is done automatically.
+func SignAndSubmitTx(ctx context.Context, rtc client.RuntimeClient, signer signature.Signer, tx types.Transaction) error {
+	// Get chain context.
+	chainCtx, err := GetChainContext(ctx, rtc)
+	if err != nil {
+		return err
+	}
+
+	// Get current nonce for the signer's account.
+	ac := accounts.NewV1(rtc)
+	nonce, err := ac.Nonce(ctx, client.RoundLatest, types.NewAddress(signer.Public()))
+	if err != nil {
+		return err
+	}
+	tx.AppendAuthSignature(signer.Public(), nonce)
+
+	// Estimate gas.
+	etx := EstimateGas(ctx, rtc, tx)
+
+	// Sign the transaction.
+	stx := etx.PrepareForSigning()
+	if err = stx.AppendSign(chainCtx, signer); err != nil {
+		return err
+	}
+
+	// Submit the signed transaction.
+	if _, err = rtc.SubmitTx(ctx, stx.UnverifiedTransaction()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateAndFundAccount creates a new account and funds it using the
+// given funding account.
+func CreateAndFundAccount(ctx context.Context, rtc client.RuntimeClient, funder signature.Signer, id int, acctType AccountType, fundAmount uint64) (signature.Signer, error) {
+	// Create new account.
+	var sig signature.Signer
+	switch acctType {
+	case AccountEd25519:
+		cs := coreMemSig.NewTestSigner(fmt.Sprintf("test account %d", id))
+		sig = ed25519.WrapSigner(cs)
+	case AccountSecp256k1:
+		pk, err := btcec.NewPrivateKey(btcec.S256())
+		if err != nil {
+			return nil, err
+		}
+		sig = secp256k1.NewSigner(pk.Serialize())
+	default:
+		return nil, fmt.Errorf("invalid account type")
+	}
+
+	// Give it some coins.
+	tx := types.NewTransaction(nil, "accounts.Transfer", struct {
+		To     types.Address   `json:"to"`
+		Amount types.BaseUnits `json:"amount"`
+	}{
+		To:     types.NewAddress(sig.Public()),
+		Amount: types.NewBaseUnits(*quantity.NewFromUint64(fundAmount), types.NativeDenomination),
+	})
+	if err := SignAndSubmitTx(ctx, rtc, funder, *tx); err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}
+
+// Generate generates and submits a random transaction for the given accounts
+// every txDelay seconds until the context is terminated.
+func Generate(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, accounts []signature.Signer, txGens []GenerateTx, txDelay time.Duration) (uint64, uint64, uint64, error) {
+	if len(txGens) == 0 {
+		return 0, 0, 0, fmt.Errorf("no transaction generators specified")
+	}
+
+	if len(accounts) == 0 {
+		return 0, 0, 0, fmt.Errorf("no accounts specified")
+	}
+
+	if txDelay.Milliseconds() < 100 {
+		return 0, 0, 0, fmt.Errorf("tx delay is too small")
+	}
+
+	ticker := time.NewTicker(txDelay)
+	defer ticker.Stop()
+
+	var (
+		genErrCount uint64
+		subErrCount uint64
+		okCount     uint64
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return genErrCount, subErrCount, okCount, nil
+		case <-ticker.C:
+			// Choose random account and txn generator.
+			acct := accounts[rng.Intn(len(accounts))]
+			gen := txGens[rng.Intn(len(txGens))]
+
+			go func(acct signature.Signer, gen GenerateTx) {
+				// Generate random transaction or perform random query.
+				if tx, err := gen(ctx, rtc, rng, acct, accounts); err != nil {
+					atomic.AddUint64(&genErrCount, 1)
+				} else {
+					// The tx generator can choose not to generate a tx
+					// (e.g. if it's only testing queries), so count this case
+					// as a success.
+					if tx == nil {
+						atomic.AddUint64(&okCount, 1)
+						return
+					}
+
+					// Sign and submit the generated transaction.
+					if err = SignAndSubmitTx(ctx, rtc, acct, *tx); err != nil {
+						atomic.AddUint64(&subErrCount, 1)
+					} else {
+						atomic.AddUint64(&okCount, 1)
+					}
+				}
+			}(acct, gen)
+		}
+	}
+}

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -46,7 +46,7 @@ impl sdk::Runtime for Runtime {
                     // Alice.
                     b.insert(sdk::testing::keys::alice::address(), {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 3_000.into());
+                        d.insert(Denomination::NATIVE, 10_003_000.into());
                         d
                     });
                     // Bob.
@@ -77,7 +77,7 @@ impl sdk::Runtime for Runtime {
                 },
                 total_supplies: {
                     let mut ts = BTreeMap::new();
-                    ts.insert(Denomination::NATIVE, 16_100.into());
+                    ts.insert(Denomination::NATIVE, 10_016_100.into());
                     ts
                 },
                 ..Default::default()


### PR DESCRIPTION
Closes #50.

This PR adds a reusable random transaction generator to the e2e tests.

Currently, an e2e test uses the transaction generator to generate random transactions and queries for the `simple-keyvalue` runtime (including transfers between accounts) for 1 minute and then stops.
A separate long-term test that generates random transactions and queries for 15 minutes is scheduled to run once per day at midnight UTC.