### PR TITLE
runtime-sdk: Static call/query/message result handler dispatch

### DIFF
--- a/runtime-sdk/src/context.rs
+++ b/runtime-sdk/src/context.rs
@@ -1,6 +1,6 @@
 //! Execution context.
 use core::fmt;
-use std::{any::Any, collections::BTreeMap, sync::Arc};
+use std::{any::Any, collections::BTreeMap, marker::PhantomData, sync::Arc};
 
 use io_context::Context as IoContext;
 use slog::{self, o};
@@ -15,9 +15,8 @@ use oasis_core_runtime::{
 
 use crate::{
     event::Event,
-    module::MethodRegistry,
     modules::core::Error,
-    storage,
+    runtime, storage,
     types::{address::Address, message::MessageEventHookInvocation, transaction},
 };
 
@@ -51,8 +50,10 @@ impl From<&Mode> for &'static str {
 
 /// Runtime SDK context.
 pub trait Context {
+    /// Runtime that the context is being invoked in.
+    type Runtime: runtime::Runtime;
     /// Runtime state output type.
-    type S: storage::Store;
+    type Store: storage::Store;
 
     /// Returns a logger.
     fn get_logger(&self, module: &'static str) -> slog::Logger;
@@ -77,7 +78,7 @@ pub trait Context {
     fn runtime_round_results(&self) -> &roothash::RoundResults;
 
     /// Runtime state store.
-    fn runtime_state(&mut self) -> &mut Self::S;
+    fn runtime_state(&mut self) -> &mut Self::Store;
 
     /// Consensus state.
     fn consensus_state(&self) -> &consensus::state::ConsensusState;
@@ -157,48 +158,91 @@ pub trait Context {
     fn take_tx_value<V>(&mut self, key: &'static str) -> Option<Box<V>>
     where
         V: Any + Default;
+
+    /// Executes a function with the transaction-specific context set.
+    fn with_tx<F, Rs>(&mut self, tx: transaction::Transaction, f: F) -> Rs
+    where
+        F: FnOnce(TxContext<'_, '_, Self::Runtime, Self::Store>, transaction::Call) -> Rs;
+
+    /// Executes a function in a simulation context.
+    ///
+    /// The simulation context collects its own messages and starts with an empty set of context
+    /// values.
+    fn with_simulation<F, Rs>(&mut self, f: F) -> Rs
+    where
+        F: FnOnce(
+            DispatchContext<'_, Self::Runtime, storage::OverlayStore<&mut Self::Store>>,
+        ) -> Rs;
 }
 
 /// Dispatch context for the whole batch.
-pub struct DispatchContext<'a> {
-    pub(crate) mode: Mode,
+pub struct DispatchContext<'a, R: runtime::Runtime, S: storage::Store> {
+    mode: Mode,
 
-    pub(crate) runtime_header: &'a roothash::Header,
-    pub(crate) runtime_round_results: &'a roothash::RoundResults,
-    pub(crate) runtime_storage: storage::MKVSStore<&'a mut dyn mkvs::MKVS>,
+    runtime_header: &'a roothash::Header,
+    runtime_round_results: &'a roothash::RoundResults,
+    runtime_storage: S,
     // TODO: linked consensus layer block
-    pub(crate) consensus_state: &'a consensus::state::ConsensusState,
-    pub(crate) epoch: consensus::beacon::EpochTime,
-    pub(crate) io_ctx: Arc<IoContext>,
-    pub(crate) logger: slog::Logger,
+    consensus_state: &'a consensus::state::ConsensusState,
+    epoch: consensus::beacon::EpochTime,
+    io_ctx: Arc<IoContext>,
+    logger: slog::Logger,
 
-    /// The runtime's methods, in case you need to look them up for some reason.
-    pub(crate) methods: &'a MethodRegistry,
-
-    pub(crate) block_tags: Tags,
+    block_tags: Tags,
 
     /// Maximum number of messages that can be emitted.
-    pub(crate) max_messages: u32,
+    max_messages: u32,
     /// Emitted messages.
-    pub(crate) messages: Vec<(roothash::Message, MessageEventHookInvocation)>,
+    messages: Vec<(roothash::Message, MessageEventHookInvocation)>,
 
     /// Per-context values.
-    pub(crate) values: BTreeMap<&'static str, Box<dyn Any>>,
+    values: BTreeMap<&'static str, Box<dyn Any>>,
+
+    _runtime: PhantomData<R>,
 }
 
-impl<'a> DispatchContext<'a> {
+impl<'a, R: runtime::Runtime, S: storage::Store> DispatchContext<'a, R, S> {
+    /// Create a new dispatch context.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        mode: Mode,
+        runtime_header: &'a roothash::Header,
+        runtime_round_results: &'a roothash::RoundResults,
+        runtime_storage: S,
+        consensus_state: &'a consensus::state::ConsensusState,
+        epoch: consensus::beacon::EpochTime,
+        io_ctx: Arc<IoContext>,
+        max_messages: u32,
+    ) -> Self {
+        Self {
+            mode,
+            runtime_header,
+            runtime_round_results,
+            runtime_storage,
+            consensus_state,
+            epoch,
+            io_ctx,
+            logger: get_logger("runtime-sdk")
+                .new(o!("ctx" => "dispatch", "mode" => Into::<&'static str>::into(&mode))),
+            block_tags: Tags::new(),
+            max_messages,
+            messages: Vec::new(),
+            values: BTreeMap::new(),
+            _runtime: PhantomData,
+        }
+    }
+
     /// Create a new dispatch context from the low-level runtime context.
     pub(crate) fn from_runtime(
         ctx: &'a RuntimeContext<'_>,
         mkvs: &'a mut dyn mkvs::MKVS,
-        methods: &'a MethodRegistry,
-    ) -> Self {
+    ) -> DispatchContext<'a, R, storage::MKVSStore<&'a mut dyn mkvs::MKVS>> {
         let mode = if ctx.check_only {
             Mode::CheckTx
         } else {
             Mode::ExecuteTx
         };
-        Self {
+        DispatchContext {
             mode,
             runtime_header: ctx.header,
             runtime_round_results: ctx.round_results,
@@ -208,81 +252,18 @@ impl<'a> DispatchContext<'a> {
             io_ctx: ctx.io_ctx.clone(),
             logger: get_logger("runtime-sdk")
                 .new(o!("ctx" => "dispatch", "mode" => Into::<&'static str>::into(&mode))),
-            methods,
             block_tags: Tags::new(),
             max_messages: ctx.max_messages,
             messages: Vec::new(),
             values: BTreeMap::new(),
+            _runtime: PhantomData,
         }
-    }
-
-    /// Executes a function with the transaction-specific context set.
-    pub fn with_tx<F, R>(&mut self, tx: transaction::Transaction, f: F) -> R
-    where
-        F: FnOnce(TxContext<'_, '_>, transaction::Call) -> R,
-    {
-        // Create a store wrapped by an overlay store so we can either rollback or commit.
-        let store = storage::OverlayStore::new(&mut self.runtime_storage);
-
-        let tx_ctx = TxContext {
-            mode: self.mode,
-            runtime_header: self.runtime_header,
-            runtime_round_results: self.runtime_round_results,
-            consensus_state: self.consensus_state,
-            epoch: self.epoch,
-            store,
-            io_ctx: self.io_ctx.clone(),
-            logger: self
-                .logger
-                .new(o!("ctx" => "transaction", "mode" => Into::<&'static str>::into(&self.mode))),
-            tx_auth_info: tx.auth_info,
-            tags: Tags::new(),
-            // NOTE: Since a limit is enforced (which is a u32) this cast is always safe.
-            max_messages: self.max_messages.saturating_sub(self.messages.len() as u32),
-            messages: Vec::new(),
-            values: &mut self.values,
-            tx_values: BTreeMap::new(),
-        };
-        f(tx_ctx, tx.call)
-    }
-
-    /// Executes a function with the transaction-specific context set in simulation mode.
-    /// The simulation context collects its own messages and starts with an empty set of context
-    /// values.
-    /// Runtime storage is shared with this context, so don't go committing it.
-    pub fn with_tx_simulation<F, R>(&mut self, tx: transaction::Transaction, f: F) -> R
-    where
-        F: FnOnce(TxContext<'_, '_>, transaction::Call) -> R,
-    {
-        // Create a store wrapped by an overlay store so we can either rollback or commit.
-        let store = storage::OverlayStore::new(&mut self.runtime_storage);
-        let mut values = BTreeMap::new();
-
-        let tx_ctx = TxContext {
-            mode: Mode::SimulateTx,
-            runtime_header: self.runtime_header,
-            runtime_round_results: self.runtime_round_results,
-            consensus_state: self.consensus_state,
-            epoch: self.epoch,
-            store,
-            io_ctx: self.io_ctx.clone(),
-            logger: self
-                .logger
-                .new(o!("ctx" => "transaction", "mode" => MODE_SIMULATE_TX)),
-            tx_auth_info: tx.auth_info,
-            // Other than for storage, simulation has a blank slate.
-            tags: Tags::new(),
-            max_messages: self.max_messages,
-            messages: Vec::new(),
-            values: &mut values,
-            tx_values: BTreeMap::new(),
-        };
-        f(tx_ctx, tx.call)
     }
 }
 
-impl<'a> Context for DispatchContext<'a> {
-    type S = storage::MKVSStore<&'a mut dyn mkvs::MKVS>;
+impl<'a, R: runtime::Runtime, S: storage::Store> Context for DispatchContext<'a, R, S> {
+    type Runtime = R;
+    type Store = S;
 
     fn get_logger(&self, module: &'static str) -> slog::Logger {
         self.logger.new(o!("sdk_module" => module))
@@ -300,7 +281,7 @@ impl<'a> Context for DispatchContext<'a> {
         &self.runtime_round_results
     }
 
-    fn runtime_state(&mut self) -> &mut Self::S {
+    fn runtime_state(&mut self) -> &mut Self::Store {
         &mut self.runtime_storage
     }
 
@@ -377,10 +358,70 @@ impl<'a> Context for DispatchContext<'a> {
     {
         None
     }
+
+    fn with_tx<F, Rs>(&mut self, tx: transaction::Transaction, f: F) -> Rs
+    where
+        F: FnOnce(TxContext<'_, '_, Self::Runtime, Self::Store>, transaction::Call) -> Rs,
+    {
+        // Create a store wrapped by an overlay store so we can either rollback or commit.
+        let store = storage::OverlayStore::new(&mut self.runtime_storage);
+
+        let tx_ctx = TxContext {
+            mode: self.mode,
+            runtime_header: self.runtime_header,
+            runtime_round_results: self.runtime_round_results,
+            consensus_state: self.consensus_state,
+            epoch: self.epoch,
+            store,
+            io_ctx: self.io_ctx.clone(),
+            logger: self
+                .logger
+                .new(o!("ctx" => "transaction", "mode" => Into::<&'static str>::into(&self.mode))),
+            tx_auth_info: tx.auth_info,
+            tags: Tags::new(),
+            // NOTE: Since a limit is enforced (which is a u32) this cast is always safe.
+            max_messages: self.max_messages.saturating_sub(self.messages.len() as u32),
+            messages: Vec::new(),
+            values: &mut self.values,
+            tx_values: BTreeMap::new(),
+            _runtime: PhantomData,
+        };
+        f(tx_ctx, tx.call)
+    }
+
+    fn with_simulation<F, Rs>(&mut self, f: F) -> Rs
+    where
+        F: FnOnce(
+            DispatchContext<'_, Self::Runtime, storage::OverlayStore<&mut Self::Store>>,
+        ) -> Rs,
+    {
+        // Create a store wrapped by an overlay store so any state changes don't leak.
+        let store = storage::OverlayStore::new(&mut self.runtime_storage);
+
+        let sim_ctx = DispatchContext {
+            mode: Mode::SimulateTx,
+            runtime_header: self.runtime_header,
+            runtime_round_results: self.runtime_round_results,
+            runtime_storage: store,
+            consensus_state: self.consensus_state,
+            epoch: self.epoch,
+            io_ctx: self.io_ctx.clone(),
+            logger: self
+                .logger
+                .new(o!("ctx" => "dispatch", "mode" => MODE_SIMULATE_TX)),
+            // Other than for storage, simulation has a blank slate.
+            block_tags: Tags::new(),
+            max_messages: self.max_messages,
+            messages: Vec::new(),
+            values: BTreeMap::new(),
+            _runtime: PhantomData,
+        };
+        f(sim_ctx)
+    }
 }
 
 /// Per-transaction/method dispatch sub-context.
-pub struct TxContext<'a, 'b> {
+pub struct TxContext<'a, 'b, R: runtime::Runtime, S: storage::Store> {
     mode: Mode,
 
     runtime_header: &'a roothash::Header,
@@ -388,7 +429,7 @@ pub struct TxContext<'a, 'b> {
     consensus_state: &'a consensus::state::ConsensusState,
     epoch: consensus::beacon::EpochTime,
     // TODO: linked consensus layer block
-    store: storage::OverlayStore<&'b mut storage::MKVSStore<&'a mut dyn mkvs::MKVS>>,
+    store: storage::OverlayStore<&'b mut S>,
 
     io_ctx: Arc<IoContext>,
     logger: slog::Logger,
@@ -409,10 +450,13 @@ pub struct TxContext<'a, 'b> {
 
     /// Per-transaction values.
     tx_values: BTreeMap<&'static str, Box<dyn Any>>,
+
+    _runtime: PhantomData<R>,
 }
 
-impl<'a, 'b> Context for TxContext<'a, 'b> {
-    type S = storage::OverlayStore<&'b mut storage::MKVSStore<&'a mut dyn mkvs::MKVS>>;
+impl<'a, 'b, R: runtime::Runtime, S: storage::Store> Context for TxContext<'a, 'b, R, S> {
+    type Runtime = R;
+    type Store = storage::OverlayStore<&'b mut S>;
 
     fn get_logger(&self, module: &'static str) -> slog::Logger {
         self.logger.new(o!("sdk_module" => module))
@@ -430,7 +474,7 @@ impl<'a, 'b> Context for TxContext<'a, 'b> {
         self.runtime_round_results
     }
 
-    fn runtime_state(&mut self) -> &mut Self::S {
+    fn runtime_state(&mut self) -> &mut Self::Store {
         &mut self.store
     }
 
@@ -495,7 +539,6 @@ impl<'a, 'b> Context for TxContext<'a, 'b> {
             .unwrap_or_default()
     }
 
-    /// Fetches or sets a value associated with the transaction.
     fn tx_value<V>(&mut self, key: &'static str) -> Option<&mut V>
     where
         V: Any + Default,
@@ -509,9 +552,6 @@ impl<'a, 'b> Context for TxContext<'a, 'b> {
         )
     }
 
-    /// Takes a value associated with the transaction.
-    ///
-    /// The previous value is removed so subsequent fetches will return the default value.
     fn take_tx_value<V>(&mut self, key: &'static str) -> Option<Box<V>>
     where
         V: Any + Default,
@@ -522,6 +562,43 @@ impl<'a, 'b> Context for TxContext<'a, 'b> {
                 .map(|x| x.downcast().expect("type should stay the same"))
                 .unwrap_or_default(),
         )
+    }
+
+    fn with_tx<F, Rs>(&mut self, _tx: transaction::Transaction, _f: F) -> Rs
+    where
+        F: FnOnce(TxContext<'_, '_, Self::Runtime, Self::Store>, transaction::Call) -> Rs,
+    {
+        panic!("cannot nest transaction contexts");
+    }
+
+    fn with_simulation<F, Rs>(&mut self, f: F) -> Rs
+    where
+        F: FnOnce(
+            DispatchContext<'_, Self::Runtime, storage::OverlayStore<&mut Self::Store>>,
+        ) -> Rs,
+    {
+        // Create a store wrapped by an overlay store so any state changes don't leak.
+        let store = storage::OverlayStore::new(&mut self.store);
+
+        let sim_ctx = DispatchContext {
+            mode: Mode::SimulateTx,
+            runtime_header: self.runtime_header,
+            runtime_round_results: self.runtime_round_results,
+            runtime_storage: store,
+            consensus_state: self.consensus_state,
+            epoch: self.epoch,
+            io_ctx: self.io_ctx.clone(),
+            logger: self
+                .logger
+                .new(o!("ctx" => "dispatch", "mode" => MODE_SIMULATE_TX)),
+            // Other than for storage, simulation has a blank slate.
+            block_tags: Tags::new(),
+            max_messages: self.max_messages,
+            messages: Vec::new(),
+            values: BTreeMap::new(),
+            _runtime: PhantomData,
+        };
+        f(sim_ctx)
     }
 }
 

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -22,7 +22,7 @@ use oasis_core_runtime::{
 };
 
 use crate::{
-    context::{Context, DispatchContext},
+    context::{BatchContext, Context, RuntimeBatchContext},
     error::{Error as _, RuntimeError},
     module::{self, AuthHandler, BlockHandler, MethodHandler},
     modules,
@@ -98,7 +98,7 @@ impl<R: Runtime> Dispatcher<R> {
     }
 
     /// Dispatch a runtime transaction in the given context.
-    pub fn dispatch_tx<C: Context>(
+    pub fn dispatch_tx<C: BatchContext>(
         ctx: &mut C,
         tx: types::transaction::Transaction,
     ) -> Result<DispatchResult, Error> {
@@ -132,7 +132,7 @@ impl<R: Runtime> Dispatcher<R> {
     }
 
     /// Check whether the given transaction is valid.
-    pub fn check_tx<C: Context>(ctx: &mut C, tx: &[u8]) -> Result<CheckTxResult, Error> {
+    pub fn check_tx<C: BatchContext>(ctx: &mut C, tx: &[u8]) -> Result<CheckTxResult, Error> {
         let tx = match Self::decode_tx(ctx, &tx) {
             Ok(tx) => tx,
             Err(err) => {
@@ -169,7 +169,7 @@ impl<R: Runtime> Dispatcher<R> {
     }
 
     /// Execute the given transaction.
-    pub fn execute_tx<C: Context>(ctx: &mut C, tx: &[u8]) -> Result<ExecuteTxResult, Error> {
+    pub fn execute_tx<C: BatchContext>(ctx: &mut C, tx: &[u8]) -> Result<ExecuteTxResult, Error> {
         // It is an error to include a malformed transaction in a batch. So instead of only
         // reporting a failed execution result, we fail the whole batch. This will make the compute
         // node vote for failure and the round will fail.
@@ -248,7 +248,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
             let mut ctx =
-                DispatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
+                RuntimeBatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
                     &rt_ctx, mkvs,
                 );
             // Perform state migrations if required.
@@ -293,7 +293,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
             let mut ctx =
-                DispatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
+                RuntimeBatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
                     &ctx, mkvs,
                 );
             // Perform state migrations if required.
@@ -323,7 +323,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
             let mut ctx =
-                DispatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
+                RuntimeBatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
                     &ctx, mkvs,
                 );
             // Perform state migrations if required.

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -11,8 +11,7 @@ use thiserror::Error;
 use oasis_core_runtime::{
     self,
     common::cbor,
-    consensus::roothash::MessageEvent,
-    storage::context::StorageContext,
+    storage::{context::StorageContext, mkvs},
     transaction::{
         self,
         dispatcher::{ExecuteBatchResult, ExecuteTxResult},
@@ -25,7 +24,7 @@ use oasis_core_runtime::{
 use crate::{
     context::{Context, DispatchContext},
     error::{Error as _, RuntimeError},
-    module::{AuthHandler, BlockHandler, MessageHandlerRegistry, MethodRegistry},
+    module::{self, AuthHandler, BlockHandler, MethodHandler},
     modules,
     runtime::Runtime,
     storage, types,
@@ -47,9 +46,10 @@ pub enum Error {
     MalformedTransactionInBatch(#[source] modules::core::Error),
 }
 
-struct DispatchResult {
-    result: types::transaction::CallResult,
-    tags: Tags,
+/// Result of dispatching a transaction.
+pub struct DispatchResult {
+    pub result: types::transaction::CallResult,
+    pub tags: Tags,
 }
 
 impl From<types::transaction::CallResult> for DispatchResult {
@@ -61,30 +61,25 @@ impl From<types::transaction::CallResult> for DispatchResult {
     }
 }
 
+/// The runtime dispatcher.
 pub struct Dispatcher<R: Runtime> {
-    /// Method registry.
-    methods: MethodRegistry,
-    /// Handlers registered for consensus messages.
-    consensus_message_handlers: MessageHandlerRegistry,
-
     _runtime: PhantomData<R>,
 }
 
 impl<R: Runtime> Dispatcher<R> {
-    pub(super) fn new(
-        methods: MethodRegistry,
-        consensus_message_handlers: MessageHandlerRegistry,
-    ) -> Self {
+    /// Create a new instance of the dispatcher for the given runtime.
+    ///
+    /// Note that the dispatcher is fully static and the constructor is only needed so that the
+    /// instance can be used directly with the dispatcher system provided by Oasis Core.
+    pub(super) fn new() -> Self {
         Self {
-            methods,
-            consensus_message_handlers,
             _runtime: PhantomData,
         }
     }
 
-    fn decode_tx(
-        &self,
-        ctx: &mut DispatchContext<'_>,
+    /// Decode a runtime transaction.
+    pub fn decode_tx<C: Context>(
+        ctx: &mut C,
         tx: &[u8],
     ) -> Result<types::transaction::Transaction, modules::core::Error> {
         // TODO: Check against transaction size limit.
@@ -102,9 +97,9 @@ impl<R: Runtime> Dispatcher<R> {
             .map_err(|_| modules::core::Error::MalformedTransaction)
     }
 
-    fn dispatch_tx(
-        &self,
-        ctx: &mut DispatchContext<'_>,
+    /// Dispatch a runtime transaction in the given context.
+    pub fn dispatch_tx<C: Context>(
+        ctx: &mut C,
         tx: types::transaction::Transaction,
     ) -> Result<DispatchResult, Error> {
         // Run pre-processing hooks.
@@ -112,20 +107,16 @@ impl<R: Runtime> Dispatcher<R> {
             return Ok(err.to_call_result().into());
         }
 
-        // Perform transaction method lookup.
-        let method_info = match self.methods.lookup_callable(&tx.call.method) {
-            Some(method_info) => method_info,
-            None => {
-                // Method not found.
-                return Ok(modules::core::Error::InvalidMethod.to_call_result().into());
-            }
-        };
-
         let (result, messages) = ctx.with_tx(tx, |mut ctx, call| {
-            let result = (method_info.handler)(&method_info, &mut ctx, call.body);
-            if !result.is_success() {
-                return (result.into(), Vec::new());
-            }
+            let result = match R::Modules::dispatch_call(&mut ctx, &call.method, call.body) {
+                module::DispatchResult::Handled(result) => result,
+                module::DispatchResult::Unhandled(_) => {
+                    return (
+                        modules::core::Error::InvalidMethod.to_call_result().into(),
+                        Vec::new(),
+                    )
+                }
+            };
 
             // Commit store and return emitted tags and messages.
             let (tags, messages) = ctx.commit();
@@ -140,8 +131,9 @@ impl<R: Runtime> Dispatcher<R> {
         Ok(result)
     }
 
-    fn check_tx(&self, ctx: &mut DispatchContext<'_>, tx: &[u8]) -> Result<CheckTxResult, Error> {
-        let tx = match self.decode_tx(ctx, &tx) {
+    /// Check whether the given transaction is valid.
+    pub fn check_tx<C: Context>(ctx: &mut C, tx: &[u8]) -> Result<CheckTxResult, Error> {
+        let tx = match Self::decode_tx(ctx, &tx) {
             Ok(tx) => tx,
             Err(err) => {
                 return Ok(CheckTxResult {
@@ -155,7 +147,7 @@ impl<R: Runtime> Dispatcher<R> {
             }
         };
 
-        match self.dispatch_tx(ctx, tx)?.result {
+        match Self::dispatch_tx(ctx, tx)?.result {
             types::transaction::CallResult::Ok(value) => Ok(CheckTxResult {
                 error: Default::default(),
                 meta: Some(value),
@@ -176,21 +168,16 @@ impl<R: Runtime> Dispatcher<R> {
         }
     }
 
-    fn execute_tx(
-        &self,
-        ctx: &mut DispatchContext<'_>,
-        tx: &[u8],
-    ) -> Result<ExecuteTxResult, Error> {
+    /// Execute the given transaction.
+    pub fn execute_tx<C: Context>(ctx: &mut C, tx: &[u8]) -> Result<ExecuteTxResult, Error> {
         // It is an error to include a malformed transaction in a batch. So instead of only
         // reporting a failed execution result, we fail the whole batch. This will make the compute
         // node vote for failure and the round will fail.
         //
         // Correct proposers should only include transactions which have passed check_tx.
-        let tx = self
-            .decode_tx(ctx, &tx)
-            .map_err(Error::MalformedTransactionInBatch)?;
+        let tx = Self::decode_tx(ctx, &tx).map_err(Error::MalformedTransactionInBatch)?;
 
-        let dispatch_result = self.dispatch_tx(ctx, tx)?;
+        let dispatch_result = Self::dispatch_tx(ctx, tx)?;
 
         Ok(ExecuteTxResult {
             output: cbor::to_vec(&dispatch_result.result),
@@ -198,28 +185,7 @@ impl<R: Runtime> Dispatcher<R> {
         })
     }
 
-    fn dispatch_message(
-        &self,
-        mut ctx: &mut DispatchContext<'_>,
-        handler_name: String,
-        message_event: MessageEvent,
-        handler_ctx: cbor::Value,
-    ) -> Result<(), modules::core::Error> {
-        // Perform message handler lookup.
-        let method_info = self
-            .consensus_message_handlers
-            .lookup_handler(&handler_name)
-            .ok_or(modules::core::Error::InvalidMethod)?;
-
-        (method_info.handler)(&method_info, &mut ctx, message_event, handler_ctx);
-
-        Ok(())
-    }
-
-    fn handle_last_round_messages(
-        &self,
-        ctx: &mut DispatchContext<'_>,
-    ) -> Result<(), modules::core::Error> {
+    fn handle_last_round_messages<C: Context>(ctx: &mut C) -> Result<(), modules::core::Error> {
         let message_events = ctx.runtime_round_results().messages.clone();
 
         let store = storage::TypedStore::new(storage::PrefixStore::new(
@@ -234,7 +200,16 @@ impl<R: Runtime> Dispatcher<R> {
             let handler = handlers
                 .remove(&event.index)
                 .ok_or(modules::core::Error::MessageHandlerMissing(event.index))?;
-            self.dispatch_message(ctx, handler.hook_name, event, handler.payload)?;
+
+            R::Modules::dispatch_message_result(
+                ctx,
+                &handler.hook_name,
+                types::message::MessageResult {
+                    event,
+                    context: handler.payload,
+                },
+            )
+            .ok_or(modules::core::Error::InvalidMethod)?;
         }
 
         if !handlers.is_empty() {
@@ -246,7 +221,6 @@ impl<R: Runtime> Dispatcher<R> {
     }
 
     fn save_emitted_message_handlers<S: storage::Store>(
-        &self,
         store: S,
         handlers: Vec<types::message::MessageEventHookInvocation>,
     ) {
@@ -262,10 +236,6 @@ impl<R: Runtime> Dispatcher<R> {
         ));
         store.insert(&modules::core::state::MESSAGE_HANDLERS, &message_handlers);
     }
-
-    fn maybe_init_state(&self, ctx: &mut DispatchContext<'_>) {
-        R::migrate(ctx)
-    }
 }
 
 impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
@@ -277,12 +247,15 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
-            let mut ctx = DispatchContext::from_runtime(&rt_ctx, mkvs, &self.methods);
+            let mut ctx =
+                DispatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
+                    &rt_ctx, mkvs,
+                );
             // Perform state migrations if required.
-            self.maybe_init_state(&mut ctx);
+            R::migrate(&mut ctx);
 
             // Handle last round message results.
-            self.handle_last_round_messages(&mut ctx)?;
+            Self::handle_last_round_messages(&mut ctx)?;
 
             // Run begin block hooks.
             R::Modules::begin_block(&mut ctx);
@@ -290,7 +263,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
             // Execute the batch.
             let mut results = Vec::with_capacity(batch.len());
             for tx in batch.iter() {
-                results.push(self.execute_tx(&mut ctx, &tx)?);
+                results.push(Self::execute_tx(&mut ctx, &tx)?);
             }
 
             // Run end block hooks.
@@ -301,7 +274,7 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
             let (messages, handlers) = messages.into_iter().unzip();
 
             let state = storage::MKVSStore::new(rt_ctx.io_ctx.clone(), mkvs);
-            self.save_emitted_message_handlers(state, handlers);
+            Self::save_emitted_message_handlers(state, handlers);
 
             Ok(ExecuteBatchResult {
                 results,
@@ -319,14 +292,17 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
-            let mut ctx = DispatchContext::from_runtime(&ctx, mkvs, &self.methods);
+            let mut ctx =
+                DispatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
+                    &ctx, mkvs,
+                );
             // Perform state migrations if required.
-            self.maybe_init_state(&mut ctx);
+            R::migrate(&mut ctx);
 
             // Check the batch.
             let mut results = Vec::with_capacity(batch.len());
             for tx in batch.iter() {
-                results.push(self.check_tx(&mut ctx, &tx)?);
+                results.push(Self::check_tx(&mut ctx, &tx)?);
             }
 
             Ok(results)
@@ -346,16 +322,16 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
         // TODO: Get rid of StorageContext (pass mkvs in ctx).
         StorageContext::with_current(|mkvs, _| {
             // Prepare dispatch context.
-            let mut ctx = DispatchContext::from_runtime(&ctx, mkvs, &self.methods);
+            let mut ctx =
+                DispatchContext::<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>>::from_runtime(
+                    &ctx, mkvs,
+                );
             // Perform state migrations if required.
-            self.maybe_init_state(&mut ctx);
+            R::migrate(&mut ctx);
 
             // Execute the query.
-            let method_info = self
-                .methods
-                .lookup_query(method)
-                .ok_or(modules::core::Error::InvalidMethod)?;
-            (method_info.handler)(&method_info, &mut ctx, args)
+            R::Modules::dispatch_query(&mut ctx, method, args)
+                .ok_or(modules::core::Error::InvalidMethod)?
         })
     }
 }

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -15,7 +15,7 @@ pub mod testing;
 pub mod types;
 
 pub use crate::{
-    context::{Context, DispatchContext},
+    context::{BatchContext, Context, TxContext},
     core::common::version::Version,
     module::Module,
     runtime::Runtime,

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -7,7 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use oasis_core_runtime::common::cbor;
 
 use crate::{
-    context::Context,
+    context::{Context, TxContext},
     error, event, modules, storage,
     storage::Store,
     types::{
@@ -36,7 +36,7 @@ impl<B, R> DispatchResult<B, R> {
 /// Method handler.
 pub trait MethodHandler {
     /// Dispatch a call.
-    fn dispatch_call<C: Context>(
+    fn dispatch_call<C: TxContext>(
         _ctx: &mut C,
         _method: &str,
         body: cbor::Value,
@@ -68,7 +68,7 @@ pub trait MethodHandler {
 
 #[impl_for_tuples(30)]
 impl MethodHandler for Tuple {
-    fn dispatch_call<C: Context>(
+    fn dispatch_call<C: TxContext>(
         ctx: &mut C,
         method: &str,
         body: cbor::Value,

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -1,5 +1,5 @@
 //! Runtime modules.
-use std::{collections::BTreeMap, fmt::Debug};
+use std::fmt::Debug;
 
 use impl_trait_for_tuples::impl_for_tuples;
 use serde::{de::DeserializeOwned, Serialize};
@@ -7,138 +7,113 @@ use serde::{de::DeserializeOwned, Serialize};
 use oasis_core_runtime::common::cbor;
 
 use crate::{
-    context::{DispatchContext, TxContext},
+    context::Context,
     error, event, modules, storage,
     storage::Store,
     types::{
-        message::MessageEvent,
+        message::MessageResult,
         transaction::{CallResult, Transaction, UnverifiedTransaction},
     },
 };
 
-/// Metadata of a callable method.
-pub struct CallableMethodInfo {
-    /// Method name.
-    pub name: &'static str,
-
-    /// Method handler function.
-    pub handler: fn(&CallableMethodInfo, &mut TxContext<'_, '_>, cbor::Value) -> CallResult,
+/// Result of invoking the method handler.
+pub enum DispatchResult<B, R> {
+    Handled(R),
+    Unhandled(B),
 }
 
-/// Metadata of a query method.
-pub struct QueryMethodInfo {
-    /// Method name.
-    pub name: &'static str,
-
-    /// Method handler function.
-    pub handler: fn(
-        &QueryMethodInfo,
-        &mut DispatchContext<'_>,
-        cbor::Value,
-    ) -> Result<cbor::Value, error::RuntimeError>,
-}
-
-/// Registry of methods exposed by the modules.
-pub struct MethodRegistry {
-    callable_methods: BTreeMap<&'static str, CallableMethodInfo>,
-    query_methods: BTreeMap<&'static str, QueryMethodInfo>,
-}
-
-impl MethodRegistry {
-    /// Create a new method registry.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self {
-            callable_methods: BTreeMap::new(),
-            query_methods: BTreeMap::new(),
+impl<B, R> DispatchResult<B, R> {
+    /// Transforms `DispatchResult<B, R>` into `Result<R, E>`, mapping `Handled(r)` to `Ok(r)` and
+    /// `Unhandled(_)` to `Err(err)`.
+    pub fn ok_or<E>(self, err: E) -> Result<R, E> {
+        match self {
+            DispatchResult::Handled(result) => Ok(result),
+            DispatchResult::Unhandled(_) => Err(err),
         }
     }
-
-    /// Register a new callable method.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic in case a method with the same name is already registered.
-    pub fn register_callable(&mut self, mi: CallableMethodInfo) {
-        if self.callable_methods.contains_key(mi.name) {
-            panic!("callable method already exists: {}", mi.name);
-        }
-        self.callable_methods.insert(mi.name, mi);
-    }
-
-    /// Looks up a previously registered callable method.
-    pub fn lookup_callable(&self, name: &str) -> Option<&CallableMethodInfo> {
-        self.callable_methods.get(name)
-    }
-
-    /// Register a new query method.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic in case a method with the same name is already registered.
-    pub fn register_query(&mut self, mi: QueryMethodInfo) {
-        if self.query_methods.contains_key(mi.name) {
-            panic!("query method already exists: {}", mi.name);
-        }
-        self.query_methods.insert(mi.name, mi);
-    }
-
-    /// Looks up a previously registered callable method.
-    pub fn lookup_query(&self, name: &str) -> Option<&QueryMethodInfo> {
-        self.query_methods.get(name)
-    }
 }
 
-/// Method registration handler.
-#[impl_for_tuples(30)]
-pub trait MethodRegistrationHandler {
-    /// Register any methods exported by the module.
-    fn register_methods(_methods: &mut MethodRegistry) {
-        // Default implementation doesn't do anything.
-    }
-}
-
-/// Metadata of the consensus message handling callback.
-pub struct MessageHandlerInfo {
-    /// Message handler name.
-    pub name: &'static str,
-    /// Message handler.
-    pub handler: fn(&MessageHandlerInfo, &mut DispatchContext<'_>, MessageEvent, cbor::Value),
-}
-
-/// Registry of message handlers registered by the module.
-pub struct MessageHandlerRegistry {
-    handlers: BTreeMap<&'static str, MessageHandlerInfo>,
-}
-
-impl MessageHandlerRegistry {
-    /// Create a new method registry.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self {
-            handlers: BTreeMap::new(),
-        }
+/// Method handler.
+pub trait MethodHandler {
+    /// Dispatch a call.
+    fn dispatch_call<C: Context>(
+        _ctx: &mut C,
+        _method: &str,
+        body: cbor::Value,
+    ) -> DispatchResult<cbor::Value, CallResult> {
+        // Default implementation indicates that the call was not handled.
+        DispatchResult::Unhandled(body)
     }
 
-    /// Register a message handler exposed by the module.
-    pub fn register_handler(&mut self, method_info: MessageHandlerInfo) {
-        if self.handlers.contains_key(method_info.name) {
-            panic!("message handler already exists: {}", method_info.name);
-        }
-        self.handlers.insert(method_info.name, method_info);
+    /// Dispatch a query.
+    fn dispatch_query<C: Context>(
+        _ctx: &mut C,
+        _method: &str,
+        args: cbor::Value,
+    ) -> DispatchResult<cbor::Value, Result<cbor::Value, error::RuntimeError>> {
+        // Default implementation indicates that the query was not handled.
+        DispatchResult::Unhandled(args)
     }
 
-    /// Looks up a previously registered message handler.
-    pub fn lookup_handler(&self, name: &str) -> Option<&MessageHandlerInfo> {
-        self.handlers.get(name)
+    /// Dispatch a message result.
+    fn dispatch_message_result<C: Context>(
+        _ctx: &mut C,
+        _handler_name: &str,
+        result: MessageResult,
+    ) -> DispatchResult<MessageResult, ()> {
+        // Default implementation indicates that the query was not handled.
+        DispatchResult::Unhandled(result)
     }
 }
 
 #[impl_for_tuples(30)]
-pub trait MessageHookRegistrationHandler {
-    /// Register any handlers defined by the module.
-    fn register_handlers(_handlers: &mut MessageHandlerRegistry) {
-        // Default implementation doesn't do anything.
+impl MethodHandler for Tuple {
+    fn dispatch_call<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        body: cbor::Value,
+    ) -> DispatchResult<cbor::Value, CallResult> {
+        // Return on first handler that can handle the method.
+        for_tuples!( #(
+            let body = match Tuple::dispatch_call::<C>(ctx, method, body) {
+                DispatchResult::Handled(result) => return DispatchResult::Handled(result),
+                DispatchResult::Unhandled(body) => body,
+            };
+        )* );
+
+        DispatchResult::Unhandled(body)
+    }
+
+    fn dispatch_query<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        args: cbor::Value,
+    ) -> DispatchResult<cbor::Value, Result<cbor::Value, error::RuntimeError>> {
+        // Return on first handler that can handle the method.
+        for_tuples!( #(
+            let args = match Tuple::dispatch_query::<C>(ctx, method, args) {
+                DispatchResult::Handled(result) => return DispatchResult::Handled(result),
+                DispatchResult::Unhandled(args) => args,
+            };
+        )* );
+
+        DispatchResult::Unhandled(args)
+    }
+
+    fn dispatch_message_result<C: Context>(
+        ctx: &mut C,
+        handler_name: &str,
+        result: MessageResult,
+    ) -> DispatchResult<MessageResult, ()> {
+        // Return on first handler that can handle the method.
+        for_tuples!( #(
+            let result = match Tuple::dispatch_message_result::<C>(ctx, handler_name, result) {
+                DispatchResult::Handled(result) => return DispatchResult::Handled(result),
+                DispatchResult::Unhandled(result) => result,
+            };
+        )* );
+
+        DispatchResult::Unhandled(result)
     }
 }
 
@@ -146,8 +121,8 @@ pub trait MessageHookRegistrationHandler {
 pub trait AuthHandler {
     /// Judge if an unverified transaction is good enough to undergo verification.
     /// This takes place before even verifying signatures.
-    fn approve_unverified_tx(
-        _ctx: &mut DispatchContext<'_>,
+    fn approve_unverified_tx<C: Context>(
+        _ctx: &mut C,
         _utx: &UnverifiedTransaction,
     ) -> Result<(), modules::core::Error> {
         // Default implementation doesn't do any checks.
@@ -157,8 +132,8 @@ pub trait AuthHandler {
     /// Authenticate a transaction.
     ///
     /// Note that any signatures have already been verified.
-    fn authenticate_tx(
-        _ctx: &mut DispatchContext<'_>,
+    fn authenticate_tx<C: Context>(
+        _ctx: &mut C,
         _tx: &Transaction,
     ) -> Result<(), modules::core::Error> {
         // Default implementation doesn't do any checks.
@@ -168,16 +143,16 @@ pub trait AuthHandler {
 
 #[impl_for_tuples(30)]
 impl AuthHandler for Tuple {
-    fn approve_unverified_tx(
-        ctx: &mut DispatchContext<'_>,
+    fn approve_unverified_tx<C: Context>(
+        ctx: &mut C,
         utx: &UnverifiedTransaction,
     ) -> Result<(), modules::core::Error> {
         for_tuples!( #( Tuple::approve_unverified_tx(ctx, utx)?; )* );
         Ok(())
     }
 
-    fn authenticate_tx(
-        ctx: &mut DispatchContext<'_>,
+    fn authenticate_tx<C: Context>(
+        ctx: &mut C,
         tx: &Transaction,
     ) -> Result<(), modules::core::Error> {
         for_tuples!( #( Tuple::authenticate_tx(ctx, tx)?; )* );
@@ -196,11 +171,14 @@ pub trait MigrationHandler {
     /// Initialize state from genesis or perform a migration.
     ///
     /// Should return true in case metadata has been changed.
-    fn init_or_migrate(
-        ctx: &mut DispatchContext<'_>,
-        meta: &mut modules::core::types::Metadata,
-        genesis: &Self::Genesis,
-    ) -> bool;
+    fn init_or_migrate<C: Context>(
+        _ctx: &mut C,
+        _meta: &mut modules::core::types::Metadata,
+        _genesis: &Self::Genesis,
+    ) -> bool {
+        // Default implementation doesn't perform any migrations.
+        false
+    }
 }
 
 #[allow(clippy::type_complexity)]
@@ -208,8 +186,8 @@ pub trait MigrationHandler {
 impl MigrationHandler for Tuple {
     for_tuples!( type Genesis = ( #( Tuple::Genesis ),* ); );
 
-    fn init_or_migrate(
-        ctx: &mut DispatchContext<'_>,
+    fn init_or_migrate<C: Context>(
+        ctx: &mut C,
         meta: &mut modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {
@@ -224,13 +202,13 @@ impl MigrationHandler for Tuple {
 pub trait BlockHandler {
     /// Perform any common actions at the start of the block (before any transactions have been
     /// executed).
-    fn begin_block(_ctx: &mut DispatchContext<'_>) {
+    fn begin_block<C: Context>(_ctx: &mut C) {
         // Default implementation doesn't do anything.
     }
 
     /// Perform any common actions at the end of the block (after all transactions have been
     /// executed).
-    fn end_block(_ctx: &mut DispatchContext<'_>) {
+    fn end_block<C: Context>(_ctx: &mut C) {
         // Default implementation doesn't do anything.
     }
 }

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use oasis_core_runtime::common::cbor;
 
 use crate::{
-    context::Context,
+    context::{BatchContext, Context},
     module::{AuthHandler, BlockHandler},
     modules::core,
     testing::{keys, mock},

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use oasis_core_runtime::common::cbor;
 
 use crate::{
-    context::{Context, DispatchContext},
+    context::Context,
     module::{AuthHandler, BlockHandler},
     modules::core,
     testing::{keys, mock},
@@ -199,7 +199,7 @@ fn test_api_tx_transfer_disabled() {
     });
 }
 
-pub(crate) fn init_accounts(ctx: &mut DispatchContext<'_>) {
+pub(crate) fn init_accounts<C: Context>(ctx: &mut C) {
     Accounts::init(
         ctx,
         &Genesis {

--- a/runtime-sdk/src/modules/consensus/mod.rs
+++ b/runtime-sdk/src/modules/consensus/mod.rs
@@ -14,7 +14,7 @@ use oasis_core_runtime::consensus::{
 };
 
 use crate::{
-    context::Context,
+    context::{Context, TxContext},
     crypto::signature::PublicKey,
     module,
     module::Module as _,
@@ -122,7 +122,7 @@ pub trait API {
     fn consensus_denomination<C: Context>(ctx: &mut C) -> Result<token::Denomination, Error>;
 
     /// Ensures transaction signer is consensus compatible.
-    fn ensure_compatible_tx_signer<C: Context>(ctx: &C) -> Result<(), Error>;
+    fn ensure_compatible_tx_signer<C: TxContext>(ctx: &C) -> Result<(), Error>;
 
     /// Query consensus account info.
     fn account<C: Context>(ctx: &C, addr: Address) -> Result<ConsensusAccount, Error>;
@@ -237,13 +237,8 @@ impl API for Module {
         Ok(params.consensus_denomination)
     }
 
-    fn ensure_compatible_tx_signer<C: Context>(ctx: &C) -> Result<(), Error> {
-        match ctx
-            .tx_auth_info()
-            .expect("should be called with a transaction ctx")
-            .signer_info[0]
-            .address_spec
-        {
+    fn ensure_compatible_tx_signer<C: TxContext>(ctx: &C) -> Result<(), Error> {
+        match ctx.tx_auth_info().signer_info[0].address_spec {
             AddressSpec::Signature(PublicKey::Ed25519(_)) => Ok(()),
             _ => Err(Error::ConsensusIncompatibleSigner),
         }

--- a/runtime-sdk/src/modules/consensus/mod.rs
+++ b/runtime-sdk/src/modules/consensus/mod.rs
@@ -14,7 +14,7 @@ use oasis_core_runtime::consensus::{
 };
 
 use crate::{
-    context::{Context, DispatchContext, TxContext},
+    context::Context,
     crypto::signature::PublicKey,
     module,
     module::Module as _,
@@ -122,7 +122,7 @@ pub trait API {
     fn consensus_denomination<C: Context>(ctx: &mut C) -> Result<token::Denomination, Error>;
 
     /// Ensures transaction signer is consensus compatible.
-    fn ensure_compatible_tx_signer(ctx: &TxContext<'_, '_>) -> Result<(), Error>;
+    fn ensure_compatible_tx_signer<C: Context>(ctx: &C) -> Result<(), Error>;
 
     /// Query consensus account info.
     fn account<C: Context>(ctx: &C, addr: Address) -> Result<ConsensusAccount, Error>;
@@ -237,7 +237,7 @@ impl API for Module {
         Ok(params.consensus_denomination)
     }
 
-    fn ensure_compatible_tx_signer(ctx: &TxContext<'_, '_>) -> Result<(), Error> {
+    fn ensure_compatible_tx_signer<C: Context>(ctx: &C) -> Result<(), Error> {
         match ctx
             .tx_auth_info()
             .expect("should be called with a transaction ctx")
@@ -265,14 +265,13 @@ impl module::Module for Module {
     type Parameters = Parameters;
 }
 
-impl module::MethodRegistrationHandler for Module {}
-impl module::MessageHookRegistrationHandler for Module {}
+impl module::MethodHandler for Module {}
 
 impl module::MigrationHandler for Module {
     type Genesis = Genesis;
 
-    fn init_or_migrate(
-        ctx: &mut DispatchContext<'_>,
+    fn init_or_migrate<C: Context>(
+        ctx: &mut C,
         meta: &mut modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {

--- a/runtime-sdk/src/modules/consensus/test.rs
+++ b/runtime-sdk/src/modules/consensus/test.rs
@@ -11,7 +11,7 @@ use oasis_core_runtime::{
 };
 
 use crate::{
-    context::Context,
+    context::{BatchContext, Context},
     modules::consensus::Module as Consensus,
     testing::{keys, mock},
     types::{

--- a/runtime-sdk/src/modules/consensus_accounts/mod.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/mod.rs
@@ -8,15 +8,15 @@ use thiserror::Error;
 use oasis_core_runtime::{common::cbor, consensus::staking::Account as ConsensusAccount};
 
 use crate::{
-    context::{Context, DispatchContext, TxContext},
+    context::Context,
     error::{self, Error as _},
     module,
-    module::{CallableMethodInfo, Module as _, QueryMethodInfo},
+    module::Module as _,
     modules,
     modules::core::{Module as Core, API as _},
     types::{
         address::Address,
-        message::{MessageEvent, MessageEventHookInvocation},
+        message::{MessageEvent, MessageEventHookInvocation, MessageResult},
         token,
         transaction::CallResult,
     },
@@ -192,7 +192,7 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
     Module<Accounts, Consensus>
 {
     /// Deposit in the runtime.
-    fn tx_deposit(ctx: &mut TxContext<'_, '_>, body: types::Deposit) -> Result<(), Error> {
+    fn tx_deposit<C: Context>(ctx: &mut C, body: types::Deposit) -> Result<(), Error> {
         let params = Self::params(ctx.runtime_state());
         Core::use_gas(ctx, params.gas_costs.tx_deposit)?;
 
@@ -207,7 +207,7 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
     }
 
     /// Withdraw from the runtime.
-    fn tx_withdraw(ctx: &mut TxContext<'_, '_>, body: types::Withdraw) -> Result<(), Error> {
+    fn tx_withdraw<C: Context>(ctx: &mut C, body: types::Withdraw) -> Result<(), Error> {
         let params = Self::params(ctx.runtime_state());
         Core::use_gas(ctx, params.gas_costs.tx_withdraw)?;
 
@@ -222,8 +222,8 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
         Self::withdraw(ctx, address, body.amount)
     }
 
-    fn query_balance(
-        ctx: &mut DispatchContext<'_>,
+    fn query_balance<C: Context>(
+        ctx: &mut C,
         args: types::BalanceQuery,
     ) -> Result<types::AccountBalance, Error> {
         let denomination = Consensus::consensus_denomination(ctx)?;
@@ -238,63 +238,39 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
         })
     }
 
-    fn query_consensus_account(
-        ctx: &mut DispatchContext<'_>,
+    fn query_consensus_account<C: Context>(
+        ctx: &mut C,
         args: types::ConsensusAccountQuery,
     ) -> Result<ConsensusAccount, Error> {
         Consensus::account(ctx, args.address).map_err(|_| Error::InvalidArgument)
     }
-}
 
-impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
-    Module<Accounts, Consensus>
-{
-    fn _callable_deposit_handler(
-        _mi: &CallableMethodInfo,
-        ctx: &mut TxContext<'_, '_>,
-        body: cbor::Value,
-    ) -> CallResult {
-        let result = || -> Result<cbor::Value, Error> {
-            let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
-            Ok(cbor::to_value(&Self::tx_deposit(ctx, args)?))
-        }();
-        match result {
-            Ok(value) => CallResult::Ok(value),
-            Err(err) => err.to_call_result(),
+    fn message_result_transfer<C: Context>(
+        ctx: &mut C,
+        me: MessageEvent,
+        context: types::ConsensusTransferContext,
+    ) {
+        if !me.is_success() {
+            // Transfer out failed.
+            return;
         }
+
+        // Update runtime state.
+        Accounts::burn(ctx, context.address, &context.amount).expect("should have enough balance");
     }
 
-    fn _callable_withdraw_handler(
-        _mi: &CallableMethodInfo,
-        ctx: &mut TxContext<'_, '_>,
-        body: cbor::Value,
-    ) -> CallResult {
-        let result = || -> Result<cbor::Value, Error> {
-            let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
-            Ok(cbor::to_value(&Self::tx_withdraw(ctx, args)?))
-        }();
-        match result {
-            Ok(value) => CallResult::Ok(value),
-            Err(err) => err.to_call_result(),
+    fn message_result_withdraw<C: Context>(
+        ctx: &mut C,
+        me: MessageEvent,
+        context: types::ConsensusWithdrawContext,
+    ) {
+        if !me.is_success() {
+            // Transfer out failed.
+            return;
         }
-    }
 
-    fn _query_balance_handler(
-        _mi: &QueryMethodInfo,
-        ctx: &mut DispatchContext<'_>,
-        args: cbor::Value,
-    ) -> Result<cbor::Value, error::RuntimeError> {
-        let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
-        Ok(cbor::to_value(&Self::query_balance(ctx, args)?))
-    }
-
-    fn _query_consensus_account_handler(
-        _mi: &QueryMethodInfo,
-        ctx: &mut DispatchContext<'_>,
-        args: cbor::Value,
-    ) -> Result<cbor::Value, error::RuntimeError> {
-        let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
-        Ok(cbor::to_value(&Self::query_consensus_account(ctx, args)?))
+        // Update runtime state.
+        Accounts::mint(ctx, context.address, &context.amount).unwrap();
     }
 }
 
@@ -309,84 +285,81 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API> modul
 }
 
 /// Module methods.
-impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
-    module::MethodRegistrationHandler for Module<Accounts, Consensus>
+impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API> module::MethodHandler
+    for Module<Accounts, Consensus>
 {
-    fn register_methods(methods: &mut module::MethodRegistry) {
-        // Callable methods.
-        methods.register_callable(module::CallableMethodInfo {
-            name: "consensus.Deposit",
-            handler: Self::_callable_deposit_handler,
-        });
-        methods.register_callable(module::CallableMethodInfo {
-            name: "consensus.Withdraw",
-            handler: Self::_callable_withdraw_handler,
-        });
-
-        // Queries.
-        methods.register_query(module::QueryMethodInfo {
-            name: "consensus.Balance",
-            handler: Self::_query_balance_handler,
-        });
-
-        methods.register_query(module::QueryMethodInfo {
-            name: "consensus.Account",
-            handler: Self::_query_consensus_account_handler,
-        })
-    }
-}
-
-impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
-    Module<Accounts, Consensus>
-{
-    fn _consensus_transfer_handler(
-        _mi: &module::MessageHandlerInfo,
-        ctx: &mut DispatchContext<'_>,
-        me: MessageEvent,
-        h_ctx: cbor::Value,
-    ) {
-        let h_ctx: types::ConsensusTransferContext =
-            cbor::from_value(h_ctx).expect("invalid message handler context");
-
-        // Transfer out succeed.
-        if me.is_success() {
-            // Update runtime state.
-            Accounts::burn(ctx, h_ctx.address, &h_ctx.amount).expect("should have enough balance");
+    fn dispatch_call<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        body: cbor::Value,
+    ) -> module::DispatchResult<cbor::Value, CallResult> {
+        match method {
+            "consensus.Deposit" => {
+                let result = || -> Result<cbor::Value, Error> {
+                    let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
+                    Ok(cbor::to_value(&Self::tx_deposit(ctx, args)?))
+                }();
+                match result {
+                    Ok(value) => module::DispatchResult::Handled(CallResult::Ok(value)),
+                    Err(err) => module::DispatchResult::Handled(err.to_call_result()),
+                }
+            }
+            "consensus.Withdraw" => {
+                let result = || -> Result<cbor::Value, Error> {
+                    let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
+                    Ok(cbor::to_value(&Self::tx_withdraw(ctx, args)?))
+                }();
+                match result {
+                    Ok(value) => module::DispatchResult::Handled(CallResult::Ok(value)),
+                    Err(err) => module::DispatchResult::Handled(err.to_call_result()),
+                }
+            }
+            _ => module::DispatchResult::Unhandled(body),
         }
     }
 
-    fn _consensus_withdraw_handler(
-        _mi: &module::MessageHandlerInfo,
-        ctx: &mut DispatchContext<'_>,
-        me: MessageEvent,
-        h_ctx: cbor::Value,
-    ) {
-        let h_ctx: types::ConsensusWithdrawContext =
-            cbor::from_value(h_ctx).expect("invalid message handler context");
-
-        // Deposit in succeed.
-        if me.is_success() {
-            // Update runtime state.
-            Accounts::mint(ctx, h_ctx.address, &h_ctx.amount).unwrap();
+    fn dispatch_query<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        args: cbor::Value,
+    ) -> module::DispatchResult<cbor::Value, Result<cbor::Value, error::RuntimeError>> {
+        match method {
+            "consensus.Balance" => module::DispatchResult::Handled((|| {
+                let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
+                Ok(cbor::to_value(&Self::query_balance(ctx, args)?))
+            })()),
+            "consensus.Account" => module::DispatchResult::Handled((|| {
+                let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
+                Ok(cbor::to_value(&Self::query_consensus_account(ctx, args)?))
+            })()),
+            _ => module::DispatchResult::Unhandled(args),
         }
     }
-}
 
-/// Module message handlers.
-impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API>
-    module::MessageHookRegistrationHandler for Module<Accounts, Consensus>
-{
-    // Register message handlers.
-    fn register_handlers(handlers: &mut module::MessageHandlerRegistry) {
-        handlers.register_handler(module::MessageHandlerInfo {
-            name: CONSENSUS_TRANSFER_HANDLER,
-            handler: Self::_consensus_transfer_handler,
-        });
-
-        handlers.register_handler(module::MessageHandlerInfo {
-            name: CONSENSUS_WITHDRAW_HANDLER,
-            handler: Self::_consensus_withdraw_handler,
-        });
+    fn dispatch_message_result<C: Context>(
+        ctx: &mut C,
+        handler_name: &str,
+        result: MessageResult,
+    ) -> module::DispatchResult<MessageResult, ()> {
+        match handler_name {
+            CONSENSUS_TRANSFER_HANDLER => {
+                Self::message_result_transfer(
+                    ctx,
+                    result.event,
+                    cbor::from_value(result.context).expect("invalid message handler context"),
+                );
+                module::DispatchResult::Handled(())
+            }
+            CONSENSUS_WITHDRAW_HANDLER => {
+                Self::message_result_withdraw(
+                    ctx,
+                    result.event,
+                    cbor::from_value(result.context).expect("invalid message handler context"),
+                );
+                module::DispatchResult::Handled(())
+            }
+            _ => module::DispatchResult::Unhandled(result),
+        }
     }
 }
 
@@ -395,8 +368,8 @@ impl<Accounts: modules::accounts::API, Consensus: modules::consensus::API> modul
 {
     type Genesis = Genesis;
 
-    fn init_or_migrate(
-        ctx: &mut DispatchContext<'_>,
+    fn init_or_migrate<C: Context>(
+        ctx: &mut C,
         meta: &mut modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {

--- a/runtime-sdk/src/modules/consensus_accounts/test.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/test.rs
@@ -324,23 +324,13 @@ fn test_consensus_transfer_handler() {
     );
     Module::<Accounts, Consensus>::init_or_migrate(&mut ctx, &mut meta, &Default::default());
 
-    // Invoke message handler.
-    let mi = module::MessageHandlerInfo {
-        name: CONSENSUS_TRANSFER_HANDLER,
-        handler: Module::<Accounts, Consensus>::_consensus_transfer_handler,
-    };
-    // Successful event.
+    // Simulate successful event.
     let me = Default::default();
     let h_ctx = types::ConsensusTransferContext {
         address: keys::alice::address(),
         amount: BaseUnits::new(999_999.into(), denom.clone()),
     };
-    Module::<Accounts, Consensus>::_consensus_transfer_handler(
-        &mi,
-        &mut ctx,
-        me,
-        cbor::to_value(h_ctx),
-    );
+    Module::<Accounts, Consensus>::message_result_transfer(&mut ctx, me, h_ctx);
 
     // Ensure runtime balance is updated.
     let bals = Accounts::get_balances(ctx.runtime_state(), keys::alice::address()).unwrap();
@@ -384,23 +374,13 @@ fn test_consensus_withdraw_handler() {
     );
     Module::<Accounts, Consensus>::init_or_migrate(&mut ctx, &mut meta, &Default::default());
 
-    // Invoke message handler.
-    let mi = module::MessageHandlerInfo {
-        name: CONSENSUS_WITHDRAW_HANDLER,
-        handler: Module::<Accounts, Consensus>::_consensus_withdraw_handler,
-    };
-    // Successful event.
+    // Simulate successful event.
     let me = Default::default();
     let h_ctx = types::ConsensusWithdrawContext {
         address: keys::alice::address(),
         amount: BaseUnits::new(1.into(), denom.clone()),
     };
-    Module::<Accounts, Consensus>::_consensus_withdraw_handler(
-        &mi,
-        &mut ctx,
-        me,
-        cbor::to_value(h_ctx),
-    );
+    Module::<Accounts, Consensus>::message_result_withdraw(&mut ctx, me, h_ctx);
 
     // Ensure runtime balance is updated.
     let bals = Accounts::get_balances(ctx.runtime_state(), keys::alice::address()).unwrap();

--- a/runtime-sdk/src/modules/consensus_accounts/test.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/test.rs
@@ -6,6 +6,7 @@ use oasis_core_runtime::consensus::{
 };
 
 use crate::{
+    context::BatchContext,
     module::MigrationHandler,
     modules::{
         accounts::{Genesis as AccountsGenesis, Module as Accounts, API},

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -5,9 +5,9 @@ use thiserror::Error;
 use oasis_core_runtime::common::cbor;
 
 use crate::{
-    context::{Context, DispatchContext},
-    error,
-    module::{self, Module as _, QueryMethodInfo},
+    context::Context,
+    dispatcher, error,
+    module::{self, Module as _},
     types::transaction::{self, AuthProof, UnverifiedTransaction},
 };
 
@@ -129,13 +129,13 @@ const CONTEXT_KEY_GAS_USED: &str = "core.GasUsed";
 
 impl Module {
     /// Initialize state from genesis.
-    fn init(ctx: &mut DispatchContext<'_>, genesis: &Genesis) {
+    fn init<C: Context>(ctx: &mut C, genesis: &Genesis) {
         // Set genesis parameters.
         Self::set_params(ctx.runtime_state(), &genesis.parameters);
     }
 
     /// Migrate state from a previous version.
-    fn migrate(_ctx: &mut DispatchContext<'_>, _from: u32) -> bool {
+    fn migrate<C: Context>(_ctx: &mut C, _from: u32) -> bool {
         // No migrations currently supported.
         false
     }
@@ -164,6 +164,7 @@ impl API for Module {
             .checked_add(gas)
             .ok_or(Error::BatchGasOverflow)?;
         if batch_new_gas_used > batch_gas_limit {
+            println!("batch gas limit: {:?}", batch_gas_limit);
             return Err(Error::BatchOutOfGas);
         }
 
@@ -185,31 +186,16 @@ impl Module {
     /// estimate that and return successfully, so do not use this query to see if a transaction will
     /// succeed. Failure due to OutOfGas are included, so it's best to set the query argument
     /// transaction's gas to something high.
-    fn query_estimate_gas(
-        ctx: &mut DispatchContext<'_>,
+    fn query_estimate_gas<C: Context>(
+        ctx: &mut C,
         args: transaction::Transaction,
     ) -> Result<u64, Error> {
-        let mi = ctx
-            .methods
-            .lookup_callable(&args.call.method)
-            .ok_or(Error::InvalidMethod)?;
-        ctx.with_tx_simulation(args, |mut tx_ctx, call| {
-            (mi.handler)(&mi, &mut tx_ctx, call.body);
+        ctx.with_simulation(|mut ctx| {
+            dispatcher::Dispatcher::<C::Runtime>::dispatch_tx(&mut ctx, args).ok();
             // Warning: we don't report success or failure. If the call fails, we still report
             // how much gas it uses while it fails.
-            Ok(*tx_ctx.tx_value::<u64>(CONTEXT_KEY_GAS_USED).unwrap())
+            Ok(*ctx.value::<u64>(CONTEXT_KEY_GAS_USED))
         })
-    }
-}
-
-impl Module {
-    fn _query_estimate_gas_handler(
-        _mi: &QueryMethodInfo,
-        ctx: &mut DispatchContext<'_>,
-        args: cbor::Value,
-    ) -> Result<cbor::Value, error::RuntimeError> {
-        let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
-        Ok(cbor::to_value(&Self::query_estimate_gas(ctx, args)?))
     }
 }
 
@@ -221,8 +207,8 @@ impl module::Module for Module {
 }
 
 impl module::AuthHandler for Module {
-    fn approve_unverified_tx(
-        ctx: &mut DispatchContext<'_>,
+    fn approve_unverified_tx<C: Context>(
+        ctx: &mut C,
         utx: &UnverifiedTransaction,
     ) -> Result<(), Error> {
         let params = Self::params(ctx.runtime_state());
@@ -243,8 +229,8 @@ impl module::AuthHandler for Module {
 impl module::MigrationHandler for Module {
     type Genesis = Genesis;
 
-    fn init_or_migrate(
-        ctx: &mut DispatchContext<'_>,
+    fn init_or_migrate<C: Context>(
+        ctx: &mut C,
         meta: &mut types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {
@@ -261,16 +247,20 @@ impl module::MigrationHandler for Module {
     }
 }
 
-impl module::MethodRegistrationHandler for Module {
-    fn register_methods(methods: &mut module::MethodRegistry) {
-        // Queries.
-        methods.register_query(module::QueryMethodInfo {
-            name: "core.EstimateGas",
-            handler: Self::_query_estimate_gas_handler,
-        });
+impl module::MethodHandler for Module {
+    fn dispatch_query<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        args: cbor::Value,
+    ) -> module::DispatchResult<cbor::Value, Result<cbor::Value, error::RuntimeError>> {
+        match method {
+            "core.EstimateGas" => module::DispatchResult::Handled((|| {
+                let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
+                Ok(cbor::to_value(&Self::query_estimate_gas(ctx, args)?))
+            })()),
+            _ => module::DispatchResult::Unhandled(args),
+        }
     }
 }
 
 impl module::BlockHandler for Module {}
-
-impl module::MessageHookRegistrationHandler for Module {}

--- a/runtime-sdk/src/modules/rewards/mod.rs
+++ b/runtime-sdk/src/modules/rewards/mod.rs
@@ -7,11 +7,11 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    context::{Context, DispatchContext},
+    context::Context,
     core::{common::cbor, consensus::beacon},
     crypto::signature::PublicKey,
     error,
-    module::{self, Module as _, Parameters as _, QueryMethodInfo},
+    module::{self, Module as _, Parameters as _},
     modules, storage,
     types::address::Address,
 };
@@ -96,19 +96,8 @@ pub static ADDRESS_REWARD_POOL: Lazy<Address> =
     Lazy::new(|| Address::from_module(MODULE_NAME, "reward-pool"));
 
 impl<Accounts: modules::accounts::API> Module<Accounts> {
-    fn query_parameters(ctx: &mut DispatchContext<'_>, _args: ()) -> Result<Parameters, Error> {
+    fn query_parameters<C: Context>(ctx: &mut C, _args: ()) -> Result<Parameters, Error> {
         Ok(Self::params(ctx.runtime_state()))
-    }
-}
-
-impl<Accounts: modules::accounts::API> Module<Accounts> {
-    fn _query_parameters_handler(
-        _mi: &QueryMethodInfo,
-        ctx: &mut DispatchContext<'_>,
-        args: cbor::Value,
-    ) -> Result<cbor::Value, error::RuntimeError> {
-        let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
-        Ok(cbor::to_value(&Self::query_parameters(ctx, args)?))
     }
 }
 
@@ -119,21 +108,25 @@ impl<Accounts: modules::accounts::API> module::Module for Module<Accounts> {
     type Parameters = Parameters;
 }
 
-impl<Accounts: modules::accounts::API> module::MessageHookRegistrationHandler for Module<Accounts> {}
-
-impl<Accounts: modules::accounts::API> module::MethodRegistrationHandler for Module<Accounts> {
-    fn register_methods(methods: &mut module::MethodRegistry) {
-        // Queries.
-        methods.register_query(module::QueryMethodInfo {
-            name: "rewards.Parameters",
-            handler: Self::_query_parameters_handler,
-        });
+impl<Accounts: modules::accounts::API> module::MethodHandler for Module<Accounts> {
+    fn dispatch_query<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        args: cbor::Value,
+    ) -> module::DispatchResult<cbor::Value, Result<cbor::Value, error::RuntimeError>> {
+        match method {
+            "rewards.Parameters" => module::DispatchResult::Handled((|| {
+                let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
+                Ok(cbor::to_value(&Self::query_parameters(ctx, args)?))
+            })()),
+            _ => module::DispatchResult::Unhandled(args),
+        }
     }
 }
 
 impl<Accounts: modules::accounts::API> Module<Accounts> {
     /// Initialize state from genesis.
-    fn init(ctx: &mut DispatchContext<'_>, genesis: &Genesis) {
+    fn init<C: Context>(ctx: &mut C, genesis: &Genesis) {
         genesis
             .parameters
             .validate_basic()
@@ -144,7 +137,7 @@ impl<Accounts: modules::accounts::API> Module<Accounts> {
     }
 
     /// Migrate state from a previous version.
-    fn migrate(_ctx: &mut DispatchContext<'_>, _from: u32) -> bool {
+    fn migrate<C: Context>(_ctx: &mut C, _from: u32) -> bool {
         // No migrations currently supported.
         false
     }
@@ -153,8 +146,8 @@ impl<Accounts: modules::accounts::API> Module<Accounts> {
 impl<Accounts: modules::accounts::API> module::MigrationHandler for Module<Accounts> {
     type Genesis = Genesis;
 
-    fn init_or_migrate(
-        ctx: &mut DispatchContext<'_>,
+    fn init_or_migrate<C: Context>(
+        ctx: &mut C,
         meta: &mut modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {
@@ -174,7 +167,7 @@ impl<Accounts: modules::accounts::API> module::MigrationHandler for Module<Accou
 impl<Accounts: modules::accounts::API> module::AuthHandler for Module<Accounts> {}
 
 impl<Accounts: modules::accounts::API> module::BlockHandler for Module<Accounts> {
-    fn end_block(ctx: &mut DispatchContext<'_>) {
+    fn end_block<C: Context>(ctx: &mut C) {
         let epoch = ctx.epoch();
 
         // Load previous epoch.

--- a/runtime-sdk/src/modules/rewards/test.rs
+++ b/runtime-sdk/src/modules/rewards/test.rs
@@ -2,7 +2,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    context::{Context, DispatchContext},
+    context::Context,
     module::{BlockHandler, MigrationHandler},
     modules::{
         accounts::{self, Module as Accounts, API as _},
@@ -16,7 +16,7 @@ use super::{types, Genesis, Parameters, ADDRESS_REWARD_POOL};
 
 type Rewards = super::Module<Accounts>;
 
-fn init_accounts(ctx: &mut DispatchContext<'_>) {
+fn init_accounts<C: Context>(ctx: &mut C) {
     Accounts::init_or_migrate(
         ctx,
         &mut core::types::Metadata::default(),

--- a/runtime-sdk/src/testing/mock.rs
+++ b/runtime-sdk/src/testing/mock.rs
@@ -8,7 +8,7 @@ use oasis_core_runtime::{
 };
 
 use crate::{
-    context::{DispatchContext, Mode},
+    context::{Mode, RuntimeBatchContext},
     module::MigrationHandler,
     modules,
     runtime::Runtime,
@@ -44,7 +44,7 @@ impl Mock {
     /// Create a new mock dispatch context.
     pub fn create_ctx(
         &mut self,
-    ) -> DispatchContext<'_, EmptyRuntime, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
+    ) -> RuntimeBatchContext<'_, EmptyRuntime, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
         self.create_ctx_for_runtime(Mode::ExecuteTx)
     }
 
@@ -52,8 +52,8 @@ impl Mock {
     pub fn create_ctx_for_runtime<R: Runtime>(
         &mut self,
         mode: Mode,
-    ) -> DispatchContext<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
-        DispatchContext::new(
+    ) -> RuntimeBatchContext<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
+        RuntimeBatchContext::new(
             mode,
             &self.runtime_header,
             &self.runtime_round_results,

--- a/runtime-sdk/src/testing/mock.rs
+++ b/runtime-sdk/src/testing/mock.rs
@@ -1,21 +1,33 @@
 //! Mock dispatch context for use in tests.
-use std::collections::BTreeMap;
-
 use io_context::Context as IoContext;
 
 use oasis_core_runtime::{
-    common::{cbor, logger::get_logger},
+    common::{cbor, version::Version},
     consensus::{beacon, roothash, state::ConsensusState},
     storage::mkvs,
-    transaction::tags::Tags,
 };
 
 use crate::{
     context::{DispatchContext, Mode},
-    module::MethodRegistry,
+    module::MigrationHandler,
+    modules,
+    runtime::Runtime,
     storage,
     types::transaction,
 };
+
+/// A mock runtime that only has the core module.
+pub struct EmptyRuntime;
+
+impl Runtime for EmptyRuntime {
+    const VERSION: Version = Version::new(0, 0, 0);
+
+    type Modules = modules::core::Module;
+
+    fn genesis_state() -> <Self::Modules as MigrationHandler>::Genesis {
+        Default::default()
+    }
+}
 
 /// Mock dispatch context factory.
 pub struct Mock {
@@ -25,32 +37,32 @@ pub struct Mock {
     pub consensus_state: ConsensusState,
     pub epoch: beacon::EpochTime,
 
-    pub methods: MethodRegistry,
-
     pub max_messages: u32,
 }
 
 impl Mock {
     /// Create a new mock dispatch context.
-    pub fn create_ctx(&mut self) -> DispatchContext<'_> {
-        DispatchContext {
-            mode: Mode::ExecuteTx,
-            runtime_header: &self.runtime_header,
-            runtime_round_results: &self.runtime_round_results,
-            runtime_storage: storage::MKVSStore::new(
-                IoContext::background().freeze(),
-                self.mkvs.as_mut(),
-            ),
-            consensus_state: &self.consensus_state,
-            epoch: self.epoch,
-            io_ctx: IoContext::background().freeze(),
-            methods: &self.methods,
-            logger: get_logger("mock"),
-            block_tags: Tags::new(),
-            messages: Vec::new(),
-            max_messages: self.max_messages,
-            values: BTreeMap::new(),
-        }
+    pub fn create_ctx(
+        &mut self,
+    ) -> DispatchContext<'_, EmptyRuntime, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
+        self.create_ctx_for_runtime(Mode::ExecuteTx)
+    }
+
+    /// Create a new mock dispatch context.
+    pub fn create_ctx_for_runtime<R: Runtime>(
+        &mut self,
+        mode: Mode,
+    ) -> DispatchContext<'_, R, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
+        DispatchContext::new(
+            mode,
+            &self.runtime_header,
+            &self.runtime_round_results,
+            storage::MKVSStore::new(IoContext::background().freeze(), self.mkvs.as_mut()),
+            &self.consensus_state,
+            self.epoch,
+            IoContext::background().freeze(),
+            self.max_messages,
+        )
     }
 }
 
@@ -71,7 +83,6 @@ impl Default for Mock {
             mkvs: Box::new(mkvs),
             consensus_state: ConsensusState::new(consensus_tree),
             epoch: 1,
-            methods: MethodRegistry::new(),
             max_messages: 32,
         }
     }

--- a/runtime-sdk/src/types/message.rs
+++ b/runtime-sdk/src/types/message.rs
@@ -9,8 +9,12 @@ pub type MessageEvent = consensus::roothash::MessageEvent;
 
 /// Handler name and context to be called after message is executed.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MessageEventHookInvocation {
+    #[serde(rename = "hook_name")]
     pub hook_name: String,
+
+    #[serde(rename = "payload")]
     pub payload: cbor::Value,
 }
 
@@ -22,4 +26,12 @@ impl MessageEventHookInvocation {
             payload: cbor::to_value(payload),
         }
     }
+}
+
+/// Result of a message being processed by the consensus layer combined with the context for the
+/// result handler.
+#[derive(Clone, Debug)]
+pub struct MessageResult {
+    pub event: MessageEvent,
+    pub context: cbor::Value,
 }

--- a/tests/runtimes/simple-keyvalue/src/keyvalue.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue.rs
@@ -3,10 +3,10 @@ use thiserror::Error;
 
 use oasis_runtime_sdk::{
     self as sdk,
-    context::{Context, DispatchContext, TxContext},
+    context::Context,
     core::common::cbor,
     error::{Error as _, RuntimeError},
-    module::{CallableMethodInfo, Module as _, QueryMethodInfo},
+    module::Module as _,
     modules::{
         core,
         core::{Module as Core, API as _},
@@ -89,72 +89,57 @@ impl sdk::module::Module for Module {
 
 impl sdk::module::AuthHandler for Module {}
 impl sdk::module::BlockHandler for Module {}
-impl sdk::module::MessageHookRegistrationHandler for Module {}
 
-impl sdk::module::MethodRegistrationHandler for Module {
-    /// Register all supported methods.
-    fn register_methods(methods: &mut sdk::module::MethodRegistry) {
-        methods.register_callable(sdk::module::CallableMethodInfo {
-            name: "keyvalue.Insert",
-            handler: Self::_callable_insert_handler,
-        });
-        methods.register_callable(sdk::module::CallableMethodInfo {
-            name: "keyvalue.Remove",
-            handler: Self::_callable_remove_handler,
-        });
-        methods.register_query(sdk::module::QueryMethodInfo {
-            name: "keyvalue.Get",
-            handler: Self::_query_get_handler,
-        });
-    }
-}
-
-// Boilerplate.
-impl Module {
-    fn _callable_insert_handler(
-        _mi: &CallableMethodInfo,
-        ctx: &mut TxContext,
+impl sdk::module::MethodHandler for Module {
+    fn dispatch_call<C: Context>(
+        ctx: &mut C,
+        method: &str,
         body: cbor::Value,
-    ) -> CallResult {
-        let result = || -> Result<cbor::Value, Error> {
-            let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
-            Ok(cbor::to_value(&Self::insert(ctx, args)?))
-        }();
-        match result {
-            Ok(value) => CallResult::Ok(value),
-            Err(err) => err.to_call_result(),
+    ) -> sdk::module::DispatchResult<cbor::Value, CallResult> {
+        match method {
+            "keyvalue.Insert" => {
+                let result = || -> Result<cbor::Value, Error> {
+                    let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
+                    Ok(cbor::to_value(&Self::tx_insert(ctx, args)?))
+                }();
+                match result {
+                    Ok(value) => sdk::module::DispatchResult::Handled(CallResult::Ok(value)),
+                    Err(err) => sdk::module::DispatchResult::Handled(err.to_call_result()),
+                }
+            }
+            "keyvalue.Remove" => {
+                let result = || -> Result<cbor::Value, Error> {
+                    let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
+                    Ok(cbor::to_value(&Self::tx_remove(ctx, args)?))
+                }();
+                match result {
+                    Ok(value) => sdk::module::DispatchResult::Handled(CallResult::Ok(value)),
+                    Err(err) => sdk::module::DispatchResult::Handled(err.to_call_result()),
+                }
+            }
+            _ => sdk::module::DispatchResult::Unhandled(body),
         }
     }
 
-    fn _callable_remove_handler(
-        _mi: &CallableMethodInfo,
-        ctx: &mut TxContext,
-        body: cbor::Value,
-    ) -> CallResult {
-        let result = || -> Result<cbor::Value, Error> {
-            let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
-            Ok(cbor::to_value(&Self::remove(ctx, args)?))
-        }();
-        match result {
-            Ok(value) => CallResult::Ok(value),
-            Err(err) => err.to_call_result(),
+    fn dispatch_query<C: Context>(
+        ctx: &mut C,
+        method: &str,
+        args: cbor::Value,
+    ) -> sdk::module::DispatchResult<cbor::Value, Result<cbor::Value, RuntimeError>> {
+        match method {
+            "keyvalue.Get" => sdk::module::DispatchResult::Handled((|| {
+                let args = cbor::from_value(args).map_err(|_| Error::InvalidArgument)?;
+                Ok(cbor::to_value(&Self::query_get(ctx, args)?))
+            })()),
+            _ => sdk::module::DispatchResult::Unhandled(args),
         }
-    }
-
-    fn _query_get_handler(
-        _mi: &QueryMethodInfo,
-        ctx: &mut DispatchContext,
-        body: cbor::Value,
-    ) -> Result<cbor::Value, RuntimeError> {
-        let args = cbor::from_value(body).map_err(|_| Error::InvalidArgument)?;
-        Ok(cbor::to_value(&Self::get(ctx, args)?))
     }
 }
 
 // Actual implementation of this runtime's externally-callable methods.
 impl Module {
-    // Insert given keyvalue into storage.
-    fn insert(ctx: &mut TxContext, body: types::KeyValue) -> Result<(), Error> {
+    /// Insert given keyvalue into storage.
+    fn tx_insert<C: Context>(ctx: &mut C, body: types::KeyValue) -> Result<(), Error> {
         if ctx.is_check_only() {
             return Ok(());
         }
@@ -179,8 +164,8 @@ impl Module {
         Ok(())
     }
 
-    // Remove keyvalue from storage using given key.
-    fn remove(ctx: &mut TxContext, body: types::Key) -> Result<(), Error> {
+    /// Remove keyvalue from storage using given key.
+    fn tx_remove<C: Context>(ctx: &mut C, body: types::Key) -> Result<(), Error> {
         if ctx.is_check_only() {
             return Ok(());
         }
@@ -205,8 +190,8 @@ impl Module {
         Ok(())
     }
 
-    // Fetch keyvalue from storage using given key.
-    fn get(ctx: &mut DispatchContext, body: types::Key) -> Result<types::KeyValue, Error> {
+    /// Fetch keyvalue from storage using given key.
+    fn query_get<C: Context>(ctx: &mut C, body: types::Key) -> Result<types::KeyValue, Error> {
         let mut store = sdk::storage::PrefixStore::new(ctx.runtime_state(), &MODULE_NAME);
         let ts = sdk::storage::TypedStore::new(&mut store);
         let v: Vec<u8> = ts.get(body.key.clone()).ok_or(Error::InvalidArgument)?;
@@ -220,8 +205,8 @@ impl Module {
 impl sdk::module::MigrationHandler for Module {
     type Genesis = Genesis;
 
-    fn init_or_migrate(
-        ctx: &mut DispatchContext,
+    fn init_or_migrate<C: Context>(
+        ctx: &mut C,
         meta: &mut sdk::modules::core::types::Metadata,
         genesis: &Self::Genesis,
     ) -> bool {


### PR DESCRIPTION
Refactors the way method dispatch is performed by removing the method
registries and replacing them with static dispatch in the form of a
MethodHandler trait which needs to be provided by modules.

Additionally the contexts are made more composable by making sure that
the we take Context as a generic type argument everywhere and improving
the way simulation mode is handled.

Each context is now also bound to a specific Runtime type to allow for
nested method dispatch.