### PR TITLE
Documentation materials improvements

### DIFF
--- a/client-sdk/ts-web/core/playground/sample-envoy.yaml
+++ b/client-sdk/ts-web/core/playground/sample-envoy.yaml
@@ -41,6 +41,7 @@ static_resources:
               #   allow_origin_string_match:
               #   - exact: '*'
               #   allow_headers: content-type,x-grpc-web,x-user-agent
+              #   expose_headers: grpc-status,grpc-message
               #   max_age: '1728000'
           http_filters:
           - name: envoy.filters.http.grpc_web

--- a/client-sdk/ts-web/core/playground/sample-envoy.yaml
+++ b/client-sdk/ts-web/core/playground/sample-envoy.yaml
@@ -21,7 +21,7 @@ static_resources:
                   safe_regex:
                     google_re2:
                       max_program_size: 1000000
-                    regex: '/oasis-core\.(Registry/(GetNodes)|Staking/(Account|DelegationsTo|GetEvents)|Consensus/(SubmitTx|EstimateGas|GetSignerNonce|GetBlock|GetTransactionsWithResults|GetGenesisDocument|GetChainContext|WatchBlocks)|NodeController/(WaitReady))'
+                    regex: '/oasis-core\.(Registry/(GetNodes)|Staking/(Account|DebondingDelegationInfosFor|DelegationInfosFor|DelegationsTo||GetEvents)|Consensus/(SubmitTx|EstimateGas|GetSignerNonce|GetBlock|GetTransactionsWithResults|GetGenesisDocument|GetChainContext|WatchBlocks)|NodeController/(WaitReady))'
                 route:
                   cluster: oasis_node_grpc
                   timeout: 0s

--- a/client-sdk/ts-web/ext-utils/src/ext.ts
+++ b/client-sdk/ts-web/ext-utils/src/ext.ts
@@ -4,6 +4,24 @@
  *
  * There's logic here to accept connections from web content and pass requests
  * to your code and pass responses back to the web content.
+ *
+ * Run this code in a `web_accessible_resources` page named
+ * `oasis-xu-frame.html`. Each web page creates its own instance of this page,
+ * and this code communicates specifically with its parent web page.
+ *
+ * ```
+ *                web app A
+ *                    |
+ *          +--------------------+
+ *          |                    |
+ *    page-a1.html         page-a2.html      } `oasisExt.connection` et al.
+ *          |                    |
+ * oasis-xu-frame.html  oasis-xu-frame.html  } `oasisExt.ext`
+ *          |                    |
+ *          +--------------------+
+ *                    |
+ *          extension shared state
+ * ```
  */
 
 import * as protocol from './protocol';


### PR DESCRIPTION
1. clarify that `oasisExt.ext` communicates with a single web page that embeds an instance of oasis-xu-frame.html
2. add `expose_headers` to sample envoy config, without which grpc errors aren't shown to the client
3. add [debonding] delegation infos to allowed methods in sample envoy config because they're easy to misspell 