### PR TITLE
runtime-sdk: Replace serde-cbor with oasis-cbor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
+checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
 ]
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "b2a930fd487faaa92a30afa92cc9dd1526a5cff67124abbbb1c617ce070f4dcf"
 dependencies = [
  "aead",
  "aes",
@@ -199,9 +199,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cb0ed2d2ce37766ac86c05f66973ace8c51f7f1533bedce8fb79e2b54b3f14"
+checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
  "signature",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -757,12 +757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +768,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac 0.11.1",
  "digest",
 ]
 
@@ -834,9 +828,9 @@ checksum = "6deff8086863b4b598829cfe72d405540d1497fe997f903cc171aade51dae88c"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -883,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libm"
@@ -974,7 +968,6 @@ dependencies = [
  "autocfg 1.0.1",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1038,9 +1031,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "oasis-cbor"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a714efa871254872ab829697ca51931fb3bc261e5c982bb7491548f09bc7a6f"
+dependencies = [
+ "impl-trait-for-tuples",
+ "oasis-cbor-derive",
+ "sk-cbor",
+ "thiserror",
+]
+
+[[package]]
+name = "oasis-cbor-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443eb6a8dbb39373377072d28d97aeee08ba8725b0517d6f0a0a1d0a5a4ddc4"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "sk-cbor",
+ "syn",
+]
+
+[[package]]
 name = "oasis-core-runtime"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.2.5#c7dbeb55f204eea8fd28babf741087a82891069f"
+source = "git+https://github.com/oasisprotocol/oasis-core?rev=a1c9fe982c32d550e8eac530bf8e79402728d64a#a1c9fe982c32d550e8eac530bf8e79402728d64a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1063,16 +1082,14 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits",
+ "oasis-cbor",
  "oid-registry",
  "percent-encoding",
  "rand 0.7.3",
  "rsa",
  "rustc-hex",
  "serde",
- "serde_bytes",
- "serde_cbor",
  "serde_json",
- "serde_repr",
  "sgx-isa",
  "sha2",
  "slog",
@@ -1104,11 +1121,10 @@ dependencies = [
  "io-context",
  "k256",
  "num-traits",
+ "oasis-cbor",
  "oasis-core-runtime",
  "oasis-runtime-sdk-macros",
  "once_cell",
- "serde",
- "serde_bytes",
  "sha2",
  "slog",
  "thiserror",
@@ -1133,9 +1149,9 @@ checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 
 [[package]]
 name = "oid-registry"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26c042283b4ecc71edde70de2d6d0ab7e8743b8e7a7cb8467e4d153dfc7ad43"
+checksum = "f6aae73e474f83beacd8ae2179e328e03d63d9223949d97e1b7c108059a34715"
 dependencies = [
  "der-parser",
 ]
@@ -1192,9 +1208,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
+checksum = "87bb2d5c68b7505a3a89eb2f3583a4d56303863005226c2ef99319930a262be4"
 dependencies = [
  "der",
  "spki",
@@ -1202,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
+checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -1213,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1228,6 +1244,16 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1252,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1262,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1275,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost",
@@ -1437,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "rusticata-macros"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+checksum = "d8db3e42c9a4a9479e121c66d4925d15a87734f6fa37f1df0434708718d316ce"
 dependencies = [
  "nom",
 ]
@@ -1495,16 +1521,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -1565,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
  "rand_core 0.6.3",
@@ -1584,6 +1600,12 @@ dependencies = [
  "num-traits",
  "thiserror",
 ]
+
+[[package]]
+name = "sk-cbor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e94879a793aba6e65d691f345cfd172c4cc924a78259d5f9612a2cbfb78847a"
 
 [[package]]
 name = "slab"
@@ -1693,9 +1715,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subtle-encoding"
@@ -1719,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1737,9 +1759,8 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tendermint"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831486f28e65c6f6c6f8afb067796f3c470db91a44d177224f8e6287601391b6"
+version = "0.20.0"
+source = "git+https://github.com/informalsystems/tendermint-rs?rev=1efe42c8625045fd99072718faf96e81aeb9c6e6#1efe42c8625045fd99072718faf96e81aeb9c6e6"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -1747,7 +1768,6 @@ dependencies = [
  "chrono",
  "ed25519",
  "ed25519-dalek",
- "funty",
  "futures",
  "num-traits",
  "once_cell",
@@ -1770,9 +1790,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32bbc1bc55f09de4d00b5d69aa6b60392ba37c5e4761d869f76065d352bd3360"
+version = "0.20.0"
+source = "git+https://github.com/informalsystems/tendermint-rs?rev=1efe42c8625045fd99072718faf96e81aeb9c6e6#1efe42c8625045fd99072718faf96e81aeb9c6e6"
 dependencies = [
  "anomaly",
  "bytes",
@@ -1791,8 +1810,8 @@ dependencies = [
 name = "test-runtime-benchmarking"
 version = "0.1.0"
 dependencies = [
+ "oasis-cbor",
  "oasis-runtime-sdk",
- "serde",
  "thiserror",
 ]
 
@@ -1800,6 +1819,7 @@ dependencies = [
 name = "test-runtime-simple-consensus"
 version = "0.1.0"
 dependencies = [
+ "oasis-cbor",
  "oasis-runtime-sdk",
 ]
 
@@ -1807,9 +1827,8 @@ dependencies = [
 name = "test-runtime-simple-keyvalue"
 version = "0.1.0"
 dependencies = [
+ "oasis-cbor",
  "oasis-runtime-sdk",
- "serde",
- "serde_bytes",
  "thiserror",
 ]
 
@@ -1864,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1879,9 +1898,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg 1.0.1",
  "pin-project-lite",
@@ -1934,9 +1953,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",

--- a/runtime-sdk-macros/src/event_derive.rs
+++ b/runtime-sdk-macros/src/event_derive.rs
@@ -65,7 +65,7 @@ pub fn derive_event(input: DeriveInput) -> TokenStream {
     let sdk_crate = gen::sdk_crate_path();
 
     gen::wrap_in_const(quote! {
-        use #sdk_crate::core::common::cbor;
+        use #sdk_crate::cbor;
 
         impl #sdk_crate::event::Event for #event_ty_ident {
             fn module_name() -> &'static str {
@@ -76,7 +76,7 @@ pub fn derive_event(input: DeriveInput) -> TokenStream {
                 #code_converter
             }
 
-            fn value(&self) -> cbor::Value {
+            fn into_value(self) -> cbor::Value {
                 cbor::to_value(self)
             }
         }
@@ -89,7 +89,7 @@ mod tests {
     fn generate_event_impl_auto() {
         let expected: syn::Stmt = syn::parse_quote!(
             const _: () = {
-                use oasis_runtime_sdk::core::common::cbor;
+                use oasis_runtime_sdk::cbor;
                 impl ::oasis_runtime_sdk::event::Event for MainEvent {
                     fn module_name() -> &'static str {
                         MODULE_NAME
@@ -102,7 +102,7 @@ mod tests {
                             Self::Event3 { .. } => 3u32,
                         }
                     }
-                    fn value(&self) -> cbor::Value {
+                    fn into_value(self) -> cbor::Value {
                         cbor::to_value(self)
                     }
                 }
@@ -132,7 +132,7 @@ mod tests {
     fn generate_event_impl_manual() {
         let expected: syn::Stmt = syn::parse_quote!(
             const _: () = {
-                use oasis_runtime_sdk::core::common::cbor;
+                use oasis_runtime_sdk::cbor;
                 impl ::oasis_runtime_sdk::event::Event for MainEvent {
                     fn module_name() -> &'static str {
                         THE_MODULE_NAME
@@ -140,7 +140,7 @@ mod tests {
                     fn code(&self) -> u32 {
                         0
                     }
-                    fn value(&self) -> cbor::Value {
+                    fn into_value(self) -> cbor::Value {
                         cbor::to_value(self)
                     }
                 }

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.2.5" }
+cbor = { version = "0.1.3", package = "oasis-cbor" }
+# TODO: Replace with released version once it includes https://github.com/oasisprotocol/oasis-core/pull/4133.
+oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", rev = "a1c9fe982c32d550e8eac530bf8e79402728d64a" }
 oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 
 # Third party.
-serde = { version = "1.0.126", features = ["derive"] }
-serde_bytes = "0.11.5"
 curve25519-dalek = "3.0.0"
 sha2 = "0.9.3"
 k256 = { version = "0.9.5" }

--- a/runtime-sdk/src/crypto/multisig/mod.rs
+++ b/runtime-sdk/src/crypto/multisig/mod.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::crypto::signature::{PublicKey, Signature};
@@ -18,14 +17,11 @@ pub enum Error {
 }
 
 /// One of the signers in a multisig configuration.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Signer {
     /// The public key of the signer.
-    #[serde(rename = "public_key")]
     pub public_key: PublicKey,
     /// The weight of the signer.
-    #[serde(rename = "weight")]
     pub weight: u64,
 }
 
@@ -38,14 +34,11 @@ pub type SignatureSetOwned = Vec<Option<Signature>>;
 /// A multisig configuration.
 /// A set of signers with total "weight" greater than or equal to a "threshold" can authenticate
 /// for the configuration.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Config {
     /// The signers.
-    #[serde(rename = "signers")]
     pub signers: Vec<Signer>,
     /// The threshold.
-    #[serde(rename = "threshold")]
     pub threshold: u64,
 }
 

--- a/runtime-sdk/src/crypto/signature/ed25519.rs
+++ b/runtime-sdk/src/crypto/signature/ed25519.rs
@@ -1,6 +1,5 @@
 //! Ed25519 signatures.
 use curve25519_dalek::edwards::CompressedEdwardsY;
-use serde::{Deserialize, Serialize};
 
 use oasis_core_runtime::common::crypto::signature::{
     PublicKey as CorePublicKey, Signature as CoreSignature,
@@ -9,7 +8,8 @@ use oasis_core_runtime::common::crypto::signature::{
 use crate::crypto::signature::{Error, Signature};
 
 /// An Ed25519 public key.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+#[cbor(transparent)]
 pub struct PublicKey(CorePublicKey);
 
 impl PublicKey {

--- a/runtime-sdk/src/crypto/signature/mod.rs
+++ b/runtime-sdk/src/crypto/signature/mod.rs
@@ -1,5 +1,4 @@
 //! Cryptographic signatures.
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub mod context;
@@ -7,13 +6,12 @@ pub mod ed25519;
 pub mod secp256k1;
 
 /// A public key used for signing.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, PartialEq, Eq, cbor::Encode, cbor::Decode)]
 pub enum PublicKey {
-    #[serde(rename = "ed25519")]
+    #[cbor(rename = "ed25519")]
     Ed25519(ed25519::PublicKey),
 
-    #[serde(rename = "secp256k1")]
+    #[cbor(rename = "secp256k1")]
     Secp256k1(secp256k1::PublicKey),
 }
 
@@ -78,8 +76,9 @@ impl AsRef<[u8]> for PublicKey {
 }
 
 /// Variable-length opaque signature.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Signature(#[serde(with = "serde_bytes")] Vec<u8>);
+#[derive(Clone, Debug, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
+#[cbor(transparent)]
+pub struct Signature(Vec<u8>);
 
 impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -10,7 +10,6 @@ use thiserror::Error;
 
 use oasis_core_runtime::{
     self,
-    common::cbor,
     protocol::HostInfo,
     storage::{context::StorageContext, mkvs},
     transaction::{
@@ -222,7 +221,7 @@ impl<R: Runtime> Dispatcher<R> {
         let dispatch_result = Self::dispatch_tx(ctx, tx)?;
 
         Ok(ExecuteTxResult {
-            output: cbor::to_vec(&dispatch_result.result),
+            output: cbor::to_vec(dispatch_result.result),
             tags: dispatch_result.tags,
         })
     }
@@ -277,7 +276,7 @@ impl<R: Runtime> Dispatcher<R> {
             store,
             &modules::core::MODULE_NAME,
         ));
-        store.insert(&modules::core::state::MESSAGE_HANDLERS, &message_handlers);
+        store.insert(&modules::core::state::MESSAGE_HANDLERS, message_handlers);
     }
 
     /// Process the given runtime query.

--- a/runtime-sdk/src/error.rs
+++ b/runtime-sdk/src/error.rs
@@ -12,10 +12,9 @@ use crate::types::transaction::CallResult;
 /// ```
 /// # #[cfg(feature = "oasis-runtime-sdk-macros")]
 /// # mod example {
-/// # use serde::{Serialize, Deserialize};
 /// # use oasis_runtime_sdk_macros::Error;
 /// const MODULE_NAME: &str = "my-module";
-/// #[derive(Clone, Debug, Serialize, Deserialize, Error, thiserror::Error)]
+/// #[derive(Clone, Debug, Error, thiserror::Error)]
 /// #[sdk_error(autonumber)] // `module_name` meta is required if `MODULE_NAME` isn't in scope
 /// enum Error {
 ///    #[error("invalid argument")]

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -24,6 +24,9 @@ pub use crate::{
 // Re-export the appropriate version of the oasis-core-runtime library.
 pub use oasis_core_runtime as core;
 
+// Re-export the cbor crate.
+pub use cbor;
+
 // Re-export the SDK support proc-macros.
 #[cfg(feature = "oasis-runtime-sdk-macros")]
 pub use oasis_runtime_sdk_macros::*;

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -1,8 +1,6 @@
 //! Tests for the accounts module.
 use std::collections::BTreeMap;
 
-use oasis_core_runtime::common::cbor;
-
 use crate::{
     context::{BatchContext, Context},
     module::{AuthHandler, BlockHandler, InvariantHandler},
@@ -27,13 +25,13 @@ fn test_init_incorrect_total_supply_1() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Alice.
                 balances.insert(keys::alice::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
@@ -51,26 +49,26 @@ fn test_init_incorrect_total_supply_2() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Alice.
                 balances.insert(keys::alice::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 // Bob.
                 balances.insert(keys::bob::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
             },
             total_supplies: {
                 let mut total_supplies = BTreeMap::new();
-                total_supplies.insert(Denomination::NATIVE, 1_000_000.into());
+                total_supplies.insert(Denomination::NATIVE, 1_000_000);
                 total_supplies
             },
             ..Default::default()
@@ -86,7 +84,7 @@ fn test_debug_option_set() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             parameters: Parameters {
                 debug_disable_nonce_check: true,
                 ..Default::default()
@@ -122,20 +120,20 @@ fn test_init_1() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Alice.
                 balances.insert(keys::alice::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
             },
             total_supplies: {
                 let mut total_supplies = BTreeMap::new();
-                total_supplies.insert(Denomination::NATIVE, 1_000_000.into());
+                total_supplies.insert(Denomination::NATIVE, 1_000_000);
                 total_supplies
             },
             ..Default::default()
@@ -150,26 +148,26 @@ fn test_init_2() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Alice.
                 balances.insert(keys::alice::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 // Bob.
                 balances.insert(keys::bob::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
             },
             total_supplies: {
                 let mut total_supplies = BTreeMap::new();
-                total_supplies.insert(Denomination::NATIVE, 2_000_000.into());
+                total_supplies.insert(Denomination::NATIVE, 2_000_000);
                 total_supplies
             },
             ..Default::default()
@@ -184,20 +182,20 @@ fn test_api_tx_transfer_disabled() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Alice.
                 balances.insert(keys::alice::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
             },
             total_supplies: {
                 let mut total_supplies = BTreeMap::new();
-                total_supplies.insert(Denomination::NATIVE, 1_000_000.into());
+                total_supplies.insert(Denomination::NATIVE, 1_000_000);
                 total_supplies
             },
             parameters: Parameters {
@@ -215,7 +213,7 @@ fn test_api_tx_transfer_disabled() {
             method: "accounts.Transfer".to_owned(),
             body: cbor::to_value(Transfer {
                 to: keys::bob::address(),
-                amount: BaseUnits::new(1_000.into(), Denomination::NATIVE),
+                amount: BaseUnits::new(1_000, Denomination::NATIVE),
             }),
         },
         auth_info: transaction::AuthInfo {
@@ -242,20 +240,20 @@ fn test_api_tx_transfer_disabled() {
 pub(crate) fn init_accounts<C: Context>(ctx: &mut C) {
     Accounts::init(
         ctx,
-        &Genesis {
+        Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Alice.
                 balances.insert(keys::alice::address(), {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
             },
             total_supplies: {
                 let mut total_supplies = BTreeMap::new();
-                total_supplies.insert(Denomination::NATIVE, 1_000_000.into());
+                total_supplies.insert(Denomination::NATIVE, 1_000_000);
                 total_supplies
             },
             ..Default::default()
@@ -276,7 +274,7 @@ fn test_api_transfer() {
             &mut tx_ctx,
             keys::alice::address(),
             keys::bob::address(),
-            &BaseUnits::new(1_000.into(), Denomination::NATIVE),
+            &BaseUnits::new(1_000, Denomination::NATIVE),
         )
         .expect("transfer should succeed");
 
@@ -284,7 +282,7 @@ fn test_api_transfer() {
             &mut tx_ctx,
             keys::alice::address(),
             keys::bob::address(),
-            &BaseUnits::new(1_000_000.into(), Denomination::NATIVE),
+            &BaseUnits::new(1_000_000, Denomination::NATIVE),
         );
         assert!(matches!(result, Err(Error::InsufficientBalance)));
 
@@ -293,7 +291,7 @@ fn test_api_transfer() {
             .expect("get_balances should succeed");
         assert_eq!(
             bals.balances[&Denomination::NATIVE],
-            999_000.into(),
+            999_000,
             "balance in source account should be correct"
         );
         assert_eq!(
@@ -307,7 +305,7 @@ fn test_api_transfer() {
             .expect("get_balances should succeed");
         assert_eq!(
             bals.balances[&Denomination::NATIVE],
-            1_000.into(),
+            1_000,
             "balance in destination account should be correct"
         );
         assert_eq!(
@@ -331,13 +329,13 @@ fn test_authenticate_tx() {
             method: "accounts.Transfer".to_owned(),
             body: cbor::to_value(Transfer {
                 to: keys::bob::address(),
-                amount: BaseUnits::new(1_000.into(), Denomination::NATIVE),
+                amount: BaseUnits::new(1_000, Denomination::NATIVE),
             }),
         },
         auth_info: transaction::AuthInfo {
             signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
             fee: transaction::Fee {
-                amount: BaseUnits::new(1_000.into(), Denomination::NATIVE),
+                amount: BaseUnits::new(1_000, Denomination::NATIVE),
                 gas: 1000,
             },
         },
@@ -350,7 +348,7 @@ fn test_authenticate_tx() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        999_000.into(),
+        999_000,
         "fees should be subtracted from source account"
     );
     assert_eq!(
@@ -369,7 +367,7 @@ fn test_authenticate_tx() {
 
     // Should fail when there's not enough balance to pay fees.
     tx.auth_info.signer_info[0].nonce = nonce;
-    tx.auth_info.fee.amount = BaseUnits::new(1_100_000.into(), Denomination::NATIVE);
+    tx.auth_info.fee.amount = BaseUnits::new(1_100_000, Denomination::NATIVE);
     let result = Accounts::authenticate_tx(&mut ctx, &tx);
     assert!(matches!(result, Err(core::Error::InsufficientFeeBalance)));
 }
@@ -387,7 +385,7 @@ fn test_tx_transfer() {
             method: "accounts.Transfer".to_owned(),
             body: cbor::to_value(Transfer {
                 to: keys::bob::address(),
-                amount: BaseUnits::new(1_000.into(), Denomination::NATIVE),
+                amount: BaseUnits::new(1_000, Denomination::NATIVE),
             }),
         },
         auth_info: transaction::AuthInfo {
@@ -409,7 +407,7 @@ fn test_tx_transfer() {
             .expect("get_balances should succeed");
         assert_eq!(
             bals.balances[&Denomination::NATIVE],
-            999_000.into(),
+            999_000,
             "balance in source account should be correct"
         );
         assert_eq!(
@@ -423,7 +421,7 @@ fn test_tx_transfer() {
             .expect("get_balances should succeed");
         assert_eq!(
             bals.balances[&Denomination::NATIVE],
-            1_000.into(),
+            1_000,
             "balance in destination account should be correct"
         );
         assert_eq!(
@@ -461,7 +459,7 @@ fn test_fee_disbursement() {
             signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
             fee: transaction::Fee {
                 // Use an amount that does not split nicely among the good compute entities.
-                amount: BaseUnits::new(1_001.into(), Denomination::NATIVE),
+                amount: BaseUnits::new(1_001, Denomination::NATIVE),
                 gas: 1000,
             },
         },
@@ -477,7 +475,7 @@ fn test_fee_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        998_999.into(),
+        998_999,
         "fees should be subtracted from source account"
     );
     // Nothing should be disbursed yet to good compute entity accounts.
@@ -494,7 +492,7 @@ fn test_fee_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        1001.into(),
+        1001,
         "fees should be held in the fee accumulator address"
     );
 
@@ -506,7 +504,7 @@ fn test_fee_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        500.into(),
+        500,
         "fees should be disbursed to good compute entity"
     );
     // Check second good compute entity account balances.
@@ -514,7 +512,7 @@ fn test_fee_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        500.into(),
+        500,
         "fees should be disbursed to good compute entity"
     );
 
@@ -523,7 +521,7 @@ fn test_fee_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        1.into(),
+        1,
         "remainder should be disbursed to the common pool"
     );
 }
@@ -542,26 +540,26 @@ fn test_get_all_balances_and_total_supplies_basic() {
             // Alice.
             balances.insert(alice, {
                 let mut denominations = BTreeMap::new();
-                denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                denominations.insert(Denomination::NATIVE, 1_000_000);
                 denominations
             });
             // Bob.
             balances.insert(bob, {
                 let mut denominations = BTreeMap::new();
-                denominations.insert(Denomination::NATIVE, 2_000_000.into());
+                denominations.insert(Denomination::NATIVE, 2_000_000);
                 denominations
             });
             balances
         },
         total_supplies: {
             let mut total_supplies = BTreeMap::new();
-            total_supplies.insert(Denomination::NATIVE, 3_000_000.into());
+            total_supplies.insert(Denomination::NATIVE, 3_000_000);
             total_supplies
         },
         ..Default::default()
     };
 
-    Accounts::init(&mut ctx, &gen);
+    Accounts::init(&mut ctx, gen);
 
     let all_bals =
         Accounts::get_all_balances(ctx.runtime_state()).expect("get_all_balances should succeed");
@@ -574,13 +572,13 @@ fn test_get_all_balances_and_total_supplies_basic() {
         if addr == &alice {
             assert_eq!(
                 bals[&Denomination::NATIVE],
-                1_000_000.into(),
+                1_000_000,
                 "Alice's balance should be 1000000"
             );
         } else if addr == &bob {
             assert_eq!(
                 bals[&Denomination::NATIVE],
-                2_000_000.into(),
+                2_000_000,
                 "Bob's balance should be 2000000"
             );
         } else {
@@ -601,7 +599,7 @@ fn test_get_all_balances_and_total_supplies_basic() {
     );
     assert_eq!(
         ts[&Denomination::NATIVE],
-        3_000_000.into(),
+        3_000_000,
         "total supply should be 3000000"
     );
 }
@@ -625,32 +623,32 @@ fn test_get_all_balances_and_total_supplies_more() {
             // Alice.
             balances.insert(alice, {
                 let mut denominations = BTreeMap::new();
-                denominations.insert(dn.clone(), 1_000_000.into());
-                denominations.insert(d1.clone(), 1_000.into());
-                denominations.insert(d2.clone(), 100.into());
+                denominations.insert(dn.clone(), 1_000_000);
+                denominations.insert(d1.clone(), 1_000);
+                denominations.insert(d2.clone(), 100);
                 denominations
             });
             // Bob.
             balances.insert(bob, {
                 let mut denominations = BTreeMap::new();
-                denominations.insert(d1.clone(), 2_000.into());
-                denominations.insert(d3.clone(), 200.into());
+                denominations.insert(d1.clone(), 2_000);
+                denominations.insert(d3.clone(), 200);
                 denominations
             });
             balances
         },
         total_supplies: {
             let mut total_supplies = BTreeMap::new();
-            total_supplies.insert(dn.clone(), 1_000_000.into());
-            total_supplies.insert(d1.clone(), 3_000.into());
-            total_supplies.insert(d2.clone(), 100.into());
-            total_supplies.insert(d3.clone(), 200.into());
+            total_supplies.insert(dn.clone(), 1_000_000);
+            total_supplies.insert(d1.clone(), 3_000);
+            total_supplies.insert(d2.clone(), 100);
+            total_supplies.insert(d3.clone(), 200);
             total_supplies
         },
         ..Default::default()
     };
 
-    Accounts::init(&mut ctx, &gen);
+    Accounts::init(&mut ctx, gen);
 
     let all_bals =
         Accounts::get_all_balances(ctx.runtime_state()).expect("get_all_balances should succeed");
@@ -658,20 +656,15 @@ fn test_get_all_balances_and_total_supplies_more() {
         if addr == &alice {
             assert_eq!(bals.len(), 3, "Alice should have exactly 3 denominations");
             assert_eq!(
-                bals[&dn],
-                1_000_000.into(),
+                bals[&dn], 1_000_000,
                 "Alice's native balance should be 1000000"
             );
-            assert_eq!(
-                bals[&d1],
-                1_000.into(),
-                "Alice's den1 balance should be 1000"
-            );
-            assert_eq!(bals[&d2], 100.into(), "Alice's den2 balance should be 100");
+            assert_eq!(bals[&d1], 1_000, "Alice's den1 balance should be 1000");
+            assert_eq!(bals[&d2], 100, "Alice's den2 balance should be 100");
         } else if addr == &bob {
             assert_eq!(bals.len(), 2, "Bob should have exactly 2 denominations");
-            assert_eq!(bals[&d1], 2_000.into(), "Bob's den1 balance should be 2000");
-            assert_eq!(bals[&d3], 200.into(), "Bob's den3 balance should be 200");
+            assert_eq!(bals[&d1], 2_000, "Bob's den1 balance should be 2000");
+            assert_eq!(bals[&d3], 200, "Bob's den3 balance should be 200");
         } else {
             panic!("invalid address");
         }
@@ -700,14 +693,10 @@ fn test_get_all_balances_and_total_supplies_more() {
         ts.contains_key(&d3),
         "den3 denomination should be present in total supplies"
     );
-    assert_eq!(
-        ts[&dn],
-        1_000_000.into(),
-        "native total supply should be 1000000"
-    );
-    assert_eq!(ts[&d1], 3_000.into(), "den1 total supply should be 3000");
-    assert_eq!(ts[&d2], 100.into(), "den2 total supply should be 100");
-    assert_eq!(ts[&d3], 200.into(), "den3 total supply should be 200");
+    assert_eq!(ts[&dn], 1_000_000, "native total supply should be 1000000");
+    assert_eq!(ts[&d1], 3_000, "den1 total supply should be 3000");
+    assert_eq!(ts[&d2], 100, "den2 total supply should be 100");
+    assert_eq!(ts[&d3], 200, "den3 total supply should be 200");
 }
 
 #[test]
@@ -743,32 +732,32 @@ fn test_check_invariants_more() {
             // Alice.
             balances.insert(alice, {
                 let mut denominations = BTreeMap::new();
-                denominations.insert(dn.clone(), 1_000_000.into());
-                denominations.insert(d1.clone(), 1_000.into());
-                denominations.insert(d2.clone(), 100.into());
+                denominations.insert(dn.clone(), 1_000_000);
+                denominations.insert(d1.clone(), 1_000);
+                denominations.insert(d2.clone(), 100);
                 denominations
             });
             // Bob.
             balances.insert(bob, {
                 let mut denominations = BTreeMap::new();
-                denominations.insert(d1.clone(), 2_000.into());
-                denominations.insert(d3.clone(), 200.into());
+                denominations.insert(d1.clone(), 2_000);
+                denominations.insert(d3.clone(), 200);
                 denominations
             });
             balances
         },
         total_supplies: {
             let mut total_supplies = BTreeMap::new();
-            total_supplies.insert(dn.clone(), 1_000_000.into());
-            total_supplies.insert(d1.clone(), 3_000.into());
-            total_supplies.insert(d2.clone(), 100.into());
-            total_supplies.insert(d3.clone(), 200.into());
+            total_supplies.insert(dn.clone(), 1_000_000);
+            total_supplies.insert(d1.clone(), 3_000);
+            total_supplies.insert(d2.clone(), 100);
+            total_supplies.insert(d3.clone(), 200);
             total_supplies
         },
         ..Default::default()
     };
 
-    Accounts::init(&mut ctx, &gen);
+    Accounts::init(&mut ctx, gen);
     assert!(
         Accounts::check_invariants(&mut ctx).is_ok(),
         "initial inv chk should succeed"
@@ -778,7 +767,7 @@ fn test_check_invariants_more() {
         Accounts::add_amount(
             ctx.runtime_state(),
             charlie,
-            &BaseUnits::new(100.into(), d1.clone())
+            &BaseUnits::new(100, d1.clone())
         )
         .is_ok(),
         "giving Charlie money should succeed"
@@ -789,8 +778,7 @@ fn test_check_invariants_more() {
     );
 
     assert!(
-        Accounts::inc_total_supply(ctx.runtime_state(), &BaseUnits::new(100.into(), d1.clone()))
-            .is_ok(),
+        Accounts::inc_total_supply(ctx.runtime_state(), &BaseUnits::new(100, d1.clone())).is_ok(),
         "increasing total supply should succeed"
     );
     assert!(
@@ -804,7 +792,7 @@ fn test_check_invariants_more() {
         Accounts::add_amount(
             ctx.runtime_state(),
             charlie,
-            &BaseUnits::new(300.into(), d4.clone())
+            &BaseUnits::new(300, d4.clone())
         )
         .is_ok(),
         "giving Charlie more money should succeed"
@@ -815,8 +803,7 @@ fn test_check_invariants_more() {
     );
 
     assert!(
-        Accounts::inc_total_supply(ctx.runtime_state(), &BaseUnits::new(300.into(), d4.clone()))
-            .is_ok(),
+        Accounts::inc_total_supply(ctx.runtime_state(), &BaseUnits::new(300, d4.clone())).is_ok(),
         "increasing total supply should succeed"
     );
     assert!(
@@ -827,8 +814,7 @@ fn test_check_invariants_more() {
     let d5: Denomination = "den5".parse().unwrap();
 
     assert!(
-        Accounts::inc_total_supply(ctx.runtime_state(), &BaseUnits::new(123.into(), d5.clone()))
-            .is_ok(),
+        Accounts::inc_total_supply(ctx.runtime_state(), &BaseUnits::new(123, d5.clone())).is_ok(),
         "increasing total supply should succeed"
     );
     assert!(
@@ -840,7 +826,7 @@ fn test_check_invariants_more() {
         Accounts::add_amount(
             ctx.runtime_state(),
             charlie,
-            &BaseUnits::new(123.into(), d5.clone())
+            &BaseUnits::new(123, d5.clone())
         )
         .is_ok(),
         "giving Charlie more money should succeed"

--- a/runtime-sdk/src/modules/accounts/types.rs
+++ b/runtime-sdk/src/modules/accounts/types.rs
@@ -2,51 +2,39 @@
 use std::collections::BTreeMap;
 
 use num_traits::identities::Zero;
-use serde::{Deserialize, Serialize};
 
 use crate::types::{address::Address, token};
 
 /// Transfer call.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Transfer {
-    #[serde(rename = "to")]
     pub to: Address,
-
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }
 
 /// Account metadata.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct Account {
-    #[serde(rename = "nonce")]
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Zero::is_zero")]
+    #[cbor(optional)]
+    #[cbor(default)]
+    #[cbor(skip_serializing_if = "Zero::is_zero")]
     pub nonce: u64,
 }
 
 /// Arguments for the Nonce query.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct NonceQuery {
-    #[serde(rename = "address")]
     pub address: Address,
 }
 
 /// Arguments for the Balances query.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct BalancesQuery {
-    #[serde(rename = "address")]
     pub address: Address,
 }
 
 /// Balances in an account.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct AccountBalances {
-    #[serde(rename = "balances")]
-    pub balances: BTreeMap<token::Denomination, token::Quantity>,
+    pub balances: BTreeMap<token::Denomination, u128>,
 }

--- a/runtime-sdk/src/modules/consensus/test.rs
+++ b/runtime-sdk/src/modules/consensus/test.rs
@@ -1,9 +1,7 @@
 use std::str::FromStr;
 
-use num_traits::Zero;
-
 use oasis_core_runtime::{
-    common::quantity::Quantity,
+    common::{quantity::Quantity, versioned::Versioned},
     consensus::{
         roothash::{Message, StakingMessage},
         staking,
@@ -29,7 +27,7 @@ fn test_api_transfer_invalid_denomination() {
 
     ctx.with_tx(mock::transaction(), |mut tx_ctx, _call| {
         let hook_name = "test_event_handler";
-        let amount = BaseUnits::new(1_000.into(), Denomination::NATIVE);
+        let amount = BaseUnits::new(1_000, Denomination::NATIVE);
 
         assert!(Consensus::transfer(
             &mut tx_ctx,
@@ -48,7 +46,7 @@ fn test_api_transfer() {
 
     ctx.with_tx(mock::transaction(), |mut tx_ctx, _call| {
         let hook_name = "test_event_handler";
-        let amount = BaseUnits::new(1_000.into(), Denomination::from_str("TEST").unwrap());
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap());
         Consensus::transfer(
             &mut tx_ctx,
             keys::alice::address(),
@@ -62,13 +60,13 @@ fn test_api_transfer() {
         let (msg, hook) = msgs.first().unwrap();
 
         assert_eq!(
-            &Message::Staking {
-                v: 0,
-                msg: StakingMessage::Transfer(staking::Transfer {
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::Transfer(staking::Transfer {
                     to: keys::alice::address().into(),
-                    amount: amount.amount().clone(),
+                    amount: amount.amount().into(),
                 })
-            },
+            )),
             msg,
             "emitted message should match"
         );
@@ -88,7 +86,7 @@ fn test_api_withdraw() {
 
     ctx.with_tx(mock::transaction(), |mut tx_ctx, _call| {
         let hook_name = "test_event_handler";
-        let amount = BaseUnits::new(1_000.into(), Denomination::from_str("TEST").unwrap());
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap());
         Consensus::withdraw(
             &mut tx_ctx,
             keys::alice::address(),
@@ -102,13 +100,13 @@ fn test_api_withdraw() {
         let (msg, hook) = msgs.first().unwrap();
 
         assert_eq!(
-            &Message::Staking {
-                v: 0,
-                msg: StakingMessage::Withdraw(staking::Withdraw {
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::Withdraw(staking::Withdraw {
                     from: keys::alice::address().into(),
-                    amount: amount.amount().clone(),
+                    amount: amount.amount().into(),
                 })
-            },
+            )),
             msg,
             "emitted message should match"
         );
@@ -128,7 +126,7 @@ fn test_api_escrow() {
 
     ctx.with_tx(mock::transaction(), |mut tx_ctx, _call| {
         let hook_name = "test_event_handler";
-        let amount = BaseUnits::new(1_000.into(), Denomination::from_str("TEST").unwrap());
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap());
         Consensus::escrow(
             &mut tx_ctx,
             keys::alice::address(),
@@ -142,13 +140,13 @@ fn test_api_escrow() {
         let (msg, hook) = msgs.first().unwrap();
 
         assert_eq!(
-            &Message::Staking {
-                v: 0,
-                msg: StakingMessage::AddEscrow(staking::Escrow {
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::AddEscrow(staking::Escrow {
                     account: keys::alice::address().into(),
-                    amount: amount.amount().clone(),
+                    amount: amount.amount().into(),
                 })
-            },
+            )),
             msg,
             "emitted message should match"
         );
@@ -168,7 +166,7 @@ fn test_api_reclaim_escrow() {
 
     ctx.with_tx(mock::transaction(), |mut tx_ctx, _call| {
         let hook_name = "test_event_handler";
-        let amount = BaseUnits::new(1_000.into(), Denomination::from_str("TEST").unwrap()); // TODO: shares.
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap()); // TODO: shares.
         Consensus::reclaim_escrow(
             &mut tx_ctx,
             keys::alice::address(),
@@ -182,13 +180,13 @@ fn test_api_reclaim_escrow() {
         let (msg, hook) = msgs.first().unwrap();
 
         assert_eq!(
-            &Message::Staking {
-                v: 0,
-                msg: StakingMessage::ReclaimEscrow(staking::ReclaimEscrow {
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::ReclaimEscrow(staking::ReclaimEscrow {
                     account: keys::alice::address().into(),
-                    shares: amount.amount().clone(),
+                    shares: amount.amount().into(),
                 })
-            },
+            )),
             msg,
             "emitted message should match"
         );
@@ -209,7 +207,7 @@ fn test_api_account() {
 
     let acc = Consensus::account(&ctx, keys::alice::address()).expect("query should succeed");
     assert_eq!(
-        Quantity::zero(),
+        Quantity::from(0u128),
         acc.general.balance,
         "consensus balance should be zero"
     )

--- a/runtime-sdk/src/modules/consensus_accounts/types.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/types.rs
@@ -1,63 +1,45 @@
 //! Consensus module types.
-use serde::{Deserialize, Serialize};
-
 use crate::types::{address::Address, token};
 
 /// Deposit into runtime call.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Deposit {
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }
 
 /// Withdraw from runtime call.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Withdraw {
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }
 
 /// Balance query.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct BalanceQuery {
-    #[serde(rename = "address")]
     pub address: Address,
 }
 
 /// Consensus account query.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct ConsensusAccountQuery {
-    #[serde(rename = "address")]
     pub address: Address,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct AccountBalance {
-    #[serde(rename = "balance")]
-    pub balance: token::Quantity,
+    pub balance: u128,
 }
 
 /// Context for consensus transfer message handler.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode, Default)]
 pub struct ConsensusTransferContext {
-    #[serde(rename = "address")]
     pub address: Address,
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }
 
 /// Context for consensus withdraw message handler.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode, Default)]
 pub struct ConsensusWithdrawContext {
-    #[serde(rename = "address")]
     pub address: Address,
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }

--- a/runtime-sdk/src/modules/core/types.rs
+++ b/runtime-sdk/src/modules/core/types.rs
@@ -1,14 +1,10 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
-
 /// Key in the versions map used for the global state version.
 pub const VERSION_GLOBAL_KEY: &str = "";
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct Metadata {
     /// A set of state versions for all supported modules.
-    #[serde(rename = "versions")]
     pub versions: BTreeMap<String, u32>,
 }

--- a/runtime-sdk/src/modules/rewards/test.rs
+++ b/runtime-sdk/src/modules/rewards/test.rs
@@ -20,20 +20,20 @@ fn init_accounts<C: Context>(ctx: &mut C) {
     Accounts::init_or_migrate(
         ctx,
         &mut core::types::Metadata::default(),
-        &accounts::Genesis {
+        accounts::Genesis {
             balances: {
                 let mut balances = BTreeMap::new();
                 // Rewards pool.
                 balances.insert(*ADDRESS_REWARD_POOL, {
                     let mut denominations = BTreeMap::new();
-                    denominations.insert(Denomination::NATIVE, 1_000_000.into());
+                    denominations.insert(Denomination::NATIVE, 1_000_000);
                     denominations
                 });
                 balances
             },
             total_supplies: {
                 let mut total_supplies = BTreeMap::new();
-                total_supplies.insert(Denomination::NATIVE, 1_000_000.into());
+                total_supplies.insert(Denomination::NATIVE, 1_000_000);
                 total_supplies
             },
             ..Default::default()
@@ -50,17 +50,17 @@ fn test_init_incorrect_rewards_schedule() {
     Rewards::init_or_migrate(
         &mut ctx,
         &mut core::types::Metadata::default(),
-        &Genesis {
+        Genesis {
             parameters: Parameters {
                 schedule: types::RewardSchedule {
                     steps: vec![
                         types::RewardStep {
                             until: 10,
-                            amount: BaseUnits::new(1000.into(), Denomination::NATIVE),
+                            amount: BaseUnits::new(1000, Denomination::NATIVE),
                         },
                         types::RewardStep {
                             until: 1, // Not sorted.
-                            amount: BaseUnits::new(1000.into(), Denomination::NATIVE),
+                            amount: BaseUnits::new(1000, Denomination::NATIVE),
                         },
                     ],
                 },
@@ -82,12 +82,12 @@ fn test_init_incorrect_participation_threshold() {
     Rewards::init_or_migrate(
         &mut ctx,
         &mut core::types::Metadata::default(),
-        &Genesis {
+        Genesis {
             parameters: Parameters {
                 schedule: types::RewardSchedule {
                     steps: vec![types::RewardStep {
                         until: 10,
-                        amount: BaseUnits::new(1000.into(), Denomination::NATIVE),
+                        amount: BaseUnits::new(1000, Denomination::NATIVE),
                     }],
                 },
                 participation_threshold_numerator: 10, // Invalid numerator.
@@ -117,12 +117,12 @@ fn test_reward_disbursement() {
     Rewards::init_or_migrate(
         &mut ctx,
         &mut core::types::Metadata::default(),
-        &Genesis {
+        Genesis {
             parameters: Parameters {
                 schedule: types::RewardSchedule {
                     steps: vec![types::RewardStep {
                         until: 1000,
-                        amount: BaseUnits::new(1000.into(), Denomination::NATIVE),
+                        amount: BaseUnits::new(1000, Denomination::NATIVE),
                     }],
                 },
                 participation_threshold_numerator: 3,
@@ -147,7 +147,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        1_000_000.into(),
+        1_000_000,
         "no rewards should be disbursed yet"
     );
 
@@ -163,7 +163,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        998_000.into(),
+        998_000,
         "rewards should have been disbursed"
     );
 
@@ -172,7 +172,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        1_000.into(),
+        1_000,
         "rewards should have been disbursed"
     );
 
@@ -180,7 +180,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        1_000.into(),
+        1_000,
         "rewards should have been disbursed"
     );
 
@@ -211,7 +211,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        998_000.into(),
+        998_000,
         "no rewards should be disbursed yet"
     );
 
@@ -227,7 +227,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        997_000.into(),
+        997_000,
         "rewards should have been disbursed"
     );
 
@@ -236,7 +236,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        2_000.into(),
+        2_000,
         "rewards should have been disbursed to good entities"
     );
 
@@ -244,7 +244,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        1_000.into(),
+        1_000,
         "rewards should not have been disbursed to bad entities"
     );
 
@@ -274,7 +274,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        997_000.into(),
+        997_000,
         "no rewards should be disbursed yet"
     );
 
@@ -290,7 +290,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        996_000.into(),
+        996_000,
         "rewards should have been disbursed"
     );
 
@@ -299,7 +299,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        2_000.into(),
+        2_000,
         "rewards should not have been disbursed to non-participating entities"
     );
 
@@ -307,7 +307,7 @@ fn test_reward_disbursement() {
         .expect("get_balances should succeed");
     assert_eq!(
         bals.balances[&Denomination::NATIVE],
-        2_000.into(),
+        2_000,
         "rewards should have been disbursed to participating entities"
     );
 }

--- a/runtime-sdk/src/runtime.rs
+++ b/runtime-sdk/src/runtime.rs
@@ -42,7 +42,7 @@ pub trait Runtime {
 
         // Perform state migrations/initialization on all modules.
         let mut has_changes =
-            Self::Modules::init_or_migrate(ctx, &mut metadata, &Self::genesis_state());
+            Self::Modules::init_or_migrate(ctx, &mut metadata, Self::genesis_state());
 
         // Check if we need to also apply any global state updates.
         let global_version = metadata
@@ -75,7 +75,7 @@ pub trait Runtime {
                 ctx.runtime_state(),
                 &modules::core::MODULE_NAME,
             ));
-            store.insert(modules::core::state::METADATA, &metadata);
+            store.insert(modules::core::state::METADATA, metadata);
         }
     }
 

--- a/runtime-sdk/src/testing/mock.rs
+++ b/runtime-sdk/src/testing/mock.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use io_context::Context as IoContext;
 
 use oasis_core_runtime::{
-    common::{cbor, namespace::Namespace, version::Version},
+    common::{namespace::Namespace, version::Version},
     consensus::{beacon, roothash, state::ConsensusState},
     protocol::HostInfo,
     storage::mkvs,
@@ -112,7 +112,7 @@ pub fn transaction() -> transaction::Transaction {
         version: 1,
         call: transaction::Call {
             method: "mock".to_owned(),
-            body: cbor::Value::Null,
+            body: cbor::Value::Simple(cbor::SimpleValue::NullValue),
         },
         auth_info: transaction::AuthInfo {
             signer_info: vec![],

--- a/runtime-sdk/src/types/message.rs
+++ b/runtime-sdk/src/types/message.rs
@@ -1,26 +1,20 @@
 use std::fmt::Debug;
 
-use serde::{Deserialize, Serialize};
-
-use oasis_core_runtime::{common::cbor, consensus};
+use oasis_core_runtime::consensus;
 
 /// Result of a message being processed by the consensus layer.
 pub type MessageEvent = consensus::roothash::MessageEvent;
 
 /// Handler name and context to be called after message is executed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct MessageEventHookInvocation {
-    #[serde(rename = "hook_name")]
     pub hook_name: String,
-
-    #[serde(rename = "payload")]
     pub payload: cbor::Value,
 }
 
 impl MessageEventHookInvocation {
     /// Constructs a new message hook invocation.
-    pub fn new<S: Serialize>(name: String, payload: S) -> Self {
+    pub fn new<S: cbor::Encode>(name: String, payload: S) -> Self {
         Self {
             hook_name: name,
             payload: cbor::to_value(payload),

--- a/tests/consts.sh
+++ b/tests/consts.sh
@@ -6,7 +6,7 @@
 
 # Released version from GitHub Releases.
 # e.g. '21.1.2'
-OASIS_CORE_VERSION='21.2.5'
+OASIS_CORE_VERSION=''
 
 # Development version from GitHub Actions.
 # e.g. '58512799'
@@ -16,4 +16,4 @@ GITHUB_ARTIFACT_VERSION=''
 
 # Version from Buildkite.
 # e.g. '4759'
-BUILD_NUMBER='5432' # 21.2.5
+BUILD_NUMBER='5642' # a1c9fe982c32d550e8eac530bf8e79402728d64a

--- a/tests/runtimes/benchmarking/Cargo.toml
+++ b/tests/runtimes/benchmarking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 oasis-runtime-sdk = { path = "../../../runtime-sdk", features = ["unsafe-allow-debug"] }
+cbor = { version = "0.1.3", package = "oasis-cbor" }
 
-serde = { version = "1.0.118", features = ["derive"] }
+# Third party.
 thiserror = "1.0"

--- a/tests/runtimes/benchmarking/src/runtime/types.rs
+++ b/tests/runtimes/benchmarking/src/runtime/types.rs
@@ -1,22 +1,14 @@
-use serde::{Deserialize, Serialize};
-
 use oasis_runtime_sdk::types::{address::Address, token};
 
 /// Accounts mint call.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct AccountsMint {
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }
 
 /// Accounts transfer call.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct AccountsTransfer {
-    #[serde(rename = "to")]
     pub to: Address,
-
-    #[serde(rename = "amount")]
     pub amount: token::BaseUnits,
 }

--- a/tests/runtimes/simple-consensus/Cargo.toml
+++ b/tests/runtimes/simple-consensus/Cargo.toml
@@ -7,3 +7,4 @@ license = "Apache-2.0"
 
 [dependencies]
 oasis-runtime-sdk = { path = "../../../runtime-sdk" }
+cbor = { version = "0.1.3", package = "oasis-cbor" }

--- a/tests/runtimes/simple-keyvalue/Cargo.toml
+++ b/tests/runtimes/simple-keyvalue/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 oasis-runtime-sdk = { path = "../../../runtime-sdk" }
+cbor = { version = "0.1.3", package = "oasis-cbor" }
 
-serde = { version = "1.0.118", features = ["derive"] }
-serde_bytes = "0.11.5"
+# Third party.
 thiserror = "1.0"

--- a/tests/runtimes/simple-keyvalue/src/keyvalue/types.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue/types.rs
@@ -1,21 +1,12 @@
-use serde::{Deserialize, Serialize};
+//! Types for the keyvalue module.
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct Key {
-    #[serde(rename = "key")]
-    #[serde(with = "serde_bytes")]
     pub key: Vec<u8>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct KeyValue {
-    #[serde(rename = "key")]
-    #[serde(with = "serde_bytes")]
     pub key: Vec<u8>,
-
-    #[serde(rename = "value")]
-    #[serde(with = "serde_bytes")]
     pub value: Vec<u8>,
 }

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -51,38 +51,38 @@ impl sdk::Runtime for Runtime {
                     // Alice.
                     b.insert(sdk::testing::keys::alice::address(), {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 10_003_000.into());
+                        d.insert(Denomination::NATIVE, 10_003_000);
                         d
                     });
                     // Bob.
                     b.insert(sdk::testing::keys::bob::address(), {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 2_000.into());
+                        d.insert(Denomination::NATIVE, 2_000);
                         d
                     });
                     // Charlie.
                     b.insert(sdk::testing::keys::charlie::address(), {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 1_000.into());
+                        d.insert(Denomination::NATIVE, 1_000);
                         d
                     });
                     // Dave.
                     b.insert(sdk::testing::keys::dave::address(), {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 100.into());
+                        d.insert(Denomination::NATIVE, 100);
                         d
                     });
                     // Reward pool.
                     b.insert(*modules::rewards::ADDRESS_REWARD_POOL, {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 10_000.into());
+                        d.insert(Denomination::NATIVE, 10_000);
                         d
                     });
                     b
                 },
                 total_supplies: {
                     let mut ts = BTreeMap::new();
-                    ts.insert(Denomination::NATIVE, 10_016_100.into());
+                    ts.insert(Denomination::NATIVE, 10_016_100);
                     ts
                 },
                 ..Default::default()
@@ -92,7 +92,7 @@ impl sdk::Runtime for Runtime {
                     schedule: modules::rewards::types::RewardSchedule {
                         steps: vec![modules::rewards::types::RewardStep {
                             until: 1000,
-                            amount: BaseUnits::new(100.into(), Denomination::NATIVE),
+                            amount: BaseUnits::new(100, Denomination::NATIVE),
                         }],
                     },
                     participation_threshold_numerator: 1, // These are updated below.
@@ -124,6 +124,6 @@ impl sdk::Runtime for Runtime {
         params.participation_threshold_denominator = 4;
 
         // Store parameters.
-        Rewards::set_params(ctx.runtime_state(), &params)
+        Rewards::set_params(ctx.runtime_state(), params)
     }
 }

--- a/tests/runtimes/simple-keyvalue/src/test.rs
+++ b/tests/runtimes/simple-keyvalue/src/test.rs
@@ -12,7 +12,7 @@ fn test_impl_for_tuple() {
     let mut ctx = mock.create_ctx();
     Core::set_params(
         ctx.runtime_state(),
-        &core::Parameters {
+        core::Parameters {
             max_batch_gas: u64::MAX,
             max_tx_signers: 1,
             max_multisig_signers: 1,


### PR DESCRIPTION
* Replace `serde-cbor` with `oasis-cbor` (requires currently unreleased version of Oasis Core).
* Replace `Quantity` with `u128`.