### PR TITLE
runtime-sdk: pass dispatcher to method handlers

### DIFF
--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+const (
+	methodEstimateGas = "core.EstimateGas"
+)
+
+type V1 interface {
+	EstimateGas(ctx context.Context, round uint64, tx *types.Transaction) (uint64, error)
+}
+
+type v1 struct {
+	rc client.RuntimeClient
+}
+
+// Implements V1.
+func (a *v1) EstimateGas(ctx context.Context, round uint64, tx *types.Transaction) (uint64, error) {
+	var gas uint64
+	err := a.rc.Query(ctx, round, methodEstimateGas, tx, &gas)
+	if err != nil {
+		return 0, err
+	}
+	return gas, nil
+}
+
+func NewV1(rc client.RuntimeClient) V1 {
+	return &v1{rc: rc}
+}

--- a/runtime-sdk/src/context.rs
+++ b/runtime-sdk/src/context.rs
@@ -15,7 +15,6 @@ use oasis_core_runtime::{
 
 use crate::{
     event::Event,
-    module::MethodRegistry,
     modules::core::Error,
     storage,
     types::{address::Address, message::MessageEventHookInvocation, transaction},
@@ -172,9 +171,6 @@ pub struct DispatchContext<'a> {
     pub(crate) io_ctx: Arc<IoContext>,
     pub(crate) logger: slog::Logger,
 
-    /// The runtime's methods, in case you need to look them up for some reason.
-    pub(crate) methods: &'a MethodRegistry,
-
     pub(crate) block_tags: Tags,
 
     /// Maximum number of messages that can be emitted.
@@ -188,11 +184,7 @@ pub struct DispatchContext<'a> {
 
 impl<'a> DispatchContext<'a> {
     /// Create a new dispatch context from the low-level runtime context.
-    pub(crate) fn from_runtime(
-        ctx: &'a RuntimeContext<'_>,
-        mkvs: &'a mut dyn mkvs::MKVS,
-        methods: &'a MethodRegistry,
-    ) -> Self {
+    pub(crate) fn from_runtime(ctx: &'a RuntimeContext<'_>, mkvs: &'a mut dyn mkvs::MKVS) -> Self {
         let mode = if ctx.check_only {
             Mode::CheckTx
         } else {
@@ -208,7 +200,6 @@ impl<'a> DispatchContext<'a> {
             io_ctx: ctx.io_ctx.clone(),
             logger: get_logger("runtime-sdk")
                 .new(o!("ctx" => "dispatch", "mode" => Into::<&'static str>::into(&mode))),
-            methods,
             block_tags: Tags::new(),
             max_messages: ctx.max_messages,
             messages: Vec::new(),

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -64,7 +64,7 @@ impl From<types::transaction::CallResult> for DispatchResult {
 
 pub struct Dispatcher<R: Runtime> {
     /// Method registry.
-    methods: MethodRegistry,
+    methods: MethodRegistry<R>,
     /// Handlers registered for consensus messages.
     consensus_message_handlers: MessageHandlerRegistry,
 
@@ -73,7 +73,7 @@ pub struct Dispatcher<R: Runtime> {
 
 impl<R: Runtime> Dispatcher<R> {
     pub(super) fn new(
-        methods: MethodRegistry,
+        methods: MethodRegistry<R>,
         consensus_message_handlers: MessageHandlerRegistry,
     ) -> Self {
         Self {
@@ -394,7 +394,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
                 .methods
                 .lookup_query(method)
                 .ok_or(modules::core::Error::InvalidMethod)?;
-            (method_info.handler)(&method_info, &mut ctx, args)
+            (method_info.handler)(&method_info, &mut ctx, self, args)
         })
     }
 }

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -105,11 +105,11 @@ impl<R: Runtime> Dispatcher<R> {
 
     fn dispatch_call(
         &self,
-        mut ctx: &mut TxContext<'_, '_>,
+        ctx: &mut TxContext<'_, '_>,
         call: types::transaction::Call,
     ) -> types::transaction::CallResult {
         // Use up gas for authenticating the transaction.
-        if let Err(e) = modules::core::Module::use_gas_for_auth(&mut ctx) {
+        if let Err(e) = modules::core::Module::use_gas_for_auth(ctx) {
             return e.to_call_result();
         }
 
@@ -122,7 +122,7 @@ impl<R: Runtime> Dispatcher<R> {
             }
         };
 
-        (method_info.handler)(&method_info, &mut ctx, call.body)
+        (method_info.handler)(&method_info, ctx, call.body)
     }
 
     fn estimate_gas(
@@ -227,7 +227,7 @@ impl<R: Runtime> Dispatcher<R> {
 
     fn dispatch_message(
         &self,
-        mut ctx: &mut DispatchContext<'_>,
+        ctx: &mut DispatchContext<'_>,
         handler_name: String,
         message_event: MessageEvent,
         handler_ctx: cbor::Value,
@@ -238,7 +238,7 @@ impl<R: Runtime> Dispatcher<R> {
             .lookup_handler(&handler_name)
             .ok_or(modules::core::Error::InvalidMethod)?;
 
-        (method_info.handler)(&method_info, &mut ctx, message_event, handler_ctx);
+        (method_info.handler)(&method_info, ctx, message_event, handler_ctx);
 
         Ok(())
     }

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -23,10 +23,11 @@ use oasis_core_runtime::{
 };
 
 use crate::{
-    context::{Context, DispatchContext},
+    context::{Context, DispatchContext, TxContext},
     error::{Error as _, RuntimeError},
     module::{AuthHandler, BlockHandler, MessageHandlerRegistry, MethodRegistry},
     modules,
+    modules::core::API as _,
     runtime::Runtime,
     storage, types,
 };
@@ -102,6 +103,41 @@ impl<R: Runtime> Dispatcher<R> {
             .map_err(|_| modules::core::Error::MalformedTransaction)
     }
 
+    fn dispatch_call(
+        &self,
+        mut ctx: &mut TxContext<'_, '_>,
+        call: types::transaction::Call,
+    ) -> types::transaction::CallResult {
+        // Use up gas for authenticating the transaction.
+        if let Err(e) = modules::core::Module::use_gas_for_auth(&mut ctx) {
+            return e.to_call_result();
+        }
+
+        // Perform transaction method lookup.
+        let method_info = match self.methods.lookup_callable(&call.method) {
+            Some(method_info) => method_info,
+            None => {
+                // Method not found.
+                return modules::core::Error::InvalidMethod.to_call_result();
+            }
+        };
+
+        (method_info.handler)(&method_info, &mut ctx, call.body)
+    }
+
+    fn estimate_gas(
+        &self,
+        ctx: &mut DispatchContext<'_>,
+        tx: types::transaction::Transaction,
+    ) -> Result<u64, modules::core::Error> {
+        ctx.with_tx_simulation(tx, |mut tx_ctx, call| {
+            self.dispatch_call(&mut tx_ctx, call);
+            // Warning: we don't report success or failure. If the call fails, we still report
+            // how much gas it uses while it fails.
+            Ok(modules::core::Module::tx_gas_used(&mut tx_ctx))
+        })
+    }
+
     fn dispatch_tx(
         &self,
         ctx: &mut DispatchContext<'_>,
@@ -112,17 +148,8 @@ impl<R: Runtime> Dispatcher<R> {
             return Ok(err.to_call_result().into());
         }
 
-        // Perform transaction method lookup.
-        let method_info = match self.methods.lookup_callable(&tx.call.method) {
-            Some(method_info) => method_info,
-            None => {
-                // Method not found.
-                return Ok(modules::core::Error::InvalidMethod.to_call_result().into());
-            }
-        };
-
         let (result, messages) = ctx.with_tx(tx, |mut ctx, call| {
-            let result = (method_info.handler)(&method_info, &mut ctx, call.body);
+            let result = self.dispatch_call(&mut ctx, call);
             if !result.is_success() {
                 return (result.into(), Vec::new());
             }
@@ -277,7 +304,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
-            let mut ctx = DispatchContext::from_runtime(&rt_ctx, mkvs, &self.methods);
+            let mut ctx = DispatchContext::from_runtime(&rt_ctx, mkvs);
             // Perform state migrations if required.
             self.maybe_init_state(&mut ctx);
 
@@ -319,7 +346,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
-            let mut ctx = DispatchContext::from_runtime(&ctx, mkvs, &self.methods);
+            let mut ctx = DispatchContext::from_runtime(&ctx, mkvs);
             // Perform state migrations if required.
             self.maybe_init_state(&mut ctx);
 
@@ -346,9 +373,24 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
-            let mut ctx = DispatchContext::from_runtime(&ctx, mkvs, &self.methods);
+            let mut ctx = DispatchContext::from_runtime(&ctx, mkvs);
             // Perform state migrations if required.
             self.maybe_init_state(&mut ctx);
+
+            match method {
+                "core.EstimateGas" => {
+                    // Run a transaction in simulation and return how much gas it uses. This looks up the method
+                    // in the context's method registry. Transactions that fail still use gas, and this query will
+                    // estimate that and return successfully, so do not use this query to see if a transaction will
+                    // succeed. Failure due to OutOfGas are included, so it's best to set the query argument
+                    // transaction's gas to something high.
+                    let tx = cbor::from_value(args)
+                        .map_err(|_| modules::core::Error::InvalidArgument)?;
+                    let gas = self.estimate_gas(&mut ctx, tx)?;
+                    return Ok(cbor::to_value(gas));
+                }
+                _ => {}
+            }
 
             // Execute the query.
             let method_info = self
@@ -357,5 +399,104 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
                 .ok_or(modules::core::Error::InvalidMethod)?;
             (method_info.handler)(&method_info, &mut ctx, args)
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oasis_core_runtime::common::cbor;
+
+    use crate::{
+        context,
+        crypto::multisig,
+        module,
+        modules::core::{self, Module as Core, API as _},
+        testing::{keys, mock},
+        types::{token, transaction},
+        Runtime, Version,
+    };
+
+    use super::Dispatcher;
+
+    const AUTH_SIGNATURE_GAS: u64 = 1;
+    const AUTH_MULTISIG_GAS: u64 = 10;
+    const CALL_GAS: u64 = 100;
+
+    struct Runtime1;
+
+    impl Runtime for Runtime1 {
+        const VERSION: Version = Version {
+            major: 1,
+            minor: 0,
+            patch: 0,
+        };
+        type Modules = (Core,);
+
+        fn genesis_state() -> (core::Genesis,) {
+            (core::Genesis {
+                parameters: core::Parameters {
+                    max_batch_gas: u64::MAX,
+                    max_tx_signers: 8,
+                    max_multisig_signers: 8,
+                    gas_costs: core::GasCosts {
+                        auth_signature: AUTH_SIGNATURE_GAS,
+                        auth_multisig_signer: AUTH_MULTISIG_GAS,
+                    },
+                },
+            },)
+        }
+    }
+
+    #[test]
+    fn test_query_estimate_gas() {
+        const METHOD_WASTE_GAS: &str = "test.WasteGas";
+        let mut methods = module::MethodRegistry::new();
+        methods.register_callable(module::CallableMethodInfo {
+            name: METHOD_WASTE_GAS,
+            handler: |_mi, ctx, _args| {
+                Core::use_gas(ctx, CALL_GAS).expect("use_gas should succeed");
+                transaction::CallResult::Ok(cbor::Value::Null)
+            },
+        });
+        let consensus_message_handlers = module::MessageHandlerRegistry::new();
+        let dispatcher = Dispatcher::<Runtime1>::new(methods, consensus_message_handlers);
+
+        let mut mock = mock::Mock::default();
+        let mut ctx = mock.create_ctx();
+        ctx.mode = context::Mode::CheckTx;
+        dispatcher.maybe_init_state(&mut ctx);
+
+        let tx = transaction::Transaction {
+            version: 1,
+            call: transaction::Call {
+                method: METHOD_WASTE_GAS.to_owned(),
+                body: cbor::Value::Null,
+            },
+            auth_info: transaction::AuthInfo {
+                signer_info: vec![
+                    transaction::SignerInfo::new(keys::alice::pk(), 0),
+                    transaction::SignerInfo::new_multisig(
+                        multisig::Config {
+                            signers: vec![multisig::Signer {
+                                public_key: keys::bob::pk(),
+                                weight: 1,
+                            }],
+                            threshold: 1,
+                        },
+                        0,
+                    ),
+                ],
+                fee: transaction::Fee {
+                    amount: token::BaseUnits::new(0.into(), token::Denomination::NATIVE),
+                    gas: u64::MAX,
+                },
+            },
+        };
+
+        let est = dispatcher
+            .estimate_gas(&mut ctx, tx)
+            .expect("estimate_gas should succeed");
+        let reference_gas = AUTH_SIGNATURE_GAS + AUTH_MULTISIG_GAS + CALL_GAS;
+        assert_eq!(est, reference_gas, "estimated gas should be correct");
     }
 }

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -377,19 +377,16 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
             // Perform state migrations if required.
             self.maybe_init_state(&mut ctx);
 
-            match method {
-                "core.EstimateGas" => {
-                    // Run a transaction in simulation and return how much gas it uses. This looks up the method
-                    // in the context's method registry. Transactions that fail still use gas, and this query will
-                    // estimate that and return successfully, so do not use this query to see if a transaction will
-                    // succeed. Failure due to OutOfGas are included, so it's best to set the query argument
-                    // transaction's gas to something high.
-                    let tx = cbor::from_value(args)
-                        .map_err(|_| modules::core::Error::InvalidArgument)?;
-                    let gas = self.estimate_gas(&mut ctx, tx)?;
-                    return Ok(cbor::to_value(gas));
-                }
-                _ => {}
+            if method == "core.EstimateGas" {
+                // Run a transaction in simulation and return how much gas it uses. This looks up the method
+                // in the context's method registry. Transactions that fail still use gas, and this query will
+                // estimate that and return successfully, so do not use this query to see if a transaction will
+                // succeed. Failure due to OutOfGas are included, so it's best to set the query argument
+                // transaction's gas to something high.
+                let tx =
+                    cbor::from_value(args).map_err(|_| modules::core::Error::InvalidArgument)?;
+                let gas = self.estimate_gas(&mut ctx, tx)?;
+                return Ok(cbor::to_value(gas));
             }
 
             // Execute the query.

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -12,7 +12,7 @@ use crate::{
     storage::Store,
     types::{
         message::MessageEvent,
-        transaction::{CallResult, Transaction, UnverifiedTransaction},
+        transaction::{Call, CallResult, Transaction, UnverifiedTransaction},
     },
 };
 
@@ -165,6 +165,15 @@ pub trait AuthHandler {
         // Default implementation doesn't do any checks.
         Ok(())
     }
+
+    /// Perform any action after authentication, within the transaction context.
+    fn before_handle_call(
+        _ctx: &mut TxContext<'_, '_>,
+        _call: &Call,
+    ) -> Result<(), modules::core::Error> {
+        // Default implementation doesn't do anything.
+        Ok(())
+    }
 }
 
 #[impl_for_tuples(30)]
@@ -182,6 +191,14 @@ impl AuthHandler for Tuple {
         tx: &Transaction,
     ) -> Result<(), modules::core::Error> {
         for_tuples!( #( Tuple::authenticate_tx(ctx, tx)?; )* );
+        Ok(())
+    }
+
+    fn before_handle_call(
+        ctx: &mut TxContext<'_, '_>,
+        call: &Call,
+    ) -> Result<(), modules::core::Error> {
+        for_tuples!( #( Tuple::before_handle_call(ctx, call)?; )* );
         Ok(())
     }
 }

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -16,14 +16,24 @@ use crate::{
     },
 };
 
+type CallableMethodHandler =
+    fn(&CallableMethodInfo, &mut TxContext<'_, '_>, cbor::Value) -> CallResult;
+
 /// Metadata of a callable method.
 pub struct CallableMethodInfo {
     /// Method name.
     pub name: &'static str,
 
     /// Method handler function.
-    pub handler: fn(&CallableMethodInfo, &mut TxContext<'_, '_>, cbor::Value) -> CallResult,
+    pub handler: CallableMethodHandler,
 }
+
+type QueryMethodHandler<R> = fn(
+    &QueryMethodInfo<R>,
+    &mut DispatchContext<'_>,
+    &dispatcher::Dispatcher<R>,
+    cbor::Value,
+) -> Result<cbor::Value, error::RuntimeError>;
 
 /// Metadata of a query method.
 pub struct QueryMethodInfo<R: runtime::Runtime> {
@@ -31,12 +41,7 @@ pub struct QueryMethodInfo<R: runtime::Runtime> {
     pub name: &'static str,
 
     /// Method handler function.
-    pub handler: fn(
-        &QueryMethodInfo<R>,
-        &mut DispatchContext<'_>,
-        &dispatcher::Dispatcher<R>,
-        cbor::Value,
-    ) -> Result<cbor::Value, error::RuntimeError>,
+    pub handler: QueryMethodHandler<R>,
 }
 
 /// Registry of methods exposed by the modules.

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -11,12 +11,13 @@ use oasis_core_runtime::common::cbor;
 use crate::{
     context::{Context, DispatchContext, TxContext},
     crypto::signature::PublicKey,
+    dispatcher,
     error::{self, Error as _},
     module,
     module::{CallableMethodInfo, Module as _, QueryMethodInfo},
     modules,
     modules::core::{Module as Core, API as _},
-    storage,
+    runtime, storage,
     types::{
         address::Address,
         token,
@@ -381,18 +382,20 @@ impl Module {
         }
     }
 
-    fn _query_nonce_handler(
-        _mi: &QueryMethodInfo,
+    fn _query_nonce_handler<R: runtime::Runtime>(
+        _mi: &QueryMethodInfo<R>,
         ctx: &mut DispatchContext<'_>,
+        _dispatcher: &dispatcher::Dispatcher<R>,
         args: cbor::Value,
     ) -> Result<cbor::Value, error::RuntimeError> {
         let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
         Ok(cbor::to_value(&Self::query_nonce(ctx, args)?))
     }
 
-    fn _query_balances_handler(
-        _mi: &QueryMethodInfo,
+    fn _query_balances_handler<R: runtime::Runtime>(
+        _mi: &QueryMethodInfo<R>,
         ctx: &mut DispatchContext<'_>,
+        _dispatcher: &dispatcher::Dispatcher<R>,
         args: cbor::Value,
     ) -> Result<cbor::Value, error::RuntimeError> {
         let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
@@ -410,7 +413,7 @@ impl module::Module for Module {
 impl module::MessageHookRegistrationHandler for Module {}
 
 impl module::MethodRegistrationHandler for Module {
-    fn register_methods(methods: &mut module::MethodRegistry) {
+    fn register_methods<R: runtime::Runtime>(methods: &mut module::MethodRegistry<R>) {
         // Callable methods.
         methods.register_callable(module::CallableMethodInfo {
             name: "accounts.Transfer",

--- a/runtime-sdk/src/modules/consensus_accounts/mod.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/mod.rs
@@ -9,11 +9,13 @@ use oasis_core_runtime::{common::cbor, consensus::staking::Account as ConsensusA
 
 use crate::{
     context::{Context, DispatchContext, TxContext},
+    dispatcher,
     error::{self, Error as _},
     module,
     module::{CallableMethodInfo, Module as _, QueryMethodInfo},
     modules,
     modules::core::{Module as Core, API as _},
+    runtime,
     types::{
         address::Address,
         message::{MessageEvent, MessageEventHookInvocation},
@@ -279,18 +281,20 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
         }
     }
 
-    fn _query_balance_handler(
-        _mi: &QueryMethodInfo,
+    fn _query_balance_handler<R: runtime::Runtime>(
+        _mi: &QueryMethodInfo<R>,
         ctx: &mut DispatchContext<'_>,
+        _dispatcher: &dispatcher::Dispatcher<R>,
         args: cbor::Value,
     ) -> Result<cbor::Value, error::RuntimeError> {
         let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
         Ok(cbor::to_value(&Self::query_balance(ctx, args)?))
     }
 
-    fn _query_consensus_account_handler(
-        _mi: &QueryMethodInfo,
+    fn _query_consensus_account_handler<R: runtime::Runtime>(
+        _mi: &QueryMethodInfo<R>,
         ctx: &mut DispatchContext<'_>,
+        _dispatcher: &dispatcher::Dispatcher<R>,
         args: cbor::Value,
     ) -> Result<cbor::Value, error::RuntimeError> {
         let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
@@ -312,7 +316,7 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API> modul
 impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
     module::MethodRegistrationHandler for Module<Accounts, Consensus>
 {
-    fn register_methods(methods: &mut module::MethodRegistry) {
+    fn register_methods<R: runtime::Runtime>(methods: &mut module::MethodRegistry<R>) {
         // Callable methods.
         methods.register_callable(module::CallableMethodInfo {
             name: "consensus.Deposit",

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -22,6 +22,7 @@ fn test_use_gas() {
             max_batch_gas: BLOCK_MAX_GAS,
             max_tx_signers: 8,
             max_multisig_signers: 8,
+            gas_costs: Default::default(),
         },
     );
 
@@ -82,6 +83,7 @@ fn test_query_estimate_gas() {
             max_batch_gas: u64::MAX,
             max_tx_signers: 8,
             max_multisig_signers: 8,
+            gas_costs: Default::default(),
         },
     );
 
@@ -114,6 +116,7 @@ fn test_approve_unverified_tx() {
             max_batch_gas: u64::MAX,
             max_tx_signers: 2,
             max_multisig_signers: 2,
+            gas_costs: Default::default(),
         },
     );
     let dummy_bytes = b"you look, you die".to_vec();

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -1,11 +1,17 @@
+use oasis_core_runtime::common::{cbor, version};
+
 use crate::{
+    context,
     context::Context,
+    crypto::multisig,
+    dispatcher, module,
     module::{AuthHandler as _, Module as _},
-    testing::mock,
-    types::transaction,
+    runtime,
+    testing::{keys, mock},
+    types::{token, transaction},
 };
 
-use super::{Module as Core, API as _};
+use super::{GasCosts, Genesis, Module as Core, Parameters, API as _};
 
 #[test]
 fn test_use_gas() {
@@ -58,6 +64,87 @@ fn test_use_gas() {
     });
 
     Core::use_gas(&mut ctx, 1).expect_err("batch gas should accumulate outside tx");
+}
+
+const AUTH_SIGNATURE_GAS: u64 = 1;
+const AUTH_MULTISIG_GAS: u64 = 10;
+const CALL_GAS: u64 = 100;
+
+struct Runtime1;
+
+impl runtime::Runtime for Runtime1 {
+    const VERSION: version::Version = version::Version {
+        major: 1,
+        minor: 0,
+        patch: 0,
+    };
+    type Modules = (Core,);
+
+    fn genesis_state() -> (Genesis,) {
+        (Genesis {
+            parameters: Parameters {
+                max_batch_gas: u64::MAX,
+                max_tx_signers: 8,
+                max_multisig_signers: 8,
+                gas_costs: GasCosts {
+                    auth_signature: AUTH_SIGNATURE_GAS,
+                    auth_multisig_signer: AUTH_MULTISIG_GAS,
+                },
+            },
+        },)
+    }
+}
+
+#[test]
+fn test_query_estimate_gas() {
+    const METHOD_WASTE_GAS: &str = "test.WasteGas";
+    let mut methods = module::MethodRegistry::new();
+    methods.register_callable(module::CallableMethodInfo {
+        name: METHOD_WASTE_GAS,
+        handler: |_mi, ctx, _args| {
+            Core::use_gas(ctx, CALL_GAS).expect("use_gas should succeed");
+            transaction::CallResult::Ok(cbor::Value::Null)
+        },
+    });
+    let consensus_message_handlers = module::MessageHandlerRegistry::new();
+    let dispatcher = dispatcher::Dispatcher::<Runtime1>::new(methods, consensus_message_handlers);
+
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+    ctx.mode = context::Mode::CheckTx;
+    dispatcher.maybe_init_state(&mut ctx);
+
+    let tx = transaction::Transaction {
+        version: 1,
+        call: transaction::Call {
+            method: METHOD_WASTE_GAS.to_owned(),
+            body: cbor::Value::Null,
+        },
+        auth_info: transaction::AuthInfo {
+            signer_info: vec![
+                transaction::SignerInfo::new(keys::alice::pk(), 0),
+                transaction::SignerInfo::new_multisig(
+                    multisig::Config {
+                        signers: vec![multisig::Signer {
+                            public_key: keys::bob::pk(),
+                            weight: 1,
+                        }],
+                        threshold: 1,
+                    },
+                    0,
+                ),
+            ],
+            fee: transaction::Fee {
+                amount: token::BaseUnits::new(0.into(), token::Denomination::NATIVE),
+                gas: u64::MAX,
+            },
+        },
+    };
+
+    let est =
+        Core::query_estimate_gas(&mut ctx, &dispatcher, tx).expect("estimate_gas should succeed");
+    let reference_gas = AUTH_SIGNATURE_GAS + AUTH_MULTISIG_GAS + CALL_GAS;
+    assert_eq!(est, reference_gas, "estimated gas should be correct");
 }
 
 #[test]

--- a/runtime-sdk/src/modules/rewards/mod.rs
+++ b/runtime-sdk/src/modules/rewards/mod.rs
@@ -10,9 +10,9 @@ use crate::{
     context::{Context, DispatchContext},
     core::{common::cbor, consensus::beacon},
     crypto::signature::PublicKey,
-    error,
+    dispatcher, error,
     module::{self, Module as _, Parameters as _, QueryMethodInfo},
-    modules, storage,
+    modules, runtime, storage,
     types::address::Address,
 };
 
@@ -102,9 +102,10 @@ impl<Accounts: modules::accounts::API> Module<Accounts> {
 }
 
 impl<Accounts: modules::accounts::API> Module<Accounts> {
-    fn _query_parameters_handler(
-        _mi: &QueryMethodInfo,
+    fn _query_parameters_handler<R: runtime::Runtime>(
+        _mi: &QueryMethodInfo<R>,
         ctx: &mut DispatchContext<'_>,
+        _dispatcher: &dispatcher::Dispatcher<R>,
         args: cbor::Value,
     ) -> Result<cbor::Value, error::RuntimeError> {
         let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
@@ -122,7 +123,7 @@ impl<Accounts: modules::accounts::API> module::Module for Module<Accounts> {
 impl<Accounts: modules::accounts::API> module::MessageHookRegistrationHandler for Module<Accounts> {}
 
 impl<Accounts: modules::accounts::API> module::MethodRegistrationHandler for Module<Accounts> {
-    fn register_methods(methods: &mut module::MethodRegistry) {
+    fn register_methods<R: runtime::Runtime>(methods: &mut module::MethodRegistry<R>) {
         // Queries.
         methods.register_query(module::QueryMethodInfo {
             name: "rewards.Parameters",

--- a/runtime-sdk/src/testing/mock.rs
+++ b/runtime-sdk/src/testing/mock.rs
@@ -12,7 +12,6 @@ use oasis_core_runtime::{
 
 use crate::{
     context::{DispatchContext, Mode},
-    module::MethodRegistry,
     storage,
     types::transaction,
 };
@@ -24,8 +23,6 @@ pub struct Mock {
     pub mkvs: Box<dyn mkvs::MKVS>,
     pub consensus_state: ConsensusState,
     pub epoch: beacon::EpochTime,
-
-    pub methods: MethodRegistry,
 
     pub max_messages: u32,
 }
@@ -44,7 +41,6 @@ impl Mock {
             consensus_state: &self.consensus_state,
             epoch: self.epoch,
             io_ctx: IoContext::background().freeze(),
-            methods: &self.methods,
             logger: get_logger("mock"),
             block_tags: Tags::new(),
             messages: Vec::new(),
@@ -71,7 +67,6 @@ impl Default for Mock {
             mkvs: Box::new(mkvs),
             consensus_state: ConsensusState::new(consensus_tree),
             epoch: 1,
-            methods: MethodRegistry::new(),
             max_messages: 32,
         }
     }

--- a/runtime-sdk/src/types/transaction.rs
+++ b/runtime-sdk/src/types/transaction.rs
@@ -190,6 +190,14 @@ impl SignerInfo {
             nonce,
         }
     }
+
+    /// Create a new signer info from a multisig configuration and a nonce.
+    pub fn new_multisig(config: multisig::Config, nonce: u64) -> Self {
+        Self {
+            address_spec: AddressSpec::Multisig(config),
+            nonce,
+        }
+    }
 }
 
 /// Call result.

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -18,12 +18,9 @@ impl sdk::Runtime for Runtime {
             Default::default(),
             modules::consensus_accounts::Genesis {
                 parameters: modules::consensus_accounts::Parameters {
-                    gas_costs: modules::consensus_accounts::GasCosts {
-                        // These are free, in order to simplify testing. We do test gas accounting
-                        // with other methods elsewhere though.
-                        tx_deposit: 0,
-                        tx_withdraw: 0,
-                    },
+                    // These are free, in order to simplify testing. We do test gas accounting
+                    // with other methods elsewhere though.
+                    gas_costs: Default::default(),
                 },
             },
             modules::core::Genesis {
@@ -31,6 +28,8 @@ impl sdk::Runtime for Runtime {
                     max_batch_gas: 10_000,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
+                    // These are free, in order to simplify testing.
+                    gas_costs: Default::default(),
                 },
             },
         )

--- a/tests/runtimes/simple-keyvalue/src/keyvalue.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue.rs
@@ -5,12 +5,14 @@ use oasis_runtime_sdk::{
     self as sdk,
     context::{Context, DispatchContext, TxContext},
     core::common::cbor,
+    dispatcher,
     error::{Error as _, RuntimeError},
     module::{CallableMethodInfo, Module as _, QueryMethodInfo},
     modules::{
         core,
         core::{Module as Core, API as _},
     },
+    runtime,
     types::transaction::CallResult,
 };
 
@@ -93,7 +95,7 @@ impl sdk::module::MessageHookRegistrationHandler for Module {}
 
 impl sdk::module::MethodRegistrationHandler for Module {
     /// Register all supported methods.
-    fn register_methods(methods: &mut sdk::module::MethodRegistry) {
+    fn register_methods<R: runtime::Runtime>(methods: &mut sdk::module::MethodRegistry<R>) {
         methods.register_callable(sdk::module::CallableMethodInfo {
             name: "keyvalue.Insert",
             handler: Self::_callable_insert_handler,
@@ -141,9 +143,10 @@ impl Module {
         }
     }
 
-    fn _query_get_handler(
-        _mi: &QueryMethodInfo,
+    fn _query_get_handler<R: runtime::Runtime>(
+        _mi: &QueryMethodInfo<R>,
         ctx: &mut DispatchContext,
+        _dispatcher: &dispatcher::Dispatcher<R>,
         body: cbor::Value,
     ) -> Result<cbor::Value, RuntimeError> {
         let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -99,6 +99,10 @@ impl sdk::Runtime for Runtime {
                     max_batch_gas: 10_000,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
+                    gas_costs: modules::core::GasCosts {
+                        auth_signature: 10,
+                        auth_multisig_signer: 10,
+                    },
                 },
             },
         )

--- a/tests/runtimes/simple-keyvalue/src/test.rs
+++ b/tests/runtimes/simple-keyvalue/src/test.rs
@@ -16,6 +16,7 @@ fn test_impl_for_tuple() {
             max_batch_gas: u64::MAX,
             max_tx_signers: 1,
             max_multisig_signers: 1,
+            gas_costs: Default::default(),
         },
     );
     let dummy_bytes = b"you look, you die".to_vec();


### PR DESCRIPTION
cross reference https://github.com/oasisprotocol/oasis-sdk/pull/145#discussion_r638707458

on top of #145

also of interest: #148 -- with static dispatch, even looking up a method needs the runtime type

this takes the "dispatcher has runtime type and module methods take a runtime type parameter" approach. now we give an entire dispatcher ref to query methods. this replaces having a copy of the method registry in the context.

we can do a similar conversion when we want to access the dispatcher from calls.