### PR TITLE
ts-web/core: minor types fixes

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes:
+
+Bug fixes:
+
+- Fixes to type declarations that were inconsistent with the Go types.
+
 ## v0.1.0-alpha5
 
 Spotlight change:

--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -62,7 +62,7 @@ export interface BeaconInsecureParameters {
     /**
      * Interval is the epoch interval (in blocks).
      */
-    interval: longnum;
+    interval?: longnum;
 }
 
 /**
@@ -260,7 +260,7 @@ export interface ConsensusParameters {
     max_tx_size: longnum;
     max_block_size: longnum;
     max_block_gas: longnum;
-    max_evidence_size: number;
+    max_evidence_size: longnum;
     /**
      * StateCheckpointInterval is the expected state checkpoint interval (in blocks).
      */
@@ -753,7 +753,7 @@ export interface GovernanceProposal {
     /**
      * InvalidVotes is the number of invalid votes after tallying.
      */
-    invalid_votes: longnum;
+    invalid_votes?: longnum;
 }
 
 /**
@@ -1481,7 +1481,7 @@ export interface RegistryRuntime extends CBORVersioned {
     /**
      * Constraints are the node scheduling constraints.
      */
-    constraints: Map<number, Map<number, RegistrySchedulingConstraints>>;
+    constraints?: Map<number, Map<number, RegistrySchedulingConstraints>>;
     /**
      * Staking stores the runtime's staking-related parameters.
      */
@@ -2562,7 +2562,7 @@ export interface StakingConsensusParameters {
     /**
      * MaxAllowances is the maximum number of allowances an account can have. Zero means disabled.
      */
-    max_allowances: number;
+    max_allowances?: number;
     /**
      * FeeSplitWeightPropose is the proportion of block fee portions that go to the proposer.
      */

--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -2352,20 +2352,6 @@ export interface SGXEnclaveIdentity {
 }
 
 /**
- * MultiSigned is a blob signed by multiple public keys.
- */
-export interface SignatureMultiSigned {
-    /**
-     * Blob is the signed blob.
-     */
-    untrusted_raw_value: Uint8Array;
-    /**
-     * Signatures are the signatures over the blob.
-     */
-    signatures: Signature[];
-}
-
-/**
  * Signature is a signature, bundled with the signing public key.
  */
 export interface Signature {
@@ -2377,6 +2363,20 @@ export interface Signature {
      * Signature is the actual raw signature.
      */
     signature: Uint8Array;
+}
+
+/**
+ * MultiSigned is a blob signed by multiple public keys.
+ */
+export interface SignatureMultiSigned {
+    /**
+     * Blob is the signed blob.
+     */
+    untrusted_raw_value: Uint8Array;
+    /**
+     * Signatures are the signatures over the blob.
+     */
+    signatures: Signature[];
 }
 
 /**


### PR DESCRIPTION
detected some mismatches from the generated types from #90 

- some `omitempty` fields aren't marked as optional
- consensus `Parameters.MaxEvidenceSize` is uint64, so it should be longnum. I probably missed this when I was replacing MaxEvidenceNum. in practice it's 51200, so the difference never came up
- the lexicographical ordering between Signature and SignatureMultiSigned was swapped. possibly related to Signature having been collapsed from SignatureSignature :shrug: 

~~also I'm changing `toarray` structs to be multiline (only `StorageLogEntry` at this time). lint, please don't kill me~~ nvm lint did kill me