### PR TITLE
Add context to error messages

### DIFF
--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -98,8 +98,8 @@ impl<R: Runtime> Dispatcher<R> {
         // TODO: Check against transaction size limit.
 
         // Deserialize transaction.
-        let utx: types::transaction::UnverifiedTransaction =
-            cbor::from_slice(&tx).map_err(|_| modules::core::Error::MalformedTransaction)?;
+        let utx: types::transaction::UnverifiedTransaction = cbor::from_slice(&tx)
+            .map_err(|e| modules::core::Error::MalformedTransaction(e.into()))?;
 
         // Perform any checks before signature verification.
         R::Modules::approve_unverified_tx(ctx, &utx)?;
@@ -107,7 +107,7 @@ impl<R: Runtime> Dispatcher<R> {
         // Verify transaction signatures.
         // TODO: Support signature verification of the whole transaction batch.
         utx.verify()
-            .map_err(|_| modules::core::Error::MalformedTransaction)
+            .map_err(|e| modules::core::Error::MalformedTransaction(e.into()))
     }
 
     /// Run the dispatch steps inside a transaction context. This includes the before call hooks

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -30,6 +30,15 @@ impl<B, R> DispatchResult<B, R> {
             DispatchResult::Unhandled(_) => Err(err),
         }
     }
+
+    /// Transforms `DispatchResult<B, R>` into `Result<R, E>`, mapping `Handled(r)` to `Ok(r)` and
+    /// `Unhandled(_)` to `Err(err)` using the provided function.
+    pub fn ok_or_else<E, F: FnOnce() -> E>(self, errf: F) -> Result<R, E> {
+        match self {
+            DispatchResult::Handled(result) => Ok(result),
+            DispatchResult::Unhandled(_) => Err(errf()),
+        }
+    }
 }
 
 /// Method handler.

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -32,7 +32,7 @@ pub mod types;
 const MODULE_NAME: &str = "accounts";
 
 /// Errors emitted by the accounts module.
-#[derive(Error, Debug, PartialEq, oasis_runtime_sdk_macros::Error)]
+#[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
 pub enum Error {
     #[error("invalid argument")]
     #[sdk_error(code = 1)]

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -191,11 +191,13 @@ fn test_api_tx_transfer_disabled() {
 
     // Try to transfer.
     ctx.with_tx(tx, |mut tx_ctx, call| {
-        assert_eq!(
-            Err(Error::Forbidden),
-            Accounts::tx_transfer(&mut tx_ctx, cbor::from_value(call.body).unwrap()),
+        assert!(
+            matches!(
+                Accounts::tx_transfer(&mut tx_ctx, cbor::from_value(call.body).unwrap()),
+                Err(Error::Forbidden),
+            ),
             "transfers are forbidden",
-        );
+        )
     });
 }
 

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -23,11 +23,11 @@ pub mod types;
 pub const MODULE_NAME: &str = "core";
 
 /// Errors emitted by the core module.
-#[derive(Error, Debug, PartialEq, oasis_runtime_sdk_macros::Error)]
+#[derive(Error, Debug, oasis_runtime_sdk_macros::Error)]
 pub enum Error {
-    #[error("malformed transaction")]
+    #[error("malformed transaction: {0}")]
     #[sdk_error(code = 1)]
-    MalformedTransaction,
+    MalformedTransaction(anyhow::Error),
 
     #[error("invalid transaction: {0}")]
     #[sdk_error(code = 2)]


### PR DESCRIPTION
This was useful for me to determine that txs require at least one signature, but I don't really know why that's true.