### PR TITLE
runtime-sdk: actually call the approve_unverified_tx step

### DIFF
--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -168,6 +168,14 @@ pub trait AuthHandler {
 
 #[impl_for_tuples(30)]
 impl AuthHandler for Tuple {
+    fn approve_unverified_tx(
+        ctx: &mut DispatchContext<'_>,
+        utx: &UnverifiedTransaction,
+    ) -> Result<(), modules::core::Error> {
+        for_tuples!( #( Tuple::approve_unverified_tx(ctx, utx)?; )* );
+        Ok(())
+    }
+
     fn authenticate_tx(
         ctx: &mut DispatchContext<'_>,
         tx: &Transaction,

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -8,6 +8,8 @@ use oasis_runtime_sdk::{
 };
 
 pub mod keyvalue;
+#[cfg(test)]
+mod test;
 
 /// Simple keyvalue runtime.
 pub struct Runtime;

--- a/tests/runtimes/simple-keyvalue/src/test.rs
+++ b/tests/runtimes/simple-keyvalue/src/test.rs
@@ -1,0 +1,33 @@
+use oasis_runtime_sdk::{
+    module::AuthHandler as _,
+    modules::{core, core::Module as Core},
+    testing::mock,
+    types::transaction,
+    Context as _, Module as _,
+};
+
+#[test]
+fn test_impl_for_tuple() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+    Core::set_params(
+        ctx.runtime_state(),
+        &core::Parameters {
+            max_batch_gas: u64::MAX,
+            max_tx_signers: 1,
+            max_multisig_signers: 1,
+        },
+    );
+    let dummy_bytes = b"you look, you die".to_vec();
+    <super::Runtime as oasis_runtime_sdk::Runtime>::Modules::approve_unverified_tx(
+        &mut ctx,
+        &transaction::UnverifiedTransaction(
+            dummy_bytes.clone(),
+            vec![
+                transaction::AuthProof::Signature(dummy_bytes.clone().into()),
+                transaction::AuthProof::Signature(dummy_bytes.clone().into()),
+            ],
+        ),
+    )
+    .expect_err("too many authentication slots");
+}


### PR DESCRIPTION
those default implementations are silent but deadly :facepalm: 