### PR TITLE
ts-web/core: version 0.1.0-alpha2

### DIFF
--- a/client-sdk/ts-web/core/.gitignore
+++ b/client-sdk/ts-web/core/.gitignore
@@ -4,4 +4,3 @@
 /node_modules
 /playground/dist/main.js
 /playground/untracked
-package-lock.json

--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## Unreleased changes
+## v0.1.0-alpha2
+
+Spotlight change:
+
+- A new `hdkey` module implements ADR 0008 key generation.
 
 New features:
 
 - Compatibility with oasis-core is updated to 21.1.1.
-- A new `hdkey` module implements ADR 0008 key generation.
 
 ## v0.1.0-alpha1
 

--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -5,6 +5,7 @@
 New features:
 
 - Compatibility with oasis-core is updated to 21.1.1.
+- A new `hdkey` module implements ADR 0008 key generation.
 
 ## v0.1.0-alpha1
 

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client",
-    "version": "0.1.0-alpha1",
+    "version": "0.1.0-alpha2",
     "license": "Apache-2.0",
     "files": [
         "dist"

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "bech32": "^1.1.4",
-        "cborg": "^1.1.2",
         "bip39": "^3.0.4",
+        "cborg": "^1.1.2",
         "grpc-web": "^1.2.1",
         "js-sha512": "^0.8.0",
         "tweetnacl": "^1.0.3"

--- a/client-sdk/ts-web/core/tsconfig.json
+++ b/client-sdk/ts-web/core/tsconfig.json
@@ -7,7 +7,7 @@
         "declaration": true,
         "resolveJsonModule": true
     },
-    "exclude": [
-        "test"
+    "include": [
+        "src/**/*"
     ]
 }

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -18,7 +18,7 @@
         },
         "core": {
             "name": "@oasisprotocol/client",
-            "version": "0.1.0-alpha1",
+            "version": "0.1.0-alpha2",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^1.1.4",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -484,27 +484,6 @@
                 }
             }
         },
-        "core/node_modules/ws": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-            "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -4445,9 +4424,9 @@
             "dev": true
         },
         "node_modules/dns-packet": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
             "dev": true,
             "dependencies": {
                 "ip": "^1.1.0",
@@ -11444,9 +11423,9 @@
             }
         },
         "node_modules/ssri": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+            "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
             "dev": true,
             "dependencies": {
                 "figgy-pudding": "^3.5.1"
@@ -13107,9 +13086,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-            "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
             "dev": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -14871,13 +14850,6 @@
                         "webpack-dev-middleware": "^4.1.0",
                         "ws": "^7.4.4"
                     }
-                },
-                "ws": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-                    "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
-                    "dev": true,
-                    "requires": {}
                 }
             }
         },
@@ -17558,9 +17530,9 @@
             "dev": true
         },
         "dns-packet": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
             "dev": true,
             "requires": {
                 "ip": "^1.1.0",
@@ -23090,9 +23062,9 @@
             }
         },
         "ssri": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+            "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
             "dev": true,
             "requires": {
                 "figgy-pudding": "^3.5.1"
@@ -24386,9 +24358,9 @@
             }
         },
         "ws": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-            "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
             "dev": true,
             "requires": {}
         },

--- a/client-sdk/ts-web/rt/.gitignore
+++ b/client-sdk/ts-web/rt/.gitignore
@@ -4,4 +4,3 @@
 /node_modules
 /playground/dist/main.js
 /playground/untracked
-package-lock.json


### PR DESCRIPTION
Here's the preparation for releasing @oasisprotocol/client version 0.1.0-alpha2.

It's desired that we make a release with the new ADR 0008 implementation.

If we accept this, I'll build on master and upload to npm.

`npm pack --dry-run` output:

```
npm notice 
npm notice 📦  @oasisprotocol/client@0.1.0-alpha2
npm notice === Tarball Contents === 
npm notice 2.2kB  README.md           
npm notice 285B   dist/address.d.ts   
npm notice 945B   dist/address.js     
npm notice 1.3kB  dist/beacon.d.ts    
npm notice 1.7kB  dist/beacon.js      
npm notice 23.7kB dist/client.d.ts    
npm notice 41.8kB dist/client.js      
npm notice 2.7kB  dist/common.d.ts    
npm notice 3.5kB  dist/common.js      
npm notice 4.1kB  dist/consensus.d.ts 
npm notice 5.7kB  dist/consensus.js   
npm notice 342B   dist/control.d.ts   
npm notice 475B   dist/control.js     
npm notice 117B   dist/genesis.d.ts   
npm notice 304B   dist/genesis.js     
npm notice 2.1kB  dist/governance.d.ts
npm notice 2.6kB  dist/governance.js  
npm notice 69B    dist/hash.d.ts      
npm notice 262B   dist/hash.js        
npm notice 1.3kB  dist/hdkey.d.ts     
npm notice 3.1kB  dist/hdkey.js       
npm notice 876B   dist/index.d.ts     
npm notice 1.4kB  dist/index.js       
npm notice 592B   dist/keymanager.d.ts
npm notice 772B   dist/keymanager.js  
npm notice 357B   dist/misc.d.ts      
npm notice 2.9kB  dist/misc.js        
npm notice 117B   dist/quantity.d.ts  
npm notice 526B   dist/quantity.js    
npm notice 7.5kB  dist/registry.d.ts  
npm notice 9.1kB  dist/registry.js    
npm notice 7.2kB  dist/roothash.d.ts  
npm notice 9.7kB  dist/roothash.js    
npm notice 1.4kB  dist/runtime.d.ts   
npm notice 1.7kB  dist/runtime.js     
npm notice 858B   dist/scheduler.d.ts 
npm notice 1.1kB  dist/scheduler.js   
npm notice 2.8kB  dist/signature.d.ts 
npm notice 4.7kB  dist/signature.js   
npm notice 7.7kB  dist/staking.d.ts   
npm notice 10.4kB dist/staking.js     
npm notice 5.8kB  dist/storage.d.ts   
npm notice 7.1kB  dist/storage.js     
npm notice 78.0kB dist/types.d.ts     
npm notice 77B    dist/types.js       
npm notice 1.5kB  dist/upgrade.d.ts   
npm notice 1.8kB  dist/upgrade.js     
npm notice 278B   dist/worker.d.ts    
npm notice 412B   dist/worker.js      
npm notice 785B   package.json        
npm notice === Tarball Details === 
npm notice name:          @oasisprotocol/client                   
npm notice version:       0.1.0-alpha2                            
npm notice filename:      @oasisprotocol/client-0.1.0-alpha2.tgz  
npm notice package size:  56.5 kB                                 
npm notice unpacked size: 265.8 kB                                
npm notice shasum:        2cccbc1bc9903c4dd1ddc104555a438d88ac4b08
npm notice integrity:     sha512-UsBLuhXxZHEhc[...]oWlHWW+zGGDSQ==
npm notice total files:   50                                      
npm notice 
oasisprotocol-client-0.1.0-alpha2.tgz
```