### PR TITLE
ts-web/ext-utils: adapters around the interface

### DIFF
--- a/client-sdk/ts-web/ext-utils/sample-ext/src/index.js
+++ b/client-sdk/ts-web/ext-utils/sample-ext/src/index.js
@@ -105,6 +105,8 @@ function rtBaseUnitsDisplay(/** @type {oasisRT.types.BaseUnits} */ bu) {
  */
 async function keysList(origin, req) {
     await authorize(origin);
+    const signer = await getSigner();
+    const publicKey = signer.public();
     return {
         keys: [
             {
@@ -112,6 +114,7 @@ async function keysList(origin, req) {
                 metadata: {
                     name: 'The only key',
                     description: 'This sample extension only keeps one key--this one.',
+                    publicKey,
                 },
             },
         ],

--- a/client-sdk/ts-web/ext-utils/sample-ext/src/index.js
+++ b/client-sdk/ts-web/ext-utils/sample-ext/src/index.js
@@ -99,190 +99,202 @@ function rtBaseUnitsDisplay(/** @type {oasisRT.types.BaseUnits} */ bu) {
     }`;
 }
 
-oasisExt.ext.ready({
-    async keysList(origin, req) {
-        await authorize(origin);
-        return {
-            keys: [
-                {
-                    which: KEY_ID,
-                    metadata: {
-                        name: 'The only key',
-                        description: 'This sample extension only keeps one key--this one.',
-                    },
+/**
+ * @param {string} origin
+ * @param {oasisExt.protocol.KeysListRequest} req
+ */
+async function keysList(origin, req) {
+    await authorize(origin);
+    return {
+        keys: [
+            {
+                which: KEY_ID,
+                metadata: {
+                    name: 'The only key',
+                    description: 'This sample extension only keeps one key--this one.',
                 },
-            ],
-        };
-    },
-    async contextSignerPublic(origin, req) {
-        await authorize(origin);
-        if (req.which !== KEY_ID) {
-            throw new Error(`sample extension only supports .which === ${JSON.stringify(KEY_ID)}`);
-        }
-        const signer = await getSigner();
-        const publicKey = signer.public();
-        return {public_key: publicKey};
-    },
-    async contextSignerSign(origin, req) {
-        await authorize(origin);
-        if (req.which !== KEY_ID) {
-            throw new Error(`sample extension only supports .which === ${JSON.stringify(KEY_ID)}`);
-        }
-        let confMessage = `Signature request`;
-        try {
-            const handled = oasis.signature.visitMessage(
-                {
-                    withChainContext:
-                        /** @type {oasis.consensus.SignatureMessageHandlersWithChainContext & oasisRT.transaction.SignatureMessageHandlersWithChainContext} */ ({
-                            [oasis.consensus.TRANSACTION_SIGNATURE_CONTEXT]: (chainContext, tx) => {
-                                confMessage += `
+            },
+        ],
+    };
+}
+
+/**
+ * @param {string} origin
+ * @param {oasisExt.protocol.ContextSignerPublicRequest} req
+ */
+async function contextSignerPublic(origin, req) {
+    await authorize(origin);
+    if (req.which !== KEY_ID) {
+        throw new Error(`sample extension only supports .which === ${JSON.stringify(KEY_ID)}`);
+    }
+    const signer = await getSigner();
+    const publicKey = signer.public();
+    return {public_key: publicKey};
+}
+
+/**
+ * @param {string} origin
+ * @param {oasisExt.protocol.ContextSignerSignRequest} req
+ */
+async function contextSignerSign(origin, req) {
+    await authorize(origin);
+    if (req.which !== KEY_ID) {
+        throw new Error(`sample extension only supports .which === ${JSON.stringify(KEY_ID)}`);
+    }
+    let confMessage = `Signature request`;
+    try {
+        const handled = oasis.signature.visitMessage(
+            {
+                withChainContext:
+                    /** @type {oasis.consensus.SignatureMessageHandlersWithChainContext & oasisRT.transaction.SignatureMessageHandlersWithChainContext} */ ({
+                        [oasis.consensus.TRANSACTION_SIGNATURE_CONTEXT]: (chainContext, tx) => {
+                            confMessage += `
 Recognized message type: consensus transaction
 Chain context: ${chainContext}
 Nonce: ${tx.nonce}
 Fee amount: ${oasis.quantity.toBigInt(tx.fee.amount)} base units
 Fee gas: ${tx.fee.gas}`;
-                                const handled = oasis.consensus.visitTransaction(
-                                    /** @type {oasis.staking.ConsensusTransactionHandlers} */ ({
-                                        [oasis.staking.METHOD_TRANSFER]: (body) => {
-                                            confMessage += `
+                            const handled = oasis.consensus.visitTransaction(
+                                /** @type {oasis.staking.ConsensusTransactionHandlers} */ ({
+                                    [oasis.staking.METHOD_TRANSFER]: (body) => {
+                                        confMessage += `
 Recognized method: staking transfer
 To: ${oasis.staking.addressToBech32(body.to)}
 Amount: ${oasis.quantity.toBigInt(body.amount)} base units`;
-                                        },
-                                        [oasis.staking.METHOD_BURN]: (body) => {
-                                            confMessage += `
+                                    },
+                                    [oasis.staking.METHOD_BURN]: (body) => {
+                                        confMessage += `
 Recognized method: staking burn
 Amount: ${oasis.quantity.toBigInt(body.amount)} base units`;
-                                        },
-                                        [oasis.staking.METHOD_ADD_ESCROW]: (body) => {
-                                            confMessage += `
+                                    },
+                                    [oasis.staking.METHOD_ADD_ESCROW]: (body) => {
+                                        confMessage += `
 Recognized method: staking add escrow
 Account: ${oasis.staking.addressToBech32(body.account)}
 Amount: ${oasis.quantity.toBigInt(body.amount)} base units`;
-                                        },
-                                        [oasis.staking.METHOD_RECLAIM_ESCROW]: (body) => {
-                                            confMessage += `
+                                    },
+                                    [oasis.staking.METHOD_RECLAIM_ESCROW]: (body) => {
+                                        confMessage += `
 Recognized method: staking reclaim escrow
 Account: ${oasis.staking.addressToBech32(body.account)}
 Shares: ${oasis.quantity.toBigInt(body.shares)}`;
-                                        },
-                                        [oasis.staking.METHOD_AMEND_COMMISSION_SCHEDULE]: (
-                                            body,
-                                        ) => {
-                                            confMessage += `
+                                    },
+                                    [oasis.staking.METHOD_AMEND_COMMISSION_SCHEDULE]: (body) => {
+                                        confMessage += `
 Recognized method: staking amend commission schedule
 Amendment: ${JSON.stringify(body.amendment)}`;
-                                        },
-                                        [oasis.staking.METHOD_ALLOW]: (body) => {
-                                            confMessage += `
+                                    },
+                                    [oasis.staking.METHOD_ALLOW]: (body) => {
+                                        confMessage += `
 Recognized method: staking allow
 Beneficiary: ${oasis.staking.addressToBech32(body.beneficiary)}
 Amount change: ${body.negative ? '-' : '+'}${oasis.quantity.toBigInt(
-                                                body.amount_change,
-                                            )} base units`;
-                                        },
-                                        [oasis.staking.METHOD_WITHDRAW]: (body) => {
-                                            confMessage += `
+                                            body.amount_change,
+                                        )} base units`;
+                                    },
+                                    [oasis.staking.METHOD_WITHDRAW]: (body) => {
+                                        confMessage += `
 Recognized method: staking withdraw
 From: ${oasis.staking.addressToBech32(body.from)}
 Amount: ${oasis.quantity.toBigInt(body.amount)} base units`;
-                                        },
-                                    }),
-                                    tx,
-                                );
-                                if (!handled) {
-                                    confMessage += `
+                                    },
+                                }),
+                                tx,
+                            );
+                            if (!handled) {
+                                confMessage += `
 (pretty printing doesn't support this method)
 Method: ${tx.method}
 Body JSON: ${JSON.stringify(tx.body)}`;
-                                }
-                            },
-                            [oasisRT.transaction.SIGNATURE_CONTEXT_BASE]: (chainContext, tx) => {
-                                confMessage += `
+                            }
+                        },
+                        [oasisRT.transaction.SIGNATURE_CONTEXT_BASE]: (chainContext, tx) => {
+                            confMessage += `
 Recognized message type: runtime transaction
 Chain context: ${chainContext}
 Version: ${tx.v}`;
-                                const handled = oasisRT.transaction.visitCall(
-                                    /** @type {oasisRT.accounts.TransactionCallHandlers & oasisRT.consensusAccounts.TransactionCallHandlers} */ ({
-                                        [oasisRT.accounts.METHOD_TRANSFER]: (body) => {
-                                            confMessage += `
+                            const handled = oasisRT.transaction.visitCall(
+                                /** @type {oasisRT.accounts.TransactionCallHandlers & oasisRT.consensusAccounts.TransactionCallHandlers} */ ({
+                                    [oasisRT.accounts.METHOD_TRANSFER]: (body) => {
+                                        confMessage += `
 Recognized method: accounts transfer
 To: ${oasis.staking.addressToBech32(body.to)}
 Amount: ${rtBaseUnitsDisplay(body.amount)} base units`;
-                                        },
-                                        [oasisRT.consensusAccounts.METHOD_DEPOSIT]: (body) => {
-                                            confMessage += `
+                                    },
+                                    [oasisRT.consensusAccounts.METHOD_DEPOSIT]: (body) => {
+                                        confMessage += `
 Recognized method: consensus accounts deposit
 Amount: ${rtBaseUnitsDisplay(body.amount)} base units`;
-                                        },
-                                        [oasisRT.consensusAccounts.METHOD_WITHDRAW]: (body) => {
-                                            confMessage += `
+                                    },
+                                    [oasisRT.consensusAccounts.METHOD_WITHDRAW]: (body) => {
+                                        confMessage += `
 Recognized method: consensus accounts withdraw
 Amount: ${rtBaseUnitsDisplay(body.amount)} base units`;
-                                        },
-                                    }),
-                                    tx.call,
-                                );
-                                if (!handled) {
-                                    confMessage += `
+                                    },
+                                }),
+                                tx.call,
+                            );
+                            if (!handled) {
+                                confMessage += `
 (pretty printing doesn't support this method)
 Method: ${tx.call.method}
 Body JSON: ${JSON.stringify(tx.call.body)}`;
-                                }
-                                for (const si of tx.ai.si) {
-                                    if ('signature' in si.address_spec) {
-                                        if ('ed25519' in si.address_spec.signature) {
-                                            confMessage += `
+                            }
+                            for (const si of tx.ai.si) {
+                                if ('signature' in si.address_spec) {
+                                    if ('ed25519' in si.address_spec.signature) {
+                                        confMessage += `
 Signer: ed25519 signature with public key, base64 ${toBase64(
-                                                si.address_spec.signature.ed25519,
-                                            )}, nonce ${si.nonce}`;
-                                            continue;
-                                        }
+                                            si.address_spec.signature.ed25519,
+                                        )}, nonce ${si.nonce}`;
+                                        continue;
                                     }
-                                    confMessage += `
-Signer: other, JSON ${JSON.stringify(si.address_spec)}, nonce ${si.nonce}`;
                                 }
                                 confMessage += `
+Signer: other, JSON ${JSON.stringify(si.address_spec)}, nonce ${si.nonce}`;
+                            }
+                            confMessage += `
 Fee amount: ${rtBaseUnitsDisplay(tx.ai.fee.amount)} base units
 Fee gas: ${tx.ai.fee.gas}`;
-                            },
-                        }),
-                },
-                req.context,
-                req.message,
-            );
-            if (!handled) {
-                confMessage += `
+                        },
+                    }),
+            },
+            req.context,
+            req.message,
+        );
+        if (!handled) {
+            confMessage += `
 (pretty printing doesn't support this signature context)
 Context: ${req.context}
 Message hex: ${oasis.misc.toHex(req.message)}`;
-            }
-        } catch (e) {
-            console.error(e);
-            confMessage += `
-(couldn't parse)`;
         }
+    } catch (e) {
+        console.error(e);
         confMessage += `
+(couldn't parse)`;
+    }
+    confMessage += `
 Sign this message?`;
-        if (testNoninteractive) {
-            // We run an integration test to exercise the cross-origin messaging
-            // mechanism. Disable the user interactions in that case, due to
-            // limitations in our testing framework. But also be sure not to expose
-            // actual keys. Or better yet, remove this flag altogether in a real
-            // extension.
-            console.warn(
-                'test_noninteractive: skipping approval',
-                'confirmation message',
-                confMessage,
-            );
-        } else {
-            const conf = window.confirm(confMessage);
-            if (!conf) return {approved: false};
-        }
-        const signer = await getSigner();
-        const signature = await signer.sign(req.context, req.message);
-        return {approved: true, signature};
-    },
+    if (testNoninteractive) {
+        // We run an integration test to exercise the cross-origin messaging
+        // mechanism. Disable the user interactions in that case, due to
+        // limitations in our testing framework. But also be sure not to expose
+        // actual keys. Or better yet, remove this flag altogether in a real
+        // extension.
+        console.warn('test_noninteractive: skipping approval', 'confirmation message', confMessage);
+    } else {
+        const conf = window.confirm(confMessage);
+        if (!conf) return {approved: false};
+    }
+    const signer = await getSigner();
+    const signature = await signer.sign(req.context, req.message);
+    return {approved: true, signature};
+}
+
+oasisExt.ext.ready({
+    keysList,
+    contextSignerPublic,
+    contextSignerSign,
 });
 
 // We only ever have on key that doesn't change, but call this so that we

--- a/client-sdk/ts-web/ext-utils/sample-page/src/index.js
+++ b/client-sdk/ts-web/ext-utils/sample-page/src/index.js
@@ -15,6 +15,33 @@ function toBase64(/** @type {Uint8Array} */ u8) {
     return btoa(String.fromCharCode.apply(null, u8));
 }
 
+/**
+ * If you desire to be notified of a change to the keys list _with a copy of
+ * the new list of keys_, use this snippet or similar to request the list
+ * when the keys changed handler gets called.
+ * @param {oasisExt.connection.ExtConnection} conn
+ * @param {(keys: oasisExt.protocol.KeyInfo[]) => void} handleNewKeys
+ */
+function watchKeys(conn, handleNewKeys) {
+    let lastRequested = 0;
+    oasisExt.keys.setKeysChangeHandler(conn, (_) => {
+        // Save a copy of the counter so we can compare whether another change
+        // came in while we request the new keys list.
+        const requestSeq = ++lastRequested;
+        oasisExt.keys
+            .list(conn)
+            .then((keys) => {
+                // To avoid extraneous handler calls with outdated lists, skip any
+                // key lists that were requested before the latest keys change.
+                if (requestSeq !== lastRequested) return;
+                handleNewKeys(keys);
+            })
+            .catch((e) => {
+                console.error(e);
+            });
+    });
+}
+
 export const playground = (async function () {
     console.log('connecting');
     const conn = await oasisExt.connection.connect(extOrigin, extPath);
@@ -24,21 +51,17 @@ export const playground = (async function () {
     // developers should handle this separately if they wish to react to
     // changes to the keys list.
     console.log('waiting for keys change event');
-    await new Promise((resolve, reject) => {
+    const keys = await new Promise((resolve, reject) => {
         // Note: Due to the structure of sample-ext calling `ready` and
         // `keysChanged` in quick succession, keep this in the same task as
         // when the ready message is received (above in
         // `await ...connect(...)`). Intervening microtasks are fine.
-        oasisExt.keys.setKeysChangeHandler(conn, (e) => {
-            console.log('keys change', e);
-            resolve();
+        watchKeys(conn, (newKeys) => {
+            console.log('keys change');
+            resolve(newKeys);
         });
     });
     console.log('received');
-
-    console.log('listing keys');
-    const keys = await oasisExt.keys.list(conn);
-    console.log('listed keys');
     console.log('keys', keys);
 
     console.log('requesting signer');


### PR DESCRIPTION
This PR adds some sample code demonstrating how to use the ext-utils interfaces with some simplifications:

- in a dapp, how to receive the new keys list whenever the keys list changes
- in an extension, how to serve both `keysList` and `contextSignerPublic` with a single key list implementation (cross-reference #287 )