### PR TITLE
ts-web/core: bech32 2.0.0

### DIFF
--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -15,7 +15,6 @@
         "test": "jest"
     },
     "dependencies": {
-        "bech32": "^1.1.4",
         "bip39": "^3.0.4",
         "cborg": "^1.1.2",
         "grpc-web": "^1.2.1",
@@ -24,6 +23,7 @@
     },
     "devDependencies": {
         "@types/jest": "^26.0.23",
+        "bech32": "^2.0.0",
         "buffer": "^6.0.3",
         "cypress": "^6.6.0",
         "jest": "^26.6.3",

--- a/client-sdk/ts-web/core/src/address.ts
+++ b/client-sdk/ts-web/core/src/address.ts
@@ -1,4 +1,4 @@
-import * as bech32 from 'bech32';
+import {bech32} from 'bech32';
 
 import * as hash from './hash';
 import * as misc from './misc';

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -15,7 +15,6 @@
             "version": "0.1.0-alpha2",
             "license": "Apache-2.0",
             "dependencies": {
-                "bech32": "^1.1.4",
                 "bip39": "^3.0.4",
                 "cborg": "^1.1.2",
                 "grpc-web": "^1.2.1",
@@ -24,6 +23,7 @@
             },
             "devDependencies": {
                 "@types/jest": "^26.0.23",
+                "bech32": "^2.0.0",
                 "buffer": "^6.0.3",
                 "cypress": "^6.6.0",
                 "jest": "^26.6.3",
@@ -36,6 +36,12 @@
                 "webpack-cli": "^4.7.0",
                 "webpack-dev-server": "^4.0.0-beta.3"
             }
+        },
+        "core/node_modules/bech32": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+            "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+            "dev": true
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.13",
@@ -11639,7 +11645,7 @@
             "version": "file:core",
             "requires": {
                 "@types/jest": "^26.0.23",
-                "bech32": "^1.1.4",
+                "bech32": "2.0.0",
                 "bip39": "^3.0.4",
                 "buffer": "^6.0.3",
                 "cborg": "^1.1.2",
@@ -11656,6 +11662,14 @@
                 "webpack": "^5.38.1",
                 "webpack-cli": "^4.7.0",
                 "webpack-dev-server": "^4.0.0-beta.3"
+            },
+            "dependencies": {
+                "bech32": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+                    "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+                    "dev": true
+                }
             }
         },
         "@oasisprotocol/client-rt": {
@@ -11663,12 +11677,12 @@
             "requires": {
                 "@oasisprotocol/client": "^0.1.0-alpha1",
                 "@types/elliptic": "^6.4.12",
-                "buffer": "*",
+                "buffer": "^6.0.3",
                 "cypress": "^6.6.0",
                 "elliptic": "^6.5.3",
                 "prettier": "^2.2.1",
-                "process": "*",
-                "stream-browserify": "*",
+                "process": "^0.11.10",
+                "stream-browserify": "^3.0.0",
                 "typescript": "^4.3.2",
                 "webpack": "^5.38.1",
                 "webpack-cli": "^4.7.0",


### PR DESCRIPTION
this is what it would look like. seems like they added a bech32m implementation.

although this does take us out of sync with @oasisprotocol/ledger :thinking: 

manual version of #174