### PR TITLE
runtime-sdk: remove removed const_fn feature

### DIFF
--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -1,5 +1,4 @@
 //! Oasis runtime SDK.
-#![feature(const_fn)]
 #![deny(rust_2018_idioms, unreachable_pub)]
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
This PR removes the `const_fn` feature that breaks downstream compilation.

```
error[E0557]: feature has been removed
 --> ~/.cargo/git/checkouts/oasis-sdk-c51e681916015383/a26ce5a/runtime-sdk/src/lib.rs:2:12
  |
2 | #![feature(const_fn)]
  |            ^^^^^^^^ feature has been removed
  |
  = note: split into finer-grained feature gates
```