### PR TITLE
hello-contract: support for setting initial counter

### DIFF
--- a/runtime-sdk/modules/contracts/src/abi/oasis/test.rs
+++ b/runtime-sdk/modules/contracts/src/abi/oasis/test.rs
@@ -228,7 +228,10 @@ fn test_hello_contract() {
     let result = run_contract_with_defaults(
         HELLO_CONTRACT_CODE,
         1_000_000,
-        cbor::cbor_text!("instantiate"),
+        cbor::cbor_map! {
+        "instantiate" => cbor::cbor_map! {
+            "initial_counter" => cbor::cbor_int!(22)
+        }},
         cbor::cbor_map! { "say_hello" => cbor::cbor_map!{"who" => cbor::cbor_text!("tester")} },
     )
     .expect("contract instantiation and call should succeed");
@@ -236,7 +239,7 @@ fn test_hello_contract() {
         result,
         cbor::cbor_map! {
             "hello" => cbor::cbor_map!{
-                "greeting" => cbor::cbor_text!("hello tester (1)")
+                "greeting" => cbor::cbor_text!("hello tester (22)")
             }
         }
     );
@@ -247,8 +250,14 @@ fn test_hello_contract_invalid_request() {
     let result = run_contract_with_defaults(
         HELLO_CONTRACT_CODE,
         1_000_000,
-        cbor::cbor_text!("instantiate"),
-        cbor::cbor_text!("instantiate"), // This request is invalid.
+        cbor::cbor_map! {
+        "instantiate" => cbor::cbor_map! {
+            "initial_counter" => cbor::cbor_int!(44)
+        }},
+        cbor::cbor_map! {
+        "instantiate" => cbor::cbor_map! {
+            "initial_counter" => cbor::cbor_int!(44)
+        }}, // This request is invalid.
     )
     .expect_err("contract call should fail");
 

--- a/runtime-sdk/modules/contracts/src/test.rs
+++ b/runtime-sdk/modules/contracts/src/test.rs
@@ -77,7 +77,12 @@ fn deploy_hello_contract<C: BatchContext>(
             body: cbor::to_value(types::Instantiate {
                 code_id: 0.into(),
                 upgrades_policy: types::Policy::Address(keys::alice::address()),
-                data: cbor::to_vec(cbor::cbor_text!("instantiate")), // Needs to conform to contract API.
+                // Needs to conform to contract API.
+                data: cbor::to_vec(cbor::cbor_map! {
+                    "instantiate" => cbor::cbor_map! {
+                        "initial_counter" => cbor::cbor_int!(33)
+                    }
+                }),
                 tokens,
                 max_consensus_messages: 0,
             }),
@@ -215,7 +220,7 @@ fn test_hello_contract_call() {
             result,
             cbor::cbor_map! {
                 "hello" => cbor::cbor_map!{
-                    "greeting" => cbor::cbor_text!("hello tester (1)")
+                    "greeting" => cbor::cbor_text!("hello tester (33)")
                 }
             }
         );
@@ -296,7 +301,7 @@ fn test_hello_contract_call() {
             result,
             cbor::cbor_map! {
                 "hello" => cbor::cbor_map!{
-                    "greeting" => cbor::cbor_text!("hello second (2)")
+                    "greeting" => cbor::cbor_text!("hello second (34)")
                 }
             }
         );
@@ -359,8 +364,8 @@ fn test_hello_contract_call() {
     .expect("instance storage query should succeed");
     let value = result.value.expect("counter value should be set");
     let value: u64 = cbor::from_slice(&value).expect("counter value should be well-formed");
-    // Value is 3 because it was incremented by last call above.
-    assert_eq!(value, 3, "counter value should be correct");
+    // Value is 35 because it was incremented by last call above.
+    assert_eq!(value, 35, "counter value should be correct");
 }
 
 /// Contract runtime.

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -108,7 +108,7 @@ fn test_debug_option_set() {
 
     Accounts::init(
         &mut ctx,
-        &Genesis {
+        Genesis {
             parameters: Parameters {
                 debug_disable_nonce_check: true,
                 ..Default::default()

--- a/tests/contracts/hello/Cargo.lock
+++ b/tests/contracts/hello/Cargo.lock
@@ -211,18 +211,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Adds support for setting an initial contract value to the `hello` contract, as an example for initializing contract state.