### PR TITLE
Allow runtimes to accept unsigned transactions

### DIFF
--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -103,7 +103,7 @@ impl<R: Runtime> Dispatcher<R> {
 
         // Verify transaction signatures.
         // TODO: Support signature verification of the whole transaction batch.
-        utx.verify()
+        utx.verify(ALLOW_UNSIGNED_TXS)
             .map_err(|_| modules::core::Error::MalformedTransaction)
     }
 

--- a/runtime-sdk/src/runtime.rs
+++ b/runtime-sdk/src/runtime.rs
@@ -17,6 +17,14 @@ pub trait Runtime {
     /// Runtime version.
     const VERSION: version::Version;
 
+    /// Whether the runtime accepts unsigned transactions.
+    ///
+    /// **Note:** some modules require a signer (e.g., the accounts module
+    /// treats the first signer as the gas payer. If you're using such a
+    /// module setting this flag to `true` will cause erroneous behavior.
+    #[doc(hidden)]
+    const ALLOW_UNSIGNED_TXS: bool = false;
+
     type Modules: AuthHandler + MigrationHandler + MethodHandler + BlockHandler;
 
     /// Genesis state for the runtime.


### PR DESCRIPTION
Say the runtime is inside of a VPC with the gateway. Decentralized? No, but at least I don't need to worry about managing useless secrets. Also, this is useful for development.

re: #215 