### PR TITLE
runtime-sdk: begin and end block during check batch

### DIFF
--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -361,11 +361,17 @@ impl<R: Runtime> transaction::dispatcher::Dispatcher for Dispatcher<R> {
             // Perform state migrations if required.
             R::migrate(&mut ctx);
 
+            // Run begin block hooks.
+            R::Modules::begin_block(&mut ctx);
+
             // Check the batch.
             let mut results = Vec::with_capacity(batch.len());
             for tx in batch.iter() {
                 results.push(Self::check_tx(&mut ctx, &tx)?);
             }
+
+            // Run end block hooks.
+            R::Modules::end_block(&mut ctx);
 
             Ok(results)
         })


### PR DESCRIPTION
This PR makes it more straightforward to do setup/teardown actions without knowing whether the runtime is being invoked in check vs execute mode.