### PR TITLE
ts-web/ext-utils: keys change event with keys list

### DIFF
--- a/client-sdk/ts-web/ext-utils/docs/changelog.md
+++ b/client-sdk/ts-web/ext-utils/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+New features:
+
+- The keys change event now delivers the new keys list as part of the event.
+
 ## v0.1.0-alpha2
 
 Spotlight change:

--- a/client-sdk/ts-web/ext-utils/sample-ext/src/index.js
+++ b/client-sdk/ts-web/ext-utils/sample-ext/src/index.js
@@ -396,8 +396,14 @@ oasisExt.ext.ready({
     contextSignerSign,
 });
 
-// We only ever have on key that doesn't change, but call this so that we
+// We only ever have one key that doesn't change, but call this so that we
 // exercise the library code for it. Extension implementors should design
 // their own logic if they wish to notify the web content of changes to the
 // keys list.
-oasisExt.ext.keysChanged();
+getKeysWithPublic()
+    .then((keys) => {
+        oasisExt.ext.keysChanged(keys);
+    })
+    .catch((e) => {
+        console.error(e);
+    });

--- a/client-sdk/ts-web/ext-utils/src/ext.ts
+++ b/client-sdk/ts-web/ext-utils/src/ext.ts
@@ -124,9 +124,11 @@ function postEvent(event: unknown) {
 
 /**
  * Call this to tell the web content that the list of available keys has changed.
+ * @param keys The new list of available keys, as would be returned from `keysList`
  */
-export function keysChanged() {
+export function keysChanged(keys: protocol.KeyInfo[]) {
     postEvent({
         type: protocol.EVENT_KEYS_CHANGE,
+        keys,
     } as protocol.KeysChangeEvent);
 }

--- a/client-sdk/ts-web/ext-utils/src/protocol.ts
+++ b/client-sdk/ts-web/ext-utils/src/protocol.ts
@@ -103,4 +103,8 @@ export const EVENT_KEYS_CHANGE = 'keys-change-v1';
 
 export interface KeysChangeEvent {
     type: typeof EVENT_KEYS_CHANGE;
+    /**
+     * The new list of available keys, as would be returned from `keys.list`.
+     */
+    keys: KeyInfo[];
 }


### PR DESCRIPTION
add a field for the new keys. the extension now has to provide this when it tells the web content that the keys list has changed