### PR TITLE
runtime-sdk/core: do not enforce batch gas limit for CheckTx

### DIFF
--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -186,6 +186,10 @@ impl Module {
 
 impl API for Module {
     fn use_batch_gas<C: Context>(ctx: &mut C, gas: u64) -> Result<(), Error> {
+        // Do not enforce batch limits for check-tx.
+        if ctx.is_check_only() {
+            return Ok(());
+        }
         let batch_gas_limit = Self::params(ctx.runtime_state()).max_batch_gas;
         let batch_gas_used = ctx.value::<u64>(CONTEXT_KEY_GAS_USED).or_default();
         let batch_new_gas_used = batch_gas_used

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -66,6 +66,14 @@ fn test_use_gas() {
     });
 
     Core::use_batch_gas(&mut ctx, 1).expect_err("batch gas should accumulate outside tx");
+
+    let mut ctx = mock.create_check_ctx();
+    let mut big_tx = tx.clone();
+    big_tx.auth_info.fee.gas = u64::MAX;
+    ctx.with_tx(big_tx, |mut tx_ctx, _call| {
+        Core::use_tx_gas(&mut tx_ctx, u64::MAX)
+            .expect("batch overflow should not happen in check-tx");
+    });
 }
 
 // Module that implements the gas waster method.

--- a/runtime-sdk/src/testing/mock.rs
+++ b/runtime-sdk/src/testing/mock.rs
@@ -52,6 +52,12 @@ impl Mock {
         self.create_ctx_for_runtime(Mode::ExecuteTx)
     }
 
+    pub fn create_check_ctx(
+        &mut self,
+    ) -> RuntimeBatchContext<'_, EmptyRuntime, storage::MKVSStore<&mut dyn mkvs::MKVS>> {
+        self.create_ctx_for_runtime(Mode::CheckTx)
+    }
+
     /// Create a new mock dispatch context.
     pub fn create_ctx_for_runtime<R: Runtime>(
         &mut self,

--- a/tests/benchmark/run-benchmarks.sh
+++ b/tests/benchmark/run-benchmarks.sh
@@ -60,4 +60,4 @@ sleep 2
     --address "${CLIENT_SOCK}" \
     --runtime.id "8000000000000000000000000000000000000000000000000000000000000000" \
     --benchmarks accounts_transfers \
-    --benchmarks.concurrency 6000
+    --benchmarks.concurrency 500 # bump after oasis-core is bumped to include check-tx batching.


### PR DESCRIPTION
With https://github.com/oasisprotocol/oasis-core/pull/4131 oasis-core will be scheduling CheckTx batches. The runtime scheduler cannot enforce batch-limits for non-checked transactions, therefore the runtime should not enforce these either.

Other batch limits (emitted messages, batch size) are already not enforced for check-tx batches.