### PR TITLE
ci: install ts-web/core package first

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -102,6 +102,10 @@ jobs:
         working-directory: client-sdk/ts-web/core
         run: npm run-script lint
 
+      - name: Lint ts-web/ext-utils
+        working-directory: client-sdk/ts-web/ext-utils
+        run: npm run-script lint
+
       - name: Lint ts-web/signer-ledger
         working-directory: client-sdk/ts-web/signer-ledger
         run: npm run-script lint

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -90,7 +90,11 @@ jobs:
       - name: Set up npm
         run: npm install npm@7 -g
 
-      - name: Install Node deps
+      - name: Install ts-web/core
+        working-directory: client-sdk/ts-web
+        run: npm ci --workspace core
+
+      - name: Install other packages
         working-directory: client-sdk/ts-web
         run: npm ci
 

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -106,37 +106,25 @@ jobs:
       - name: Set up npm
         run: npm install npm@7 -g
 
-      - name: Install Node deps
+      - name: Install ts-web/core
+        working-directory: client-sdk/ts-web
+        run: npm ci --workspace core
+
+      - name: Install other packages
         working-directory: client-sdk/ts-web
         run: npm ci
-
-      - name: Prepare ts-web/core
-        working-directory: client-sdk/ts-web/core
-        run: npm run-script prepare
 
       - name: Check ts-web/core playground
         working-directory: client-sdk/ts-web/core
         run: npm run-script check-playground
 
-      - name: Prepare ts-web/signer-ledger
-        working-directory: client-sdk/ts-web/signer-ledger
-        run: npm run-script prepare
-
       - name: Check ts-web/signer-ledger playground
         working-directory: client-sdk/ts-web/signer-ledger
         run: npm run-script check-playground
 
-      - name: Prepare ts-web/rt
-        working-directory: client-sdk/ts-web/rt
-        run: npm run-script prepare
-
       - name: Check ts-web/rt playground
         working-directory: client-sdk/ts-web/rt
         run: npm run-script check-playground
-
-      - name: Prepare ts-web/ext-utils
-        working-directory: client-sdk/ts-web/ext-utils
-        run: npm run-script prepare
 
       - name: Check ts-web/ext-utils sample-page
         working-directory: client-sdk/ts-web/ext-utils
@@ -162,13 +150,13 @@ jobs:
       - name: Set up npm
         run: npm install npm@7 -g
 
-      - name: Install Node deps
+      - name: Install ts-web/core
+        working-directory: client-sdk/ts-web
+        run: npm ci --workspace core
+
+      - name: Install other packages
         working-directory: client-sdk/ts-web
         run: npm ci
-
-      - name: Prepare ts-web/core
-        working-directory: client-sdk/ts-web/core
-        run: npm run-script prepare
 
       - name: 'dev-server: Start'
         working-directory: client-sdk/ts-web/core
@@ -227,21 +215,13 @@ jobs:
       - name: Set up npm
         run: npm install npm@7 -g
 
-      - name: Install Node deps
+      - name: Install ts-web/core
+        working-directory: client-sdk/ts-web
+        run: npm ci --workspace core
+
+      - name: Install other packages
         working-directory: client-sdk/ts-web
         run: npm ci
-
-      - name: Prepare ts-web/core
-        working-directory: client-sdk/ts-web/core
-        run: npm run-script prepare
-
-      - name: Prepare ts-web/rt
-        working-directory: client-sdk/ts-web/rt
-        run: npm run-script prepare
-
-      - name: Prepare ts-web/ext-utils
-        working-directory: client-sdk/ts-web/ext-utils
-        run: npm run-script prepare
 
       - name: 'dev-server sample-page: Start'
         working-directory: client-sdk/ts-web/ext-utils
@@ -278,17 +258,13 @@ jobs:
       - name: Set up npm
         run: npm install npm@7 -g
 
-      - name: Install Node deps
+      - name: Install ts-web/core
+        working-directory: client-sdk/ts-web
+        run: npm ci --workspace core
+
+      - name: Install other packages
         working-directory: client-sdk/ts-web
         run: npm ci
-
-      - name: Prepare ts-web/core
-        working-directory: client-sdk/ts-web/core
-        run: npm run-script prepare
-
-      - name: Prepare ts-web/rt
-        working-directory: client-sdk/ts-web/rt
-        run: npm run-script prepare
 
       - name: 'dev-server: Start'
         working-directory: client-sdk/ts-web/rt
@@ -391,7 +367,11 @@ jobs:
       - name: Set up npm
         run: npm install npm@7 -g
 
-      - name: Install Node deps
+      - name: Install ts-web/core
+        working-directory: client-sdk/ts-web
+        run: npm ci --workspace core
+
+      - name: Install other packages
         working-directory: client-sdk/ts-web
         run: npm ci
 


### PR DESCRIPTION
fixes #291 

seems npm now runs 'lifecycle scripts' during workspace install https://github.com/npm/cli/issues/2900 https://github.com/npm/arborist/commit/5a4c1062aa7d0ca228fca20c6835a6a26e434f89. from convenient, no? we save a few `npm run prepare` steps.

but it does kind of a shoddy job of it. it runs all the packages' `prepare` scripts at the same time, concurrently. however, other dev tools we use, such as tsc, rely on dependencies already being built, so this broke things for us.

for now, we manually encode that `core` is lower (?) in the dependency graph and manually do that first. then we install the other packages, although I'm pretty sure that recompiles `core` :roll_eyes: 