### PR TITLE
benchmarks: fix docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,12 +36,16 @@ jobs:
           echo "::set-output name=tag::$(echo ${branch})"
           echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
-      - name: Determine oasis-core version
-        id: determine_oasis_core_version
+      - name: Determine oasis-core artifacts paths
+        id: determine-artifacts-paths
         shell: bash
         run: |
           . tests/consts.sh
-          echo "::set-output name=version::$(echo ${OASIS_CORE_VERSION})"
+          . tests/paths.sh
+          echo "::set-output name=oasis_core_node_binary_path::$(echo ${TEST_NODE_BINARY})"
+          echo "::set-output name=oasis_core_runtime_loader_path::$(echo ${TEST_RUNTIME_LOADER})"
+        env:
+          TESTS_DIR: tests
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -74,7 +78,8 @@ jobs:
           pull: true
           push: true
           build-args: |
-            OASIS_CORE_VERSION=${{ steps.determine_oasis_core_version.outputs.version }}
+            OASIS_CORE_NODE_BINARY=${{ steps.determine-artifacts-paths.outputs.oasis_core_node_binary_path }}
+            OASIS_CORE_RUNTIME_LOADER=${{ steps.determine-artifacts-paths.outputs.oasis_core_runtime_loader_path }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.determine_tag.outputs.created }}

--- a/tests/benchmark/Dockerfile
+++ b/tests/benchmark/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:20.04
 
-ARG OASIS_CORE_VERSION
+ARG OASIS_CORE_NODE_BINARY
+ARG OASIS_CORE_RUNTUME_LOADER
 
 RUN apt-get -y update && apt-get install -y bubblewrap
 
-COPY tests/untracked/oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node /oasis/bin/oasis-node
-COPY tests/untracked/oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-core-runtime-loader /oasis/bin/oasis-core-runtime-loader
+COPY ${OASIS_CORE_NODE_BINARY} /oasis/bin/oasis-node
+COPY ${OASIS_CORE_RUNTUME_LOADER} /oasis/bin/oasis-core-runtime-loader
 COPY tests/benchmark/benchmark /oasis/bin/benchmark
 COPY target/release/test-runtime-benchmarking /oasis/lib/oasis-runtime
 


### PR DESCRIPTION
Fixes the benchmarks image build when runtime-sdk depends on a unreleased oasis-core version