### PR TITLE
ts-web/core: minor types sync

### DIFF
--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -8,14 +8,6 @@ export type NotModeled = {[key: string]: unknown};
 export type longnum = number | bigint;
 
 /**
- * EpochTimeState is the epoch state.
- */
-export interface BeaconEpochTimeState {
-    epoch: longnum;
-    height: longnum;
-}
-
-/**
  * ConsensusParameters are the beacon consensus parameters.
  */
 export interface BeaconConsensusParameters {
@@ -39,6 +31,14 @@ export interface BeaconConsensusParameters {
      * PVSSParameters are the beacon parameters for the PVSS backend.
      */
     pvss_parameters?: BeaconPVSSParameters;
+}
+
+/**
+ * EpochTimeState is the epoch state.
+ */
+export interface BeaconEpochTimeState {
+    epoch: longnum;
+    height: longnum;
 }
 
 /**
@@ -1047,6 +1047,20 @@ export interface NodeConsensusInfo {
 }
 
 /**
+ * P2PInfo contains information for connecting to this node via P2P transport.
+ */
+export interface NodeP2PInfo {
+    /**
+     * ID is the unique identifier of the node on the P2P transport.
+     */
+    id: Uint8Array;
+    /**
+     * Addresses is the list of addresses at which the node can be reached.
+     */
+    addresses: NodeAddress[];
+}
+
+/**
  * Runtime represents the runtimes supported by a given Oasis node.
  */
 export interface NodeRuntime {
@@ -1104,20 +1118,6 @@ export interface NodeTLSInfo {
      * Addresses is the list of addresses at which the node can be reached.
      */
     addresses: NodeTLSAddress[];
-}
-
-/**
- * P2PInfo contains information for connecting to this node via P2P transport.
- */
-export interface NodeP2PInfo {
-    /**
-     * ID is the unique identifier of the node on the P2P transport.
-     */
-    id: Uint8Array;
-    /**
-     * Addresses is the list of addresses at which the node can be reached.
-     */
-    addresses: NodeAddress[];
 }
 
 /**

--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -1964,7 +1964,7 @@ export interface RootHashPool {
      * ExecuteCommitments are the commitments in the pool iff Committee.Kind
      * is scheduler.KindComputeExecutor.
      */
-    execute_commitments?: Map<Uint8Array, RootHashComputeBody>;
+    execute_commitments?: Map<Uint8Array, SignatureSigned>;
     /**
      * Discrepancy is a flag signalling that a discrepancy has been detected.
      */


### PR DESCRIPTION
further discrepancies with a newly expanded generated types set

- `OpenExecutorCommitment` is serialized as `ExecutorCommitment`, which we further lower to `Signed`. not `ComputeBody` as incorrectly specified before
- a couple of structs were out of order
