### PR TITLE
test/benchmark: fixes and improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 **
 
 # Allow runtime benchmarking binary.
-!target/debug/test-runtime-benchmarking
+!target/release/test-runtime-benchmarking
 
 # Allow downloaded oasis-core binaries.
 !tests/untracked/

--- a/tests/benchmark/Dockerfile
+++ b/tests/benchmark/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get -y update && apt-get install -y bubblewrap
 COPY tests/untracked/oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node /oasis/bin/oasis-node
 COPY tests/untracked/oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-core-runtime-loader /oasis/bin/oasis-core-runtime-loader
 COPY tests/benchmark/benchmark /oasis/bin/benchmark
-COPY target/debug/test-runtime-benchmarking /oasis/lib/oasis-runtime
+COPY target/release/test-runtime-benchmarking /oasis/lib/oasis-runtime
 
 ENV PATH "/oasis/bin:${PATH}"

--- a/tests/benchmark/build-benchmarks.sh
+++ b/tests/benchmark/build-benchmarks.sh
@@ -12,5 +12,5 @@ go build
 
 echo "Building test benchmarking runtime."
 pushd "${TESTS_DIR}"/runtimes/benchmarking
-    cargo build
+    cargo build --release
 popd

--- a/tests/benchmark/cmd/fixture.go
+++ b/tests/benchmark/cmd/fixture.go
@@ -93,12 +93,14 @@ func fixture() *oasis.NetworkFixture {
 			{NodeFixture: oasis.NodeFixture{ExtraArgs: clientExtraArgs}},
 		},
 		StorageWorkers: []oasis.StorageWorkerFixture{
-			{Entity: 1, Runtimes: []int{0}, Backend: badger.BackendName},
+			{NodeFixture: oasis.NodeFixture{Name: "compute-storage-1"}, Entity: 1, Runtimes: []int{0}, Backend: badger.BackendName},
+			{NodeFixture: oasis.NodeFixture{Name: "compute-storage-2"}, Entity: 1, Runtimes: []int{0}, Backend: badger.BackendName},
+			{NodeFixture: oasis.NodeFixture{Name: "compute-storage-3"}, Entity: 1, Runtimes: []int{0}, Backend: badger.BackendName},
 		},
 		ComputeWorkers: []oasis.ComputeWorkerFixture{
-			{Entity: 1, Runtimes: []int{0}, NodeFixture: oasis.NodeFixture{ExtraArgs: computeExtraArgs}},
-			{Entity: 1, Runtimes: []int{0}, NodeFixture: oasis.NodeFixture{ExtraArgs: computeExtraArgs}},
-			{Entity: 1, Runtimes: []int{0}, NodeFixture: oasis.NodeFixture{ExtraArgs: computeExtraArgs}},
+			{NodeFixture: oasis.NodeFixture{Name: "compute-storage-1", ExtraArgs: computeExtraArgs}, Entity: 1, Runtimes: []int{0}},
+			{NodeFixture: oasis.NodeFixture{Name: "compute-storage-2", ExtraArgs: computeExtraArgs}, Entity: 1, Runtimes: []int{0}},
+			{NodeFixture: oasis.NodeFixture{Name: "compute-storage-3", ExtraArgs: computeExtraArgs}, Entity: 1, Runtimes: []int{0}},
 		},
 		Seeds: []oasis.SeedFixture{{}},
 		Runtimes: []oasis.RuntimeFixture{
@@ -124,8 +126,8 @@ func fixture() *oasis.NetworkFixture {
 					ProposerTimeout:   5,
 				},
 				Storage: registry.StorageParameters{
-					GroupSize:               1,
-					MinWriteReplication:     1,
+					GroupSize:               3,
+					MinWriteReplication:     3,
 					MaxApplyWriteLogEntries: 100_000,
 					MaxApplyOps:             2,
 				},

--- a/tests/benchmark/run-benchmarks.sh
+++ b/tests/benchmark/run-benchmarks.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -o nounset -o pipefail -o errexit -x
 
-
 # Kill all dangling processes on exit.
 cleanup() {
-	pkill -P $$ || true
-	wait || true
+    pkill -P $$ || true
+    wait || true
 }
 trap "cleanup" EXIT
 
@@ -23,8 +22,8 @@ mkdir -p /tmp/oasis-net-runner-benchmarks
     fixture \
     --node.binary "${TEST_NODE_BINARY}" \
     --runtime.id "8000000000000000000000000000000000000000000000000000000000000000" \
-    --runtime.binary ../../target/debug/test-runtime-benchmarking \
-    --runtime.loader "${TEST_RUNTIME_LOADER}" > /tmp/oasis-net-runner-benchmarks/fixture.json
+    --runtime.binary ../../target/release/test-runtime-benchmarking \
+    --runtime.loader "${TEST_RUNTIME_LOADER}" >/tmp/oasis-net-runner-benchmarks/fixture.json
 
 "${TEST_NET_RUNNER}" \
     --fixture.file /tmp/oasis-net-runner-benchmarks/fixture.json \
@@ -47,7 +46,7 @@ echo "Advancing epoch."
 echo "Waiting for all nodes to be registered."
 "${TEST_NODE_BINARY}" debug control wait-nodes \
     --address "${CLIENT_SOCK}" \
-    --nodes 5 \
+    --nodes 4 \
     --wait
 
 echo "Advancing epoch."
@@ -58,7 +57,7 @@ echo "Advancing epoch."
 sleep 2
 
 ./benchmark \
-	--address "${CLIENT_SOCK}" \
-	--runtime.id "8000000000000000000000000000000000000000000000000000000000000000" \
-	--benchmarks accounts_transfers \
-	--benchmarks.concurrency 100
+    --address "${CLIENT_SOCK}" \
+    --runtime.id "8000000000000000000000000000000000000000000000000000000000000000" \
+    --benchmarks accounts_transfers \
+    --benchmarks.concurrency 6000


### PR DESCRIPTION
- use release instead of the debug benchmarks build
- use compute+storage worker nodes instead of separate workers
- bump some benchmark parameters