### PR TITLE
docs adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI lint status][github-ci-lint-badge]][github-ci-lint-link]
 [![CI audit status][github-ci-audit-badge]][github-ci-audit-link]
+[![CI test status][github-ci-test-badge]][github-ci-test-link]
 [![Rust coverage][codecov-badge]][codecov-link]
 
 <!-- markdownlint-disable line-length -->
@@ -9,6 +10,8 @@
 [github-ci-lint-link]: https://github.com/oasisprotocol/oasis-sdk/actions?query=workflow:ci-lint+branch:main
 [github-ci-audit-badge]: https://github.com/oasisprotocol/oasis-sdk/workflows/ci-audit/badge.svg
 [github-ci-audit-link]: https://github.com/oasisprotocol/oasis-sdk/actions?query=workflow:ci-audit+branch:main
+[github-ci-test-badge]: https://github.com/oasisprotocol/oasis-sdk/workflows/ci-test/badge.svg
+[github-ci-test-link]: https://github.com/oasisprotocol/oasis-sdk/actions?query=workflow:ci-test+branch:main
 [codecov-badge]: https://codecov.io/gh/oasisprotocol/oasis-sdk/branch/main/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/oasisprotocol/oasis-sdk
 <!-- markdownlint-enable line-length -->

--- a/client-sdk/ts-web/core/docs/getting-started.md
+++ b/client-sdk/ts-web/core/docs/getting-started.md
@@ -24,12 +24,23 @@ We have [a sample that uses webpack](../playground/webpack.config.js).
 ```js
 import * as oasis from '@oasisprotocol/client';
 
-const client = new oasis.OasisNodeClient('http://localhost:42280');
+// Use https://grpc-web.oasis.dev/api/testnet to interact with the testnet instead.
+const client = new oasis.OasisNodeClient('https://grpc-web.oasis.dev/api/mainnet');
 ```
+
+This connects to a public oasis-node instance.
+For security and performance reasons, some methods are not permitted.
+See the Advanced deployment section below for how to set up your own node with
+a custom set of enabled methods.
 
 # Example code
 
 We have [a few sample interactions](../playground/src/index.js).
+
+Not all methods used this sample are permitted on the public oasis-node
+instance.
+See the Advanced deployment section below for how to set up your own node with
+a custom set of enabled methods.
 
 # Now what
 

--- a/client-sdk/ts-web/core/docs/getting-started.md
+++ b/client-sdk/ts-web/core/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Putting together the pieces
+# Getting started
 
 ## Overview
 
@@ -63,6 +63,9 @@ submodules whose names don't show up in the TypeScript names here.
 Types named the same thing as the module are singly named here; for example,
 `signature.Signature` from oasis-core is just `Signature` here, not
 `SignatureSignature`.
+Most non-structure types don't have dedicated types on the TypeScript side.
+For example, `signature.PublicKey`, `hash.Hash`, and `address.Address` are all
+plain `Uint8Array`s.
 
 **Helpers** are mostly newly written in TypeScript and have slightly different
 style from oasis-core.
@@ -77,14 +80,16 @@ Collections of helpers corresponding to functionality from `go/common/...`
 modules appear in their own module here instead of in `common.ts` when they
 mostly don't correspond to oasis-core functions.
 
-**Constants** are named reminiscent to their oasis-core counterparts, but are
-they in PascalCase in Go and SCREAMING_SNAKE_CASE here.
+**Constants** are named reminiscent to their oasis-core counterparts, but they
+are in PascalCase in Go and SCREAMING_SNAKE_CASE here.
 (We've also nabbed some top secret camelCase Go private constants, but don't
 tell anyone.)
 Some constants like signature contexts and errors are structures in oasis-core
 but appear here as multiple primitive values.
 
 # Advanced deployment
+
+You can also run your own Oasis node with gRPC proxy.
 
 <!-- Authored on https://app.diagrams.net/. -->
 ![](ts-web-blocks.svg)
@@ -95,12 +100,16 @@ but appear here as multiple primitive values.
 1. Getting Envoy
 1. Configuring Envoy
 1. Running Envoy
+1. Using the SDK with your node
 
 ## Setting up a node
 
 Setting up a node results in a running process with a Unix domain socket named
 `internal.sock` that allows other programs to interact with the node, and
 through that, the network.
+We have external documentation both on setting up a node to connect to an
+existing network such as the mainnet or testnet and on setting up an entire
+local testnet of your own.
 
 ### Connect to an existing network
 
@@ -117,6 +126,9 @@ See [our guide on how to use
 oasis-net-runner](https://docs.oasis.dev/oasis-core/development-setup/running-tests-and-development-networks/oasis-net-runner).
 In this case, the net runner creates a "client" node, and you should proceed
 using that node's socket.
+The instructions there set up the socket to be in
+`/tmp/oasis-net-runnerXXXXXXXXX/net-runner/network/client-0/internal.sock`,
+where the `XXXXXXXXX` is a random number.
 
 ## Getting Envoy
 
@@ -157,3 +169,12 @@ If you're running Envoy in Docker, you can use volume mounts to allow envoy
 to access the YAML config file and the node's UNIX socket, and you can set the
 container to use the "host" network so that Envoy can connect to the web
 server.
+
+## Using the SDK with your node
+
+When you create an `OasisNodeClient`, pass the HTTP endpoint of your Envoy
+proxy:
+
+```js
+const client = new oasis.OasisNodeClient('http://localhost:42280');
+```

--- a/client-sdk/ts-web/core/docs/getting-started.md
+++ b/client-sdk/ts-web/core/docs/getting-started.md
@@ -1,78 +1,9 @@
 # Putting together the pieces
 
-<!-- Authored on https://app.diagrams.net/. -->
-![](ts-web-blocks.svg)
-
 ## Overview
 
-1. Setting up a non-validator node
-1. Getting Envoy
-1. Configuring Envoy
-1. Running Envoy
 1. Getting this SDK and building
 1. Connecting from your web app
-
-## Setting up a node
-
-Setting up a node results in a running process with a Unix domain socket named
-`internal.sock` that allows other programs to interact with the node, and
-through that, the network.
-
-### Connect to an existing network
-
-For use with an existing network such as the Oasis Mainnet, see [our docs on
-how to run a non-validator
-node](https://docs.oasis.dev/general/run-a-node/set-up-your-node/run-non-validator).
-The instructions there set up the socket to be in `/node/data/internal.sock`.
-
-### Create a local testnet
-
-For development, you can alternatively run your own local testnet using
-oasis-net-runner.
-See [our guide on how to use
-oasis-net-runner](https://docs.oasis.dev/oasis-core/development-setup/running-tests-and-development-networks/oasis-net-runner).
-In this case, the net runner creates a "client" node, and you should proceed
-using that node's socket.
-
-## Getting Envoy
-
-See [Installing
-Envoy](https://www.envoyproxy.io/docs/envoy/latest/start/install)
-for a variety of ways to get Envoy.
-
-In our sample setup, we use [the distribution from Get
-Envoy](https://www.getenvoy.io/).
-
-## Configuring Envoy
-
-Notably, need to configure a route to forward requests from the distinctly
-browser-compatible gRPC-web protocol to the Unix domain socket in native gRPC.
-
-See [our sample configuration](../playground/sample-envoy.yaml) for one way to
-do it.
-You'll need to adjust the following:
-
-- `.match.safe_regex.regex` in the route, for setting up a method whitelist
-- `.load_assignment.endpoints[0].lb_endpoints[0].endpoint.address.pipe.path`
-  in the `oasis_node_grpc` cluster, to point to your node's socket
-- `.load_assignment.endpoints[0].lb_endpoints[0].endpoint.address.socket_address`
-  in the `dev_static` cluster, to point to your web server
-
-You can alternatively disable the `dev_static` cluster and its corresponding
-route, enable CORS, and serve your web app from a separate origin.
-
-![](ts-web-blocks-cors.svg)
-
-## Running Envoy
-
-In our sample, we run Envoy and proxy the web app through it.
-
-See [our sample invocation](../playground/sample-run-envoy.sh).
-
-If you're running Envoy in Docker, you can use volume mounts to allow envoy
-to access the YAML config file and the node's UNIX socket, and you can set the
-container to use the "host" network so that Envoy can connect to the web
-server.
 
 ## Getting this SDK and building
 
@@ -141,3 +72,77 @@ they in PascalCase in Go and SCREAMING_SNAKE_CASE here.
 tell anyone.)
 Some constants like signature contexts and errors are structures in oasis-core
 but appear here as multiple primitive values.
+
+# Advanced deployment
+
+<!-- Authored on https://app.diagrams.net/. -->
+![](ts-web-blocks.svg)
+
+## Overview
+
+1. Setting up a non-validator node
+1. Getting Envoy
+1. Configuring Envoy
+1. Running Envoy
+
+## Setting up a node
+
+Setting up a node results in a running process with a Unix domain socket named
+`internal.sock` that allows other programs to interact with the node, and
+through that, the network.
+
+### Connect to an existing network
+
+For use with an existing network such as the Oasis Mainnet, see [our docs on
+how to run a non-validator
+node](https://docs.oasis.dev/general/run-a-node/set-up-your-node/run-non-validator).
+The instructions there set up the socket to be in `/node/data/internal.sock`.
+
+### Create a local testnet
+
+For development, you can alternatively run your own local testnet using
+oasis-net-runner.
+See [our guide on how to use
+oasis-net-runner](https://docs.oasis.dev/oasis-core/development-setup/running-tests-and-development-networks/oasis-net-runner).
+In this case, the net runner creates a "client" node, and you should proceed
+using that node's socket.
+
+## Getting Envoy
+
+See [Installing
+Envoy](https://www.envoyproxy.io/docs/envoy/latest/start/install)
+for a variety of ways to get Envoy.
+
+In our sample setup, we use [the distribution from Get
+Envoy](https://www.getenvoy.io/).
+
+## Configuring Envoy
+
+Notably, need to configure a route to forward requests from the distinctly
+browser-compatible gRPC-web protocol to the Unix domain socket in native gRPC.
+
+See [our sample configuration](../playground/sample-envoy.yaml) for one way to
+do it.
+You'll need to adjust the following:
+
+- `.match.safe_regex.regex` in the route, for setting up a method whitelist
+- `.load_assignment.endpoints[0].lb_endpoints[0].endpoint.address.pipe.path`
+  in the `oasis_node_grpc` cluster, to point to your node's socket
+- `.load_assignment.endpoints[0].lb_endpoints[0].endpoint.address.socket_address`
+  in the `dev_static` cluster, to point to your web server
+
+You can alternatively disable the `dev_static` cluster and its corresponding
+route, enable CORS, and serve your web app from a separate origin.
+
+![](ts-web-blocks-cors.svg)
+
+## Running Envoy
+
+In our sample, we run Envoy and proxy the web app through it.
+
+See [our sample invocation](../playground/sample-run-envoy.sh).
+
+If you're running Envoy in Docker, you can use volume mounts to allow envoy
+to access the YAML config file and the node's UNIX socket, and you can set the
+container to use the "host" network so that Envoy can connect to the web
+server.


### PR DESCRIPTION
notably, this adds a shorter 'getting started' section for the @oasisprotocol/client package that uses the public oasis-node + Envoy server