### PR TITLE
ts-web/ext-utils: fix webpack-dev-server version

### DIFF
--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -28,6 +28,7 @@
         "stream-browserify": "^3.0.0",
         "typescript": "^4.3.2",
         "webpack": "^5.41.0",
-        "webpack-cli": "^4.7.2"
+        "webpack-cli": "^4.7.2",
+        "webpack-dev-server": "^4.0.0-beta.3"
     }
 }

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -54,7 +54,8 @@
                 "stream-browserify": "^3.0.0",
                 "typescript": "^4.3.2",
                 "webpack": "^5.41.0",
-                "webpack-cli": "^4.7.2"
+                "webpack-cli": "^4.7.2",
+                "webpack-dev-server": "^4.0.0-beta.3"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -9690,7 +9691,8 @@
                 "stream-browserify": "^3.0.0",
                 "typescript": "^4.3.2",
                 "webpack": "^5.41.0",
-                "webpack-cli": "^4.7.2"
+                "webpack-cli": "^4.7.2",
+                "webpack-dev-server": "4.0.0-beta.3"
             }
         },
         "@oasisprotocol/client-rt": {


### PR DESCRIPTION
Our samples' webpack configs are written for webpack-dev-server 4. Add that to our package.json.

Previously this worked by npm installing this for the outer workspace from other packages' requests. This is more explicit.