### PR TITLE
OAS20 spec

### DIFF
--- a/.github/actions/lint-rust/action.yml
+++ b/.github/actions/lint-rust/action.yml
@@ -1,0 +1,31 @@
+name: Lint Rust Worskapce
+description: Run lints and format checks on Rust workspace code
+inputs:
+  manfiest_path:
+    description: Path to the Cargo.toml manifest of the Rust sources to lint
+    default: ${{ github.workspace }}/Cargo.toml
+    required: false
+  token:
+    description: GitHub secret token used by cliipy-check action
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Clippy check
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ inputs.token }}
+        args: |
+          --all-features
+          --locked
+          --manifest-path ${{ inputs.manfiest_path }}
+          --
+          -D warnings
+          -D clippy::dbg_macro
+          -A clippy::upper-case-acronyms
+
+    - name: Formatting check
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all --manifest-path ${{ inputs.manfiest_path }} -- --check

--- a/.github/actions/test-rust/action.yml
+++ b/.github/actions/test-rust/action.yml
@@ -1,0 +1,27 @@
+name: Unit Test Rust Worskapce with Coverage
+description: Run unit tests on a Rust workspace with coverage and uploads results to codecov
+inputs:
+  manfiest_path:
+    description: Path to the Cargo.toml manifest of the Rust sources to build and test
+    default: ${{ github.workspace }}/Cargo.toml
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Unit tests with coverage
+      uses: actions-rs/tarpaulin@v0.1
+      with:
+        version: '0.18.0'
+        args: '--avoid-cfg-tarpaulin --manifest-path ${{ inputs.manfiest_path }} -- --test-threads 1'
+      env:
+        # Required as tarpaulin doesn't honor .cargo/config.
+        RUSTFLAGS: -C target-feature=+aes,+ssse3
+
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v2.1.0
+
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: code-coverage-report
+        path: cobertura.xml

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -85,6 +85,12 @@ jobs:
           cargo build --target wasm32-unknown-unknown --release
           mv target/wasm32-unknown-unknown/release/hello.wasm ../../e2e/contracts/hello.wasm
 
+      - name: Build oas20 contract
+        working-directory: contract-sdk/specs/oas20/contract
+        run: |
+          cargo build --target wasm32-unknown-unknown --release
+          mv target/wasm32-unknown-unknown/release/oas20.wasm ../../../../tests/e2e/contracts/oas20.wasm
+
       - name: Lint E2E tests
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -30,23 +30,22 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Clippy check
-        uses: actions-rs/clippy-check@v1
+      - name: Lint Rust code
+        uses: ./.github/actions/lint-rust
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: |
-            --all-features
-            --locked
-            --
-            -D warnings
-            -D clippy::dbg_macro
-            -A clippy::upper-case-acronyms
 
-      - name: Formatting check
-        uses: actions-rs/cargo@v1
+      - name: Lint hello test contract code
+        uses: ./.github/actions/lint-rust
         with:
-          command: fmt
-          args: -- --check
+          token: ${{ secrets.GITHUB_TOKEN }}
+          manfiest_path: tests/contracts/hello/Cargo.toml
+
+      - name: Lint OAS-20 contract code
+        uses: ./.github/actions/lint-rust
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          manfiest_path: contract-sdk/specs/oas20/contract/Cargo.toml
 
   lint-go-client-sdk:
     name: lint-go-client-sdk

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -35,23 +35,13 @@ jobs:
         working-directory: tests/contracts/hello
         run: cargo build --target wasm32-unknown-unknown --release
 
-      - name: Unit tests with coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.18.0'
-          args: '--avoid-cfg-tarpaulin -- --test-threads 1'
-        env:
-          # Required as tarpaulin doesn't honor .cargo/config.
-          RUSTFLAGS: -C target-feature=+aes,+ssse3
+      - name: Test Rust code
+        uses: ./.github/actions/test-rust
 
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v2.1.0
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.4
+      - name: Test OAS-20 contract
+        uses: ./.github/actions/test-rust
         with:
-          name: code-coverage-report
-          path: cobertura.xml
+          manfiest_path: contract-sdk/specs/oas20/contract/Cargo.toml
 
   test-rust-sgx:
     # NOTE: This name appears in GitHub's Checks API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oasis-contract-sdk-oas20-types"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "oasis-cbor",
+ "oasis-contract-sdk",
+ "oasis-contract-sdk-storage",
+ "oasis-contract-sdk-types",
+ "thiserror",
+]
+
+[[package]]
 name = "oasis-contract-sdk-storage"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "contract-sdk/types",
     "contract-sdk/storage",
     "contract-sdk-macros",
+    "contract-sdk/specs/oas20/types",
 
     # Test runtimes.
     "tests/runtimes/benchmarking",
@@ -22,6 +23,9 @@ members = [
 ]
 exclude = [
     # Test contracts.
-    "tests/contracts"
+    "tests/contracts",
+
+    # OAS contracts.
+    "contract-sdk/specs/oas20/contract",
 ]
 resolver = "2"

--- a/client-sdk/go/modules/contracts/contracts_test.go
+++ b/client-sdk/go/modules/contracts/contracts_test.go
@@ -1,0 +1,36 @@
+package contracts
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceIDToAddress(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		id              InstanceID
+		expectedAddress string
+	}{
+		{
+			id:              InstanceID(0),
+			expectedAddress: "oasis1qq08mjlkztsgpgrar082rzzxwjaplxmgjs5ftugn",
+		},
+		{
+			id:              InstanceID(1),
+			expectedAddress: "oasis1qpg6jv8mxwlv4z578xyjxl7d793jamltdg9czzkx",
+		},
+		{
+			id:              InstanceID(14324),
+			expectedAddress: "oasis1qzasj0kq0hlq6vzw4ajhrwgp3tqx6rnwvg2ylu2v",
+		},
+		{
+			id:              InstanceID(math.MaxUint64),
+			expectedAddress: "oasis1qqr0nxsu5aqpu4k85z4h5z08vrfmawnnqycl6gup",
+		},
+	} {
+		require.EqualValues(tc.expectedAddress, tc.id.Address().String())
+	}
+}

--- a/client-sdk/go/modules/contracts/oas20/oas20.go
+++ b/client-sdk/go/modules/contracts/oas20/oas20.go
@@ -1,0 +1,95 @@
+package oas20
+
+import (
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/contracts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+// XXX: create a more highlevel helper wrapping Contracts client.
+
+// InitialBalance is the OAS20 contract initial balance information.
+type InitialBalance struct {
+	Address types.Address     `json:"address"`
+	Amount  quantity.Quantity `json:"amount"`
+}
+
+// MintingInformation is the OAS20 contract minting information.
+type MintingInformation struct {
+	Minter types.Address      `json:"minter"`
+	Cap    *quantity.Quantity `json:"cap,omitempty"`
+}
+
+// Instantiate is the OAS20 contract's initial state.
+type Instantiate struct {
+	// Name is the name of the token.
+	Name string `json:"name"`
+	// Symbol is the token symbol.
+	Symbol string `json:"symbol"`
+	// Decimals is the number of token decimals.
+	Decimals uint8 `json:"decimals"`
+	// InitialBalances are the initial balances of the token.
+	InitialBalances []InitialBalance `json:"initial_balances,omitempty"`
+	// Minting is the information about minting in case the token supports minting.
+	Mintting *MintingInformation `json:"minting,omitempty"`
+}
+
+// Transfer is the OAS20 contract's transfer request.
+type Transfer struct {
+	To     types.Address     `json:"to"`
+	Amount quantity.Quantity `json:"amount"`
+}
+
+// Send is the OAS20 contract's send request.
+type Send struct {
+	To     contracts.InstanceID `json:"to"`
+	Amount quantity.Quantity    `json:"amount"`
+	Data   interface{}          `json:"data"`
+}
+
+// Balance is the OAS20 contract's balance query request.
+type Balance struct {
+	Address types.Address `json:"address"`
+}
+
+// TokenInformation is the OAS20 contract's token information request.
+type TokenInformation struct{}
+
+// Request is an OAS20 contract request.
+type Request struct {
+	Instantiate      *Instantiate      `json:"instantiate,omitempty"`
+	Transfer         *Transfer         `json:"transfer,omitempty"`
+	Send             *Send             `json:"send,omitempty"`
+	TokenInformation *TokenInformation `json:"token_information,omitempty"`
+	Balance          *Balance          `json:"balance,omitempty"`
+}
+
+// TokenInformationResponse is the token information response.
+type TokenInformationResponse struct {
+	// Name is the name of the token.
+	Name string `json:"name"`
+	// Symbol is the token symbol.
+	Symbol string `json:"symbol"`
+	// Decimals is the number of token decimals.
+	Decimals uint8 `json:"decimals"`
+	// TotalSupply is the total supply of the token.
+	TotalSupply quantity.Quantity `json:"total_supply"`
+	// Minting is the information about minting in case the token supports minting.
+	Mintting *MintingInformation `json:"minting,omitempty"`
+}
+
+// Empty is the empty response.
+type Empty struct{}
+
+// Response is an OAS20 contract response.
+type Response struct {
+	TokenInformation *TokenInformationResponse `json:"token_information,omitempty"`
+	Balance          *BalanceResponse          `json:"balance,omitempty"`
+	Empty            *Empty                    `json:"empty,omitempty"`
+}
+
+// BalanceResponse is the OAS20 balance response.
+type BalanceResponse struct {
+	Balance quantity.Quantity `json:"balance"`
+}

--- a/client-sdk/go/modules/contracts/oas20/oas20_test.go
+++ b/client-sdk/go/modules/contracts/oas20/oas20_test.go
@@ -1,0 +1,60 @@
+package oas20
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	sdkTesting "github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
+)
+
+func TestInstantiateSerialization(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		in             Instantiate
+		expectedBase64 string
+	}{
+		{
+			in:             Instantiate{},
+			expectedBase64: "o2RuYW1lYGZzeW1ib2xgaGRlY2ltYWxzAA==",
+		},
+		{
+			in: Instantiate{
+				Name:     "Testing serialization",
+				Symbol:   "TEST_SER",
+				Decimals: 1,
+			},
+			expectedBase64: "o2RuYW1ldVRlc3Rpbmcgc2VyaWFsaXphdGlvbmZzeW1ib2xoVEVTVF9TRVJoZGVjaW1hbHMB",
+		},
+		{
+			in: Instantiate{
+				Name:     "TEST token name",
+				Symbol:   "TEST",
+				Decimals: 6,
+				InitialBalances: []InitialBalance{
+					{
+						Address: sdkTesting.Alice.Address,
+						Amount:  *quantity.NewFromUint64(10_000),
+					},
+					{
+						Address: sdkTesting.Charlie.Address,
+						Amount:  *quantity.NewFromUint64(10),
+					},
+				},
+			},
+			expectedBase64: "pGRuYW1lb1RFU1QgdG9rZW4gbmFtZWZzeW1ib2xkVEVTVGhkZWNpbWFscwZwaW5pdGlhbF9iYWxhbmNlc4KiZmFtb3VudEInEGdhZGRyZXNzVQDzj3nsHmz+l7T+BseJi1Ko+ttHg6JmYW1vdW50QQpnYWRkcmVzc1UA6WTLZ/m1vC5bdgxVKoClozN3AHA=",
+		},
+	} {
+		enc := cbor.Marshal(tc.in)
+		require.Equal(tc.expectedBase64, base64.StdEncoding.EncodeToString(enc), "serialization should match")
+
+		var dec Instantiate
+		err := cbor.Unmarshal(enc, &dec)
+		require.NoError(err, "Unmarshal")
+		require.EqualValues(tc.in, dec, "Instantiate serialization should round-trip")
+	}
+}

--- a/client-sdk/go/modules/contracts/types.go
+++ b/client-sdk/go/modules/contracts/types.go
@@ -1,6 +1,8 @@
 package contracts
 
 import (
+	"encoding/binary"
+
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -11,6 +13,13 @@ type CodeID uint64
 
 // InstanceID is the unique deployed code instance identifier.
 type InstanceID uint64
+
+// Address returns address for the InstanceID.
+func (i *InstanceID) Address() types.Address {
+	id := make([]byte, 8)
+	binary.BigEndian.PutUint64(id, uint64(*i))
+	return types.NewAddressForModule("contracts", id)
+}
 
 // Policy is a generic policy that specifies who is allowed to perform an action.
 type Policy struct {

--- a/client-sdk/go/types/address.go
+++ b/client-sdk/go/types/address.go
@@ -24,6 +24,8 @@ var (
 	AddressV0Sr25519Context = address.NewContext("oasis-runtime-sdk/address: sr25519", 0)
 	// AddressV0MultisigContext is the unique context for v0 multisig addresses.
 	AddressV0MultisigContext = address.NewContext("oasis-runtime-sdk/address: multisig", 0)
+	// AddressV0ModuleContext is the unique context for v0 module addresses.
+	AddressV0ModuleContext = address.NewContext("oasis-runtime-sdk/address: module", 0)
 	// AddressBech32HRP is the unique human readable part of Bech32 encoded
 	// staking account addresses.
 	AddressBech32HRP = staking.AddressBech32HRP
@@ -91,6 +93,21 @@ func NewAddress(pk signature.PublicKey) (a Address) {
 		panic("address: unsupported public key type")
 	}
 	return (Address)(address.NewAddress(ctx, pkData))
+}
+
+// NewAddressForModule creates a new address for a specific module and raw kind.
+func NewAddressForModule(module string, kind []byte) Address {
+	moduleBytes := []byte(module)
+	sepBytes := []byte(".")
+	data := make([]byte, 0, len(moduleBytes)+len(kind)+1)
+	data = append(data,
+		moduleBytes...)
+	data = append(data,
+		sepBytes...)
+	data = append(data,
+		kind...,
+	)
+	return (Address)(address.NewAddress(AddressV0ModuleContext, data))
 }
 
 // NewAddressFromBech32 creates a new address from the given bech-32 encoded string.

--- a/client-sdk/go/types/address_test.go
+++ b/client-sdk/go/types/address_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,4 +55,14 @@ func TestAddressMultisig(t *testing.T) {
 	})
 
 	require.EqualValues("oasis1qpcprk8jxpsjxw9fadxvzrv9ln7td69yus8rmtux", addr.String())
+}
+
+func TestAddressModule(t *testing.T) {
+	require := require.New(t)
+
+	id := make([]byte, 8)
+
+	binary.BigEndian.PutUint64(id, uint64(42))
+	addr := NewAddressForModule("contracts", id)
+	require.EqualValues("oasis1qq398yyk4wt2zxhtt8c66raynelgt6ngh5yq87xg", addr.String())
 }

--- a/contract-sdk/specs/oas20/README.md
+++ b/contract-sdk/specs/oas20/README.md
@@ -1,0 +1,330 @@
+# OAS-20 spec: Fungible Tokens
+
+Specification for standardization of fungible token contracts within the Oasis contracts-sdk framework. Roughly based on [ERC20] and [CW20] specs.
+
+[ERC20]: https://ethereum.org/en/developers/docs/standards/tokens/erc-20/
+[CW20]: https://github.com/CosmWasm/cw-plus/blob/main/packages/cw20/README.md
+
+## Requests
+
+### Instantiate
+
+```rust
+#[cbor(rename = "instantiate")]
+Instantiate(TokenInstantiation),
+
+/// OAS20 token instantiation information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct TokenInstantiation {
+    /// Name of the token.
+    pub name: String,
+    /// Token symbol.
+    pub symbol: String,
+    /// Number of decimals.
+    pub decimals: u8,
+    /// Initial balances of the token.
+    #[cbor(optional, default, skip_serializing_if = "Vec::is_empty")]
+    pub initial_balances: Vec<InitialBalance>,
+    /// Information about minting in case the token supports minting.
+    #[cbor(optional)]
+    pub minting: Option<MintingInformation>,
+}
+```
+
+Instantiates the OAS20 token contract.
+
+### Transfer
+
+```rust
+#[cbor(rename = "transfer")]
+Transfer { to: Address, amount: u128 },
+```
+
+Moves `amount` of tokens from the caller to the `to` account.
+
+### Send
+
+```rust
+#[cbor(rename = "send")]
+Send {
+    to: InstanceId,
+    amount: u128,
+    data: cbor::Value,
+},
+```
+Moves `amount` of tokens from the caller to the `to` contract and calls `ReceiveOas20` on the receiver contract. `to` is an instance ID of the receiving contract (not its address, to prevent sending to a non-contract address). The receiving contract should handle the `Receive { sender: Address, amount: u128, msg: cbor::Value }` call.
+
+### Burn
+
+```rust
+#[cbor(rename = "burn")]
+Burn { amount: u128 },
+```
+
+Removes `amount` of tokens from the caller and reduces the `total_supply` by `amount`.
+
+### Allow
+
+```rust
+#[cbor(rename = "allow")]
+Allow {
+    beneficiary: Address,
+    negative: bool,
+    amount_change: u128,
+},
+```
+
+Allow enables an account holder to set or decrease an allowance for a `beneficiary`.
+
+### Withdraw
+
+```rust
+#[cbor(rename = "withdraw")]
+Withdraw { from: Address, amount: u128 },
+```
+
+Withdraw enables a beneficiary to withdraw from the given account.
+
+### Mint (optional)
+
+```rust
+#[cbor(rename = "mint")]
+Mint { to: Address, amount: u128 },
+```
+
+Tokens supporting to be minted (potentially with a supply cap).
+
+## Queries
+
+### Token information
+
+```rust
+#[cbor(rename = "token_information")]
+TokenInformation,
+```
+
+Returns the general token information:
+
+```rust
+#[cbor(rename = "token_information")]
+TokenInformation { token_information: TokenInformation },
+
+/// OAS20 token information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct TokenInformation {
+    /// Name of the token.
+    pub name: String,
+    /// Token symbol.
+    pub symbol: String,
+    /// Number of decimals.
+    pub decimals: u8,
+    /// Total supply of the token.
+    pub total_supply: u128,
+    /// Information about minting in case the token supports minting.
+    #[cbor(optional)]
+    pub minting: Option<MintingInformation>,
+}
+
+/// Token minting information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct MintingInformation {
+    /// Caller address which is allowed to mint new tokens.
+    pub minter: Address,
+    /// Cap on the total supply of the token.
+    #[cbor(optional)]
+    pub cap: Option<u128>,
+}
+```
+
+### Balance
+
+```rust
+#[cbor(rename = "balance")]
+Balance { address: Address },
+```
+
+Returns the balance of the account:
+
+```rust
+#[cbor(rename = "balance")]
+Balance { balance: u128 },
+```
+
+### Allowance
+
+```rust
+#[cbor(rename = "allowance")]
+Allowance { allower: Address, beneficiary: Address },
+```
+
+Returns the allowance set by `allower` to the `beneficiary`:
+
+```rust
+#[cbor(rename = "allowance")]
+Allowance { allowance: u128 },
+```
+
+## Events
+
+### OAS-20 Instantiated event
+
+```rust
+#[sdk_event(code = 1)]
+Oas20Instantiated { token_information: TokenInformation },
+```
+
+Emitted on a successful OAS-20 token contract instantiation.
+
+### OAS-20 Transferred event
+
+```rust
+#[sdk_event(code = 2)]
+Oas20Transferred {
+    from: Address,
+    to: Address,
+    amount: u128,
+},
+```
+
+Emitted on a successful OAS-20 token transfer.
+
+### OAS-20 Sent event
+
+```rust
+#[sdk_event(code = 3)]
+Oas20Sent {
+    from: Address,
+    to: InstanceId,
+    amount: u128,
+},
+```
+
+Emitted on a successful OAS-20 token send.
+
+### OAS-20 Burned event
+
+```rust
+#[sdk_event(code = 4)]
+Oas20Burned { from: Address, amount: u128 },
+```
+
+Emitted on a successful OAS-20 token burn.
+
+### OAS-20 Allowance changed event
+
+```rust
+#[sdk_event(code = 5)]
+Oas20AllowanceChanged {
+    owner: Address,
+    beneficiary: Address,
+    allowance: u128,
+    negative: bool,
+    amount_change: u128,
+},
+```
+
+Emitted on a successful OAS-20 allow.
+
+### OAS-20 Withdraw event
+
+```rust
+#[sdk_event(code = 6)]
+Oas20Withdraw {
+    from: Address,
+    to: Address,
+    amount: u128,
+},
+```
+
+Emitted on a successful OAS-20 withdraw.
+
+### OAS-20 Minted event
+
+```rust
+#[sdk_event(code = 7)]
+Oas20Minted { to: Address, amount: u128 },
+```
+
+Emitted on a successful OAS-20 token mint.
+
+## Errors
+
+### Bad request
+
+```rust
+#[error("bad request")]
+#[sdk_error(code = 1)]
+BadRequest,
+```
+
+Error returned for requests not defined in this specification.
+
+### Balance overflow
+
+```rust
+#[error("total supply overflow")]
+#[sdk_error(code = 2)]
+TotalSupplyOverflow,
+```
+
+Error returned in case total supply overflows maximum `u128` value during instantiation or minting.
+
+### Zero amount
+
+```rust
+#[error("zero amount")]
+#[sdk_error(code = 3)]
+ZeroAmount,
+```
+
+Error returned in case zero amount is used in `transfer`, `send`, `burn` or `mint` actions.
+
+### Insufficient funds
+
+```rust
+#[error("insufficient funds")]
+#[sdk_error(code = 4)]
+InsufficientFunds,
+```
+
+Error returned in case there are insufficient funds in the account to perform the action.
+
+### Action forbidden
+
+```rust
+#[error("minting forbidden")]
+#[sdk_error(code = 5)]
+MintingForbidden,
+```
+
+Error returned in case a non authorized minter is trying to mint tokens.
+
+### Mint over cap
+
+```rust
+#[error("mint over cap")]
+#[sdk_error(code = 6)]
+MintOverCap,
+```
+
+Error returned in case minting tokens would result in exceeding the configured minting cap.
+
+### Same allower and beneficiary
+
+```rust
+#[error("allower and beneficiary same")]
+#[sdk_error(code = 7)]
+SameAllowerAndBeneficiary,
+```
+
+Error returned in case allower and beneficiary are the same in allowance transactions.
+
+### Insufficient allowance
+
+```rust
+#[error("insufficient allowance")]
+#[sdk_error(code = 8)]
+InsufficientAllowance,
+```
+
+Error returned in case the withdrawer has insufficient allowance to withdraw.

--- a/contract-sdk/specs/oas20/contract/Cargo.lock
+++ b/contract-sdk/specs/oas20/contract/Cargo.lock
@@ -56,17 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "hello"
-version = "0.0.0"
-dependencies = [
- "oasis-cbor",
- "oasis-contract-sdk",
- "oasis-contract-sdk-oas20-types",
- "oasis-contract-sdk-storage",
- "thiserror",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +130,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "oasis-contract-sdk-oas20"
+version = "0.1.0"
+dependencies = [
+ "oasis-cbor",
+ "oasis-contract-sdk",
+ "oasis-contract-sdk-oas20-types",
+ "oasis-contract-sdk-storage",
+ "oasis-contract-sdk-types",
+ "thiserror",
 ]
 
 [[package]]

--- a/contract-sdk/specs/oas20/contract/Cargo.toml
+++ b/contract-sdk/specs/oas20/contract/Cargo.toml
@@ -1,0 +1,37 @@
+cargo-features = ["strip"]
+
+[package]
+name = "oasis-contract-sdk-oas20"
+version = "0.1.0"
+description = "OAS-20 contract"
+authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[workspace]
+
+[lib]
+name = "oas20"
+crate-type = ["cdylib"]
+
+[dependencies]
+cbor = { version = "0.2.0", package = "oasis-cbor" }
+oasis-contract-sdk = { path = "../../.." }
+oasis-contract-sdk-storage = { path = "../../../storage" }
+oasis-contract-sdk-types = { path = "../../../types" }
+oasis-contract-sdk-oas20-types = { path = "../types" }
+
+# Third party.
+thiserror = "1.0.28"
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = "abort"
+incremental = false
+overflow-checks = true
+strip = true

--- a/contract-sdk/specs/oas20/contract/src/lib.rs
+++ b/contract-sdk/specs/oas20/contract/src/lib.rs
@@ -1,0 +1,716 @@
+//! An OAS20 contract.
+#![feature(wasm_abi)]
+
+extern crate alloc;
+
+use oasis_contract_sdk::{
+    self as sdk,
+    env::Env,
+    types::message::{Message, NotifyReply},
+};
+use oasis_contract_sdk_oas20_types as types;
+use oasis_contract_sdk_oas20_types::{Error, Event, Request, Response};
+use oasis_contract_sdk_storage::{cell::Cell, map::Map};
+use oasis_contract_sdk_types::address::Address;
+
+/// The contract type.
+pub struct Oas20Token;
+
+/// Storage cell for the token information.
+const TOKEN_INFO: Cell<types::TokenInformation> = Cell::new(b"token_info");
+const BALANCES: Map<Address, u128> = Map::new(b"balances");
+const ALLOWANCES: Map<(Address, Address), u128> = Map::new(b"allowances");
+
+impl Oas20Token {
+    /// Transfer the `amount` of funds from `from` to `to` address.
+    fn transfer<C: sdk::Context>(
+        ctx: &mut C,
+        from: Address,
+        to: Address,
+        amount: u128,
+    ) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        let mut from_balance = BALANCES.get(ctx.public_store(), from).unwrap_or_default();
+        let mut to_balance = BALANCES.get(ctx.public_store(), to).unwrap_or_default();
+
+        from_balance = from_balance
+            .checked_sub(amount)
+            .ok_or(Error::InsufficientFunds)?;
+        to_balance += amount;
+
+        BALANCES.insert(ctx.public_store(), from, from_balance);
+        BALANCES.insert(ctx.public_store(), to, to_balance);
+
+        Ok(())
+    }
+
+    /// Burns the `amount` of funds from `from`.
+    fn burn<C: sdk::Context>(ctx: &mut C, from: Address, amount: u128) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        // Remove from account balance.
+        let mut from_balance = BALANCES.get(ctx.public_store(), from).unwrap_or_default();
+        from_balance = from_balance
+            .checked_sub(amount)
+            .ok_or(Error::InsufficientFunds)?;
+
+        // Decrease the supply.
+        // Token info should always be present.
+        let mut token_info = TOKEN_INFO.get(ctx.public_store()).unwrap();
+        // Shouldn't ever overflow.
+        token_info.total_supply = token_info.total_supply.checked_sub(amount).unwrap();
+
+        BALANCES.insert(ctx.public_store(), from, from_balance);
+        TOKEN_INFO.set(ctx.public_store(), token_info);
+
+        Ok(())
+    }
+
+    /// Update the `beneficiary` allownace by the `amount`.
+    fn allow<C: sdk::Context>(
+        ctx: &mut C,
+        allower: Address,
+        beneficiary: Address,
+        negative: bool,
+        amount: u128,
+    ) -> Result<(u128, u128), Error> {
+        if amount == 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        if allower == beneficiary {
+            return Err(Error::SameAllowerAndBeneficiary);
+        }
+
+        let allowance = ALLOWANCES
+            .get(ctx.public_store(), (allower, beneficiary))
+            .unwrap_or_default();
+
+        let (new_allowance, change) = match negative {
+            true => {
+                let new = allowance.saturating_sub(amount);
+                (new, allowance - new)
+            }
+            false => {
+                let new = allowance.saturating_add(amount);
+                (new, new - allowance)
+            }
+        };
+
+        ALLOWANCES.insert(ctx.public_store(), (allower, beneficiary), new_allowance);
+
+        Ok((new_allowance, change))
+    }
+
+    /// Withdraw the `amunt` of funds from `from` to `to`.
+    fn withdraw<C: sdk::Context>(
+        ctx: &mut C,
+        from: Address,
+        to: Address,
+        amount: u128,
+    ) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        if from == to {
+            return Err(Error::SameAllowerAndBeneficiary);
+        }
+
+        let mut allowance = ALLOWANCES
+            .get(ctx.public_store(), (from, to))
+            .unwrap_or_default();
+        allowance = allowance
+            .checked_sub(amount)
+            .ok_or(Error::InsufficientAllowance)?;
+
+        Self::transfer(ctx, from, to, amount)?;
+
+        ALLOWANCES.insert(ctx.public_store(), (from, to), allowance);
+
+        Ok(())
+    }
+
+    /// Mints the `amount` of tokens to `to`.
+    fn mint<C: sdk::Context>(ctx: &mut C, to: Address, amount: u128) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        // Token info should always be present.
+        let mut token_info = TOKEN_INFO.get(ctx.public_store()).unwrap();
+        // Ensure token supports minting and new supply cap is bellow mint cap.
+        match token_info.minting.as_ref() {
+            Some(info) => {
+                let cap = info.cap.unwrap_or(u128::MAX);
+                match token_info.total_supply.checked_add(amount) {
+                    Some(new_cap) => {
+                        if new_cap > cap {
+                            return Err(Error::MintOverCap);
+                        }
+                    }
+                    None => return Err(Error::TotalSupplyOverflow),
+                }
+                if &info.minter != ctx.caller_address() {
+                    return Err(Error::MintingForbidden);
+                }
+            }
+            None => return Err(Error::MintingForbidden),
+        }
+
+        // Add to account balance.
+        let mut to_balance = BALANCES.get(ctx.public_store(), to).unwrap_or_default();
+        // Cannot overflow due to the total supply overflow check above.
+        to_balance = to_balance.checked_add(amount).unwrap();
+
+        // Increase the supply.
+        // Overflow already checked above.
+        token_info.total_supply = token_info.total_supply.checked_add(amount).unwrap();
+
+        BALANCES.insert(ctx.public_store(), to, to_balance);
+        TOKEN_INFO.set(ctx.public_store(), token_info);
+
+        Ok(())
+    }
+}
+
+// Implementation of the sdk::Contract trait is required in order for the type to be a contract.
+impl sdk::Contract for Oas20Token {
+    type Request = Request;
+    type Response = Response;
+    type Error = Error;
+
+    fn instantiate<C: sdk::Context>(ctx: &mut C, request: Request) -> Result<(), Error> {
+        // This method is called during the contracts.Instantiate call when the contract is first
+        // instantiated. It can be used to initialize the contract state.
+        match request {
+            // We require the caller to always pass the Instantiate request.
+            Request::Instantiate(token_instantiation) => {
+                // Setup initial balances and compute the total supply.
+                let mut total_supply: u128 = 0;
+                for types::InitialBalance { address, amount } in
+                    token_instantiation.initial_balances
+                {
+                    total_supply = total_supply
+                        .checked_add(amount)
+                        .ok_or(Error::TotalSupplyOverflow)?;
+                    BALANCES.insert(ctx.public_store(), address, amount);
+                }
+
+                let token_information = types::TokenInformation {
+                    name: token_instantiation.name,
+                    symbol: token_instantiation.symbol,
+                    decimals: token_instantiation.decimals,
+                    minting: token_instantiation.minting,
+                    total_supply,
+                };
+                TOKEN_INFO.set(ctx.public_store(), token_information.clone());
+
+                ctx.emit_event(Event::Oas20Instantiated { token_information });
+
+                Ok(())
+            }
+            _ => Err(Error::BadRequest),
+        }
+    }
+
+    fn call<C: sdk::Context>(ctx: &mut C, request: Request) -> Result<Response, Error> {
+        // This method is called for each contracts.Call call. It is supposed to handle the request
+        // and return a response.
+        match request {
+            Request::Transfer { to, amount } => {
+                // Transfers the `amount` of funds from caller to `to` address.
+                let from = ctx.caller_address().to_owned();
+                Self::transfer(ctx, from, to, amount)?;
+
+                ctx.emit_event(Event::Oas20Transferred { from, to, amount });
+
+                Ok(Response::Empty)
+            }
+            Request::Send { to, amount, data } => {
+                // Transfers the `amount` of funds from caller to `to` contract instande identifier
+                // and calls `ReceiveOas20` on the receiving contract.
+
+                // Transfers the `amount` of funds from caller to `to` address.
+                let from = ctx.caller_address().to_owned();
+                let to_address = ctx.env().address_for_instance(to);
+                Self::transfer(ctx, from, to_address, amount)?;
+
+                // There should be high-level helpers for calling methods of other contracts that follow a similar
+                // "standard" API - maybe define an API and helper methods in an OAS-0 document.
+
+                // Emit a message through which we instruct the runtime to make a call on the
+                // contract's behalf
+                use cbor::cbor_map;
+                ctx.emit_message(Message::Call {
+                    id: 0,
+                    reply: NotifyReply::Never,
+                    method: "contracts.Call".to_string(),
+                    body: cbor::cbor_map! {
+                        "id" => cbor::cbor_int!(to.as_u64() as i64),
+                        "data" => cbor::cbor_bytes!(cbor::to_vec(
+                            cbor::to_value(types::ReceiverRequest::Receive{sender: from, amount, data}),
+                        )),
+                        "tokens" => cbor::cbor_array![],
+                    },
+                    max_gas: None,
+                });
+
+                ctx.emit_event(Event::Oas20Sent { from, to, amount });
+
+                Ok(Response::Empty)
+            }
+            Request::Burn { amount } => {
+                let from = ctx.caller_address().to_owned();
+                Self::burn(ctx, from, amount)?;
+
+                ctx.emit_event(Event::Oas20Burned { from, amount });
+
+                Ok(Response::Empty)
+            }
+            Request::Mint { to, amount } => {
+                Self::mint(ctx, to, amount)?;
+
+                ctx.emit_event(Event::Oas20Minted { to, amount });
+
+                Ok(Response::Empty)
+            }
+            Request::Allow {
+                beneficiary,
+                negative,
+                amount_change,
+            } => {
+                let owner = ctx.caller_address().to_owned();
+                let (new_allowance, amount_change) =
+                    Self::allow(ctx, owner, beneficiary, negative, amount_change)?;
+
+                ctx.emit_event(Event::Oas20AllowanceChanged {
+                    owner,
+                    beneficiary,
+                    allowance: new_allowance,
+                    negative,
+                    amount_change,
+                });
+
+                Ok(Response::Empty)
+            }
+            Request::Withdraw { from, amount } => {
+                let to = ctx.caller_address().to_owned();
+                Self::withdraw(ctx, from, to, amount)?;
+
+                ctx.emit_event(Event::Oas20Withdraw { from, to, amount });
+
+                Ok(Response::Empty)
+            }
+            _ => Err(Error::BadRequest),
+        }
+    }
+
+    fn query<C: sdk::Context>(ctx: &mut C, request: Request) -> Result<Response, Error> {
+        // This method is called for each contracts.Query query. It is supposed to handle the
+        // request and return a response.
+        match request {
+            Request::TokenInformation => {
+                // Token info should always be present.
+                let token_info = TOKEN_INFO.get(ctx.public_store()).unwrap();
+
+                Ok(Response::TokenInformation {
+                    token_information: token_info,
+                })
+            }
+            Request::Balance { address } => Ok(Response::Balance {
+                balance: BALANCES
+                    .get(ctx.public_store(), address)
+                    .unwrap_or_default(),
+            }),
+            Request::Allowance {
+                allower,
+                beneficiary,
+            } => Ok(Response::Allowance {
+                allowance: ALLOWANCES
+                    .get(ctx.public_store(), (allower, beneficiary))
+                    .unwrap_or_default(),
+            }),
+            _ => Err(Error::BadRequest),
+        }
+    }
+}
+
+// Create the required WASM exports required for the contract to be runnable.
+sdk::create_contract!(Oas20Token);
+
+// We define some simple contract tests below.
+#[cfg(test)]
+mod test {
+    use oasis_contract_sdk::{testing::MockContext, types::ExecutionContext, Contract};
+    use oasis_contract_sdk_types::testing::addresses;
+
+    use super::*;
+
+    #[test]
+    fn test_basics() {
+        // Create a mock execution context with default values.
+        let mut ctx: MockContext = ExecutionContext::default().into();
+
+        let alice = addresses::alice::address();
+        let bob = addresses::bob::address();
+        let charlie = addresses::charlie::address();
+
+        let token_instantiation = types::TokenInstantiation {
+            name: "TEST".to_string(),
+            symbol: "TST".to_string(),
+            decimals: 8,
+            initial_balances: Vec::new(),
+            minting: Some(types::MintingInformation {
+                cap: Some(100_000),
+                minter: bob.into(),
+            }),
+        };
+        // Instantiate the contract.
+        Oas20Token::instantiate(&mut ctx, Request::Instantiate(token_instantiation.clone()))
+            .expect("instantiation should work");
+
+        let ti = token_instantiation.clone();
+        let rsp = Oas20Token::query(&mut ctx, Request::TokenInformation)
+            .expect("token information query should work");
+        assert_eq!(
+            rsp,
+            Response::TokenInformation {
+                token_information: types::TokenInformation {
+                    name: ti.name,
+                    symbol: ti.symbol,
+                    decimals: ti.decimals,
+                    minting: ti.minting,
+                    total_supply: 0,
+                }
+            },
+            "token information query response should be correct"
+        );
+
+        let rsp = Oas20Token::query(
+            &mut ctx,
+            Request::Balance {
+                address: alice.into(),
+            },
+        )
+        .expect("token balance query should work");
+        assert_eq!(
+            rsp,
+            Response::Balance { balance: 0 },
+            "token balance query response should be correct"
+        );
+
+        // Try to transfer some tokens.
+        ctx.ec.caller_address = bob.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Transfer {
+                amount: 5,
+                to: alice.into(),
+            },
+        )
+        .expect_err("transfer empty balances should fail");
+
+        // Mint tokens by non-minter should fail.
+        ctx.ec.caller_address = alice.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Mint {
+                amount: 10,
+                to: bob.into(),
+            },
+        )
+        .expect_err("minting by non-minter should fail");
+
+        // Minting zero tokens should fail.
+        ctx.ec.caller_address = bob.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Mint {
+                amount: 0,
+                to: bob.into(),
+            },
+        )
+        .expect_err("minting should zero tokens should fail");
+
+        // Minting more than cap should fail.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Mint {
+                amount: 100_000_000,
+                to: bob.into(),
+            },
+        )
+        .expect_err("minting should zero tokens should fail");
+
+        // Mint some tokens as minter.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Mint {
+                amount: 10,
+                to: bob.into(),
+            },
+        )
+        .expect("minting should work");
+
+        // Minting should overflow.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Mint {
+                amount: u128::MAX,
+                to: bob.into(),
+            },
+        )
+        .expect_err("minting should overflow");
+
+        // Transfering zero amount should fail.
+        ctx.ec.caller_address = bob.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Transfer {
+                amount: 0,
+                to: charlie.into(),
+            },
+        )
+        .expect_err("transfer of zero tokens should fail");
+
+        // Transfering more than available tokens should fail.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Transfer {
+                amount: 100_000,
+                to: charlie.into(),
+            },
+        )
+        .expect_err("transfer of more tokens than available should fail");
+
+        // Transfer some tokens.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Transfer {
+                amount: 4,
+                to: charlie.into(),
+            },
+        )
+        .expect("transfer of tokens should work");
+
+        // Burning zero tokens should fail.
+        Oas20Token::call(&mut ctx, Request::Burn { amount: 0 })
+            .expect_err("burning of zero tokens should fail");
+
+        // Burning more than available tokens should fail.
+        Oas20Token::call(&mut ctx, Request::Burn { amount: 100_000 })
+            .expect_err("burning more than available tokens should fail");
+
+        // Burn some tokens.
+        Oas20Token::call(&mut ctx, Request::Burn { amount: 1 })
+            .expect("burning of tokens should work");
+
+        // Sending some tokens should work.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Send {
+                amount: 1,
+                to: 0.into(),
+                data: cbor::to_value("test"),
+            },
+        )
+        .expect("transfer of tokens should work");
+
+        // Query balances.
+        let rsp = Oas20Token::query(
+            &mut ctx,
+            Request::Balance {
+                address: alice.into(),
+            },
+        )
+        .expect("token balance query should work");
+        assert_eq!(
+            rsp,
+            Response::Balance { balance: 0 },
+            "token balance query response should be correct"
+        );
+        let rsp = Oas20Token::query(
+            &mut ctx,
+            Request::Balance {
+                address: bob.into(),
+            },
+        )
+        .expect("token balance query should work");
+        assert_eq!(
+            rsp,
+            Response::Balance { balance: 4 },
+            "token balance query response should be correct"
+        );
+        let rsp = Oas20Token::query(
+            &mut ctx,
+            Request::Balance {
+                address: charlie.into(),
+            },
+        )
+        .expect("token balance query should work");
+        assert_eq!(
+            rsp,
+            Response::Balance { balance: 4 },
+            "token balance query response should be correct"
+        );
+
+        // Total supply should be updated.
+        let rsp = Oas20Token::query(&mut ctx, Request::TokenInformation)
+            .expect("token information query should work");
+        assert_eq!(
+            rsp,
+            Response::TokenInformation {
+                token_information: types::TokenInformation {
+                    name: token_instantiation.name,
+                    symbol: token_instantiation.symbol,
+                    decimals: token_instantiation.decimals,
+                    minting: token_instantiation.minting,
+                    total_supply: 9,
+                }
+            },
+            "token information query response should be correct"
+        );
+    }
+
+    #[test]
+    fn test_allowances() {
+        // Create a mock execution context with default values.
+        let mut ctx: MockContext = ExecutionContext::default().into();
+
+        let alice = addresses::alice::address();
+        let bob = addresses::bob::address();
+        let charlie = addresses::charlie::address();
+
+        let token_instantiation = types::TokenInstantiation {
+            name: "TEST".to_string(),
+            symbol: "TST".to_string(),
+            decimals: 8,
+            initial_balances: vec![
+                types::InitialBalance {
+                    address: alice,
+                    amount: 100,
+                },
+                types::InitialBalance {
+                    address: bob,
+                    amount: 10,
+                },
+                types::InitialBalance {
+                    address: charlie,
+                    amount: 1,
+                },
+            ],
+            minting: None,
+        };
+
+        // Instantiate the contract.
+        Oas20Token::instantiate(&mut ctx, Request::Instantiate(token_instantiation.clone()))
+            .expect("instantiation should work");
+
+        // Minting should not be allowed.
+        ctx.ec.caller_address = alice.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Mint {
+                amount: 10,
+                to: bob.into(),
+            },
+        )
+        .expect_err("minting should not work");
+
+        // Allowing zero amount should fail.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Allow {
+                beneficiary: bob,
+                negative: false,
+                amount_change: 0,
+            },
+        )
+        .expect_err("allowing of zero amount should fail");
+
+        // Same allower and beneficiary should fail.
+        ctx.ec.caller_address = alice.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Allow {
+                beneficiary: alice,
+                negative: false,
+                amount_change: 10,
+            },
+        )
+        .expect_err("allowing to self should fail");
+
+        // Allowing should work.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Allow {
+                beneficiary: bob,
+                negative: false,
+                amount_change: 10,
+            },
+        )
+        .expect("allowing should work");
+
+        // Reducing allowance should work.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Allow {
+                beneficiary: bob,
+                negative: true,
+                amount_change: 1,
+            },
+        )
+        .expect("allowing should work");
+
+        // Withdrawing zero amount should fail.
+        ctx.ec.caller_address = bob.into();
+        Oas20Token::call(
+            &mut ctx,
+            Request::Withdraw {
+                from: alice,
+                amount: 0,
+            },
+        )
+        .expect_err("withdrawing zero amount should fail");
+
+        Oas20Token::call(
+            &mut ctx,
+            Request::Withdraw {
+                from: bob,
+                amount: 0,
+            },
+        )
+        .expect_err("withdrawing from self should fail");
+
+        // Withdrawing should work.
+        Oas20Token::call(
+            &mut ctx,
+            Request::Withdraw {
+                from: alice,
+                amount: 2,
+            },
+        )
+        .expect("withdrawing should work");
+
+        // Query allowance.
+        let rsp = Oas20Token::query(
+            &mut ctx,
+            Request::Allowance {
+                allower: alice,
+                beneficiary: bob,
+            },
+        )
+        .expect("token allowance query should work");
+        assert_eq!(
+            rsp,
+            Response::Allowance { allowance: 7 },
+            "token allowance query response should be correct"
+        );
+    }
+}

--- a/contract-sdk/specs/oas20/types/Cargo.toml
+++ b/contract-sdk/specs/oas20/types/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "oasis-contract-sdk-oas20-types"
+version = "0.1.0"
+description = "Definition and types for the OAS-20 interface"
+authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+cbor = { version = "0.2.0", package = "oasis-cbor" }
+oasis-contract-sdk = { path = "../../.." }
+oasis-contract-sdk-storage = { path = "../../../storage" }
+oasis-contract-sdk-types = { path = "../../../types" }
+
+# Third party.
+thiserror = "1.0.28"
+
+[dev-dependencies]
+base64 = "0.13.0"

--- a/contract-sdk/specs/oas20/types/src/lib.rs
+++ b/contract-sdk/specs/oas20/types/src/lib.rs
@@ -1,0 +1,217 @@
+use oasis_contract_sdk::{self as sdk};
+use oasis_contract_sdk_types::{address::Address, InstanceId};
+
+#[cfg(test)]
+mod test;
+
+/// OAS20 token instantiation initial balance information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct InitialBalance {
+    pub address: Address,
+    pub amount: u128,
+}
+
+/// Token minting information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct MintingInformation {
+    /// Caller address which is allowed to mint new tokens.
+    pub minter: Address,
+    /// Cap on the total supply of the token.
+    #[cbor(optional)]
+    pub cap: Option<u128>,
+}
+
+/// OAS20 token instantiation information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct TokenInstantiation {
+    /// Name of the token.
+    pub name: String,
+    /// Token symbol.
+    pub symbol: String,
+    /// Number of decimals.
+    pub decimals: u8,
+    /// Initial balances of the token.
+    #[cbor(optional, default, skip_serializing_if = "Vec::is_empty")]
+    pub initial_balances: Vec<InitialBalance>,
+    /// Information about minting in case the token supports minting.
+    #[cbor(optional)]
+    pub minting: Option<MintingInformation>,
+}
+
+/// OAS20 token information.
+#[derive(Debug, Default, Clone, PartialEq, Eq, cbor::Decode, cbor::Encode)]
+pub struct TokenInformation {
+    /// Name of the token.
+    pub name: String,
+    /// Token symbol.
+    pub symbol: String,
+    /// Number of decimals.
+    pub decimals: u8,
+    /// Total supply of the token.
+    pub total_supply: u128,
+    /// Information about minting in case the token supports minting.
+    #[cbor(optional)]
+    pub minting: Option<MintingInformation>,
+}
+
+/// All possible errors that can be returned by the OAS20 contract.
+///
+/// Each error is a triplet of (module, code, message) which allows it to be both easily
+/// human readable and also identifiable programmatically.
+#[derive(Debug, thiserror::Error, sdk::Error)]
+pub enum Error {
+    #[error("bad request")]
+    #[sdk_error(code = 1)]
+    BadRequest,
+
+    #[error("total supply overflow")]
+    #[sdk_error(code = 2)]
+    TotalSupplyOverflow,
+
+    #[error("zero amount")]
+    #[sdk_error(code = 3)]
+    ZeroAmount,
+
+    #[error("insufficient funds")]
+    #[sdk_error(code = 4)]
+    InsufficientFunds,
+
+    #[error("minting forbidden")]
+    #[sdk_error(code = 5)]
+    MintingForbidden,
+
+    #[error("mint over cap")]
+    #[sdk_error(code = 6)]
+    MintOverCap,
+
+    #[error("allower and beneficiary same")]
+    #[sdk_error(code = 7)]
+    SameAllowerAndBeneficiary,
+
+    #[error("insufficient allowance")]
+    #[sdk_error(code = 8)]
+    InsufficientAllowance,
+}
+
+/// All possible events that can be returned by the OAS20 contract.
+#[derive(Debug, cbor::Encode, sdk::Event)]
+#[cbor(untagged)]
+pub enum Event {
+    #[sdk_event(code = 1)]
+    Oas20Instantiated { token_information: TokenInformation },
+
+    #[sdk_event(code = 2)]
+    Oas20Transferred {
+        from: Address,
+        to: Address,
+        amount: u128,
+    },
+
+    #[sdk_event(code = 3)]
+    Oas20Sent {
+        from: Address,
+        to: InstanceId,
+        amount: u128,
+    },
+
+    #[sdk_event(code = 4)]
+    Oas20Burned { from: Address, amount: u128 },
+
+    #[sdk_event(code = 5)]
+    Oas20AllowanceChanged {
+        owner: Address,
+        beneficiary: Address,
+        allowance: u128,
+        negative: bool,
+        amount_change: u128,
+    },
+
+    #[sdk_event(code = 6)]
+    Oas20Withdraw {
+        from: Address,
+        to: Address,
+        amount: u128,
+    },
+
+    #[sdk_event(code = 7)]
+    Oas20Minted { to: Address, amount: u128 },
+}
+
+/// All possible requests that the OAS20 contract can handle.
+///
+/// This includes both calls and queries.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub enum Request {
+    // Calls.
+    #[cbor(rename = "instantiate")]
+    Instantiate(TokenInstantiation),
+
+    #[cbor(rename = "transfer")]
+    Transfer { to: Address, amount: u128 },
+
+    #[cbor(rename = "send")]
+    Send {
+        to: InstanceId,
+        amount: u128,
+        data: cbor::Value,
+    },
+
+    #[cbor(rename = "burn")]
+    Burn { amount: u128 },
+
+    #[cbor(rename = "mint")]
+    Mint { to: Address, amount: u128 },
+
+    #[cbor(rename = "allow")]
+    Allow {
+        beneficiary: Address,
+        negative: bool,
+        amount_change: u128,
+    },
+
+    #[cbor(rename = "withdraw")]
+    Withdraw { from: Address, amount: u128 },
+
+    // Queries.
+    #[cbor(rename = "token_information")]
+    TokenInformation,
+
+    #[cbor(rename = "balance")]
+    Balance { address: Address },
+
+    #[cbor(rename = "allowance")]
+    Allowance {
+        allower: Address,
+        beneficiary: Address,
+    },
+}
+
+/// All possible responses that the OAS20 contract can return.
+///
+/// This includes both calls and queries.
+#[derive(Clone, Debug, PartialEq, cbor::Encode, cbor::Decode)]
+pub enum Response {
+    #[cbor(rename = "token_information")]
+    TokenInformation { token_information: TokenInformation },
+
+    #[cbor(rename = "balance")]
+    Balance { balance: u128 },
+
+    #[cbor(rename = "allowance")]
+    Allowance { allowance: u128 },
+
+    #[cbor(rename = "empty")]
+    Empty,
+}
+
+/// OAS20 receiver request. Contracts expecting to receive OAS20 tokens should
+/// implement these requests.
+#[derive(Clone, Debug, cbor::Decode, cbor::Encode)]
+pub enum ReceiverRequest {
+    #[cbor(rename = "oas20_receive")]
+    Receive {
+        sender: Address,
+        amount: u128,
+        data: cbor::Value,
+    },
+}

--- a/contract-sdk/specs/oas20/types/src/test.rs
+++ b/contract-sdk/specs/oas20/types/src/test.rs
@@ -1,0 +1,60 @@
+use base64;
+
+use oasis_contract_sdk_types::testing::addresses;
+
+use super::*;
+
+#[test]
+fn test_initiate_serialization() {
+    let tcs = vec![
+       (
+           "o2RuYW1lYGZzeW1ib2xgaGRlY2ltYWxzAA==",
+           Default::default(),
+       ),
+       (
+           "o2RuYW1ldVRlc3Rpbmcgc2VyaWFsaXphdGlvbmZzeW1ib2xoVEVTVF9TRVJoZGVjaW1hbHMB",
+           TokenInstantiation{
+               name: "Testing serialization".to_string(),
+               symbol: "TEST_SER".to_string(),
+               decimals: 1,
+               ..Default::default()
+           },
+       ),
+       (
+           "pGRuYW1lb1RFU1QgdG9rZW4gbmFtZWZzeW1ib2xkVEVTVGhkZWNpbWFscwZwaW5pdGlhbF9iYWxhbmNlc4KiZmFtb3VudEInEGdhZGRyZXNzVQDzj3nsHmz+l7T+BseJi1Ko+ttHg6JmYW1vdW50QQpnYWRkcmVzc1UA6WTLZ/m1vC5bdgxVKoClozN3AHA=",
+           TokenInstantiation{
+              name: "TEST token name".to_string(),
+              symbol: "TEST".to_string(),
+              decimals: 6,
+              initial_balances: vec![
+              (
+                InitialBalance{
+                  address: addresses::alice::address().into(),
+                  amount: 10_000,
+                }
+	      ),
+              (
+                InitialBalance{
+                  address: addresses::charlie::address().into(),
+                  amount: 10,
+                }
+	      ),
+              ],
+              minting: None,
+            },
+          ),
+    ];
+
+    for (encoded_base64, tc) in tcs {
+        let ser = cbor::to_vec(tc.clone());
+        assert_eq!(
+            base64::encode(ser),
+            encoded_base64,
+            "serialization should match"
+        );
+
+        let dec: TokenInstantiation = cbor::from_slice(&base64::decode(encoded_base64).unwrap())
+            .expect("token instantiation should deserialize correctly");
+        assert_eq!(dec, tc, "decoded account should match the expected value");
+    }
+}

--- a/contract-sdk/src/testing.rs
+++ b/contract-sdk/src/testing.rs
@@ -60,8 +60,13 @@ impl Env for MockEnv {
         unimplemented!()
     }
 
-    fn address_for_instance(&self, _instance_id: InstanceId) -> Address {
-        unimplemented!()
+    fn address_for_instance(&self, instance_id: InstanceId) -> Address {
+        let b = [
+            "test_12345678".as_bytes(),
+            &instance_id.as_u64().to_be_bytes(),
+        ]
+        .concat();
+        Address::from_bytes(&b).unwrap()
     }
 }
 

--- a/contract-sdk/types/src/address.rs
+++ b/contract-sdk/types/src/address.rs
@@ -1,7 +1,7 @@
 //! A minimal representation of an Oasis Runtime SDK address.
 use std::convert::TryFrom;
 
-use bech32::{self, ToBase32, Variant};
+use bech32::{self, FromBase32, ToBase32, Variant};
 use thiserror::Error;
 
 const ADDRESS_VERSION_SIZE: usize = 1;
@@ -40,6 +40,20 @@ impl Address {
         Ok(Self(a))
     }
 
+    /// Tries to create a new address from Bech32-encoded string.
+    pub fn from_bech32(data: &str) -> Result<Self, Error> {
+        let (hrp, data, variant) = bech32::decode(data).map_err(|_| Error::MalformedAddress)?;
+        if hrp != ADDRESS_BECH32_HRP {
+            return Err(Error::MalformedAddress);
+        }
+        if variant != Variant::Bech32 {
+            return Err(Error::MalformedAddress);
+        }
+        let data: Vec<u8> = FromBase32::from_base32(&data).map_err(|_| Error::MalformedAddress)?;
+
+        Address::from_bytes(&data)
+    }
+
     /// Converts an address to Bech32 representation.
     pub fn to_bech32(self) -> String {
         bech32::encode(ADDRESS_BECH32_HRP, self.0.to_base32(), Variant::Bech32).unwrap()
@@ -71,5 +85,49 @@ impl From<oasis_runtime_sdk::types::address::Address> for Address {
 impl From<Address> for oasis_runtime_sdk::types::address::Address {
     fn from(a: Address) -> Self {
         oasis_runtime_sdk::types::address::Address::from_bytes(&a.0).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_address_try_from_bytes() {
+        let bytes_fixture = vec![42u8; ADDRESS_SIZE + 1];
+        assert_eq!(
+            Address::try_from(&bytes_fixture[0..ADDRESS_SIZE]).unwrap(),
+            Address::from_bytes(&bytes_fixture[0..ADDRESS_SIZE]).unwrap()
+        );
+        assert!(matches!(
+            Address::try_from(bytes_fixture.as_slice()).unwrap_err(),
+            Error::MalformedAddress
+        ));
+    }
+
+    #[test]
+    fn test_address_from_bech32_invalid_hrp() {
+        assert!(matches!(
+            Address::from_bech32("sisoa1qpcprk8jxpsjxw9fadxvzrv9ln7td69yus8rmtux").unwrap_err(),
+            Error::MalformedAddress,
+        ));
+    }
+
+    #[test]
+    fn test_address_from_bech32_invalid_variant() {
+        let b = vec![42u8; ADDRESS_SIZE];
+        let bech32_addr =
+            bech32::encode(ADDRESS_BECH32_HRP, b.to_base32(), Variant::Bech32).unwrap();
+        let bech32m_addr =
+            bech32::encode(ADDRESS_BECH32_HRP, b.to_base32(), Variant::Bech32m).unwrap();
+
+        assert!(
+            Address::from_bech32(&bech32_addr).is_ok(),
+            "bech32 address should be ok"
+        );
+        assert!(matches!(
+            Address::from_bech32(&bech32m_addr).unwrap_err(),
+            Error::MalformedAddress,
+        ));
     }
 }

--- a/contract-sdk/types/src/lib.rs
+++ b/contract-sdk/types/src/lib.rs
@@ -7,6 +7,8 @@ pub mod message;
 pub mod storage;
 pub mod token;
 
+pub mod testing;
+
 /// Unique stored code identifier.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, cbor::Decode, cbor::Encode)]
 #[cbor(transparent)]

--- a/contract-sdk/types/src/testing.rs
+++ b/contract-sdk/types/src/testing.rs
@@ -1,0 +1,35 @@
+//! Testing helpers.
+
+pub mod addresses {
+    pub mod alice {
+        use crate::address::Address;
+
+        pub fn address() -> Address {
+            Address::from_bech32("oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve").unwrap()
+        }
+    }
+
+    pub mod bob {
+        use crate::address::Address;
+
+        pub fn address() -> Address {
+            Address::from_bech32("oasis1qrydpazemvuwtnp3efm7vmfvg3tde044qg6cxwzx").unwrap()
+        }
+    }
+
+    pub mod charlie {
+        use crate::address::Address;
+
+        pub fn address() -> Address {
+            Address::from_bech32("oasis1qr5kfjm8lx6mctjmwcx9225q5k3nxacqwqnjahkw").unwrap()
+        }
+    }
+
+    pub mod dave {
+        use crate::address::Address;
+
+        pub fn address() -> Address {
+            Address::from_bech32("oasis1qpufkctqruam5umugwn5jvxtrvvwl075rqrmxqmm").unwrap()
+        }
+    }
+}

--- a/runtime-sdk/modules/contracts/src/lib.rs
+++ b/runtime-sdk/modules/contracts/src/lib.rs
@@ -194,7 +194,7 @@ impl Default for Parameters {
     fn default() -> Self {
         // TODO: Decide what reasonable defaults should be.
         Parameters {
-            max_code_size: 256 * 1024, // 256 KiB
+            max_code_size: 512 * 1024, // 512 KiB
             max_stack_size: 60 * 1024, // 60 KiB
             max_memory_pages: 20,      // 1280 KiB
 

--- a/runtime-sdk/modules/contracts/src/types.rs
+++ b/runtime-sdk/modules/contracts/src/types.rs
@@ -253,3 +253,39 @@ pub struct ContractEvent {
     #[cbor(optional, default, skip_serializing_if = "Vec::is_empty")]
     pub data: Vec<u8>,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_instanceid_to_address() {
+        let tcs = vec![
+            (
+                InstanceId::from(0),
+                "oasis1qq08mjlkztsgpgrar082rzzxwjaplxmgjs5ftugn",
+            ),
+            (
+                InstanceId::from(1),
+                "oasis1qpg6jv8mxwlv4z578xyjxl7d793jamltdg9czzkx",
+            ),
+            (
+                InstanceId::from(14324),
+                "oasis1qzasj0kq0hlq6vzw4ajhrwgp3tqx6rnwvg2ylu2v",
+            ),
+            (
+                InstanceId::from(u64::MAX),
+                "oasis1qqr0nxsu5aqpu4k85z4h5z08vrfmawnnqycl6gup",
+            ),
+        ];
+
+        for (id, address) in tcs {
+            let instance_address = Instance::address_for(id);
+            assert_eq!(
+                instance_address.to_bech32(),
+                address.to_string(),
+                "instance address should match"
+            );
+        }
+    }
+}

--- a/runtime-sdk/src/types/address.rs
+++ b/runtime-sdk/src/types/address.rs
@@ -276,6 +276,32 @@ mod test {
     }
 
     #[test]
+    fn test_address_from_bech32_invalid_hrp() {
+        assert!(matches!(
+            Address::from_bech32("sisoa1qpcprk8jxpsjxw9fadxvzrv9ln7td69yus8rmtux").unwrap_err(),
+            Error::MalformedAddress,
+        ));
+    }
+
+    #[test]
+    fn test_address_from_bech32_invalid_variant() {
+        let b = vec![42u8; ADDRESS_SIZE];
+        let bech32_addr =
+            bech32::encode(ADDRESS_BECH32_HRP, b.to_base32(), Variant::Bech32).unwrap();
+        let bech32m_addr =
+            bech32::encode(ADDRESS_BECH32_HRP, b.to_base32(), Variant::Bech32m).unwrap();
+
+        assert!(
+            Address::from_bech32(&bech32_addr).is_ok(),
+            "bech32 address should be ok"
+        );
+        assert!(matches!(
+            Address::from_bech32(&bech32m_addr).unwrap_err(),
+            Error::MalformedAddress,
+        ));
+    }
+
+    #[test]
     fn test_address_into_consensus_address() {
         let pk = PublicKey::Ed25519("utrdHlX///////////////////////////////////8=".into());
         let addr = Address::from_pk(&pk);
@@ -292,6 +318,17 @@ mod test {
         assert_eq!(
             addr.to_bech32(),
             "oasis1qpllh99nhwzrd56px4txvl26atzgg4f3a58jzzad"
+        );
+    }
+
+    #[test]
+    fn test_address_from_module() {
+        let id: u64 = 42;
+        let addr = Address::from_module_raw("contracts", &id.to_be_bytes());
+
+        assert_eq!(
+            addr.to_bech32(),
+            "oasis1qq398yyk4wt2zxhtt8c66raynelgt6ngh5yq87xg"
         );
     }
 }

--- a/tests/contracts/hello/Cargo.toml
+++ b/tests/contracts/hello/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 cbor = { version = "0.2.1", package = "oasis-cbor" }
 oasis-contract-sdk = { path = "../../../contract-sdk" }
 oasis-contract-sdk-storage = { path = "../../../contract-sdk/storage" }
+oasis-contract-sdk-oas20-types = { path = "../../../contract-sdk/specs/oas20/types" }
 
 # Third party.
 thiserror = "1.0.26"

--- a/tests/e2e/contracts.go
+++ b/tests/e2e/contracts.go
@@ -9,16 +9,21 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/contracts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/contracts/oas20"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
 //go:embed contracts/hello.wasm
 var helloContractCode []byte
+
+//go:embed contracts/oas20.wasm
+var oas20ContractCode []byte
 
 type HelloInitiate struct {
 	InitialCounter uint64 `json:"initial_counter"`
@@ -28,12 +33,12 @@ type HelloInitiate struct {
 func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	ctx := context.Background()
 
-	initialCounter := uint64(24)
+	counter := uint64(24)
 	ac := accounts.NewV1(rtc)
 	ct := contracts.NewV1(rtc)
 	signer := testing.Alice.Signer
 
-	// Upload contract code.
+	// Upload hello contract code.
 	nonce, err := ac.Nonce(ctx, client.RoundLatest, types.NewAddress(signer.Public()))
 	if err != nil {
 		return fmt.Errorf("failed to get nonce: %w", err)
@@ -48,13 +53,13 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 		return fmt.Errorf("failed to upload contract: %w", err)
 	}
 
-	// Instantiate contract.
+	// Instantiate hello contract.
 	tb = ct.Instantiate(
 		upload.ID,
 		contracts.Policy{Everyone: &struct{}{}},
 		// This needs to conform to the contract API.
 		map[string]interface{}{
-			"instantiate": &HelloInitiate{initialCounter},
+			"instantiate": &HelloInitiate{counter},
 		},
 		[]types.BaseUnits{},
 	).
@@ -63,7 +68,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 	_ = tb.AppendSign(ctx, signer)
 	var instance contracts.InstantiateResult
 	if err := tb.SubmitTx(ctx, &instance); err != nil {
-		return fmt.Errorf("failed to instantiate contract: %w", err)
+		return fmt.Errorf("failed to instantiate hello contract: %w", err)
 	}
 
 	// Call a method on the contract.
@@ -89,8 +94,158 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 		return fmt.Errorf("failed to decode contract result: %w", err)
 	}
 
-	if result["hello"]["greeting"] != fmt.Sprintf("hello e2e test (%d)", initialCounter) {
+	if result["hello"]["greeting"] != fmt.Sprintf("hello e2e test (%d)", counter) {
 		return fmt.Errorf("unexpected result from contract: %+v", result)
+	}
+	// Calling say_hello bumps the counter.
+	counter++
+
+	// Upload OAS20 contract code.
+	tb = ct.Upload(contracts.ABIOasisV1, contracts.Policy{Everyone: &struct{}{}}, oas20ContractCode).
+		SetFeeGas(1_000_000).
+		AppendAuthSignature(signer.Public(), nonce+3)
+	_ = tb.AppendSign(ctx, signer)
+	var uploadOas20 contracts.UploadResult
+	if err := tb.SubmitTx(ctx, &uploadOas20); err != nil {
+		return fmt.Errorf("failed to upload contract: %w", err)
+	}
+
+	// Instantiate OAS20 contract.
+	tb = ct.Instantiate(
+		uploadOas20.ID,
+		contracts.Policy{Everyone: &struct{}{}},
+		// This needs to conform to the contract API.
+		map[string]interface{}{
+			"instantiate": &oas20.Instantiate{
+				Name:     "OAS20 Test token",
+				Symbol:   "OAS20TEST",
+				Decimals: 2,
+				InitialBalances: []oas20.InitialBalance{
+					{
+						Address: types.NewAddress(signer.Public()),
+						Amount:  *quantity.NewFromUint64(10_000),
+					},
+				},
+			},
+		},
+		[]types.BaseUnits{},
+	).
+		SetFeeGas(1_000_000).
+		AppendAuthSignature(signer.Public(), nonce+4)
+	_ = tb.AppendSign(ctx, signer)
+	var instanceOas20 contracts.InstantiateResult
+	if err := tb.SubmitTx(ctx, &instanceOas20); err != nil {
+		return fmt.Errorf("failed to instantiate OAS20 contract: %w", err)
+	}
+
+	// Tansfer some tokens.
+	tb = ct.Call(
+		instanceOas20.ID,
+		&oas20.Request{
+			Transfer: &oas20.Transfer{
+				To:     testing.Charlie.Address,
+				Amount: *quantity.NewFromUint64(10),
+			},
+		},
+		[]types.BaseUnits{},
+	).
+		SetFeeGas(1_000_000).
+		AppendAuthSignature(signer.Public(), nonce+5)
+	_ = tb.AppendSign(ctx, signer)
+	if err := tb.SubmitTx(ctx, &rawResult); err != nil {
+		return fmt.Errorf("failed to call OAS20 transfer: %w", err)
+	}
+
+	// TODO: watch emitted event.
+
+	var response *oas20.Response
+	if err := ct.Custom(
+		ctx,
+		client.RoundLatest,
+		instanceOas20.ID,
+		&oas20.Request{
+			Balance: &oas20.Balance{
+				Address: testing.Charlie.Address,
+			},
+		},
+		&response,
+	); err != nil {
+		return fmt.Errorf("failed to query OAS20 balance: %w", err)
+	}
+	if response.Balance == nil {
+		return fmt.Errorf("invalid OAS20 query balance response: %v", response)
+	}
+	if response.Balance.Balance.Cmp(quantity.NewFromUint64(10)) != 0 {
+		return fmt.Errorf("unexpected OAS20 query balance response: %v", response.Balance)
+	}
+
+	// Send some tokens to hello contract.
+	tb = ct.Call(
+		instanceOas20.ID,
+		&oas20.Request{
+			Send: &oas20.Send{
+				To:     instance.ID,
+				Amount: *quantity.NewFromUint64(10),
+				Data:   13, // Specifies by how much the counter should be incremented.
+			},
+		},
+		[]types.BaseUnits{},
+	).
+		SetFeeGas(1_000_000).
+		AppendAuthSignature(signer.Public(), nonce+6)
+	_ = tb.AppendSign(ctx, signer)
+	if err := tb.SubmitTx(ctx, &rawResult); err != nil {
+		return fmt.Errorf("failed to call OAS20 send: %w", err)
+	}
+	// Sending to hello contract bumps the counter.
+	counter += 13
+
+	// Check counter.
+	tb = ct.Call(
+		instance.ID,
+		map[string]map[string]string{
+			"say_hello": {
+				"who": "e2e test",
+			},
+		},
+		[]types.BaseUnits{},
+	).
+		SetFeeGas(1_000_000).
+		AppendAuthSignature(signer.Public(), nonce+7)
+	_ = tb.AppendSign(ctx, signer)
+	if err := tb.SubmitTx(ctx, &rawResult); err != nil {
+		return fmt.Errorf("failed to call hello contract: %w", err)
+	}
+
+	if err := cbor.Unmarshal(rawResult, &result); err != nil {
+		return fmt.Errorf("failed to decode contract result: %w", err)
+	}
+
+	if result["hello"]["greeting"] != fmt.Sprintf("hello e2e test (%d)", counter) {
+		return fmt.Errorf("unexpected result from contract: %+v", result)
+	}
+	// Calling say_hello bumps the counter.
+	// counter++
+
+	// Query contract OAS20 balance.
+	if err := ct.Custom(
+		ctx,
+		client.RoundLatest,
+		instanceOas20.ID,
+		&oas20.Request{
+			Balance: &oas20.Balance{
+				Address: instance.ID.Address(),
+			},
+		},
+		&response,
+	); err != nil {
+		return fmt.Errorf("failed to query OAS20 contract balance: %w", err)
+	}
+	if response.Balance == nil {
+		return fmt.Errorf("invalid OAS20 query contract balance response: %v", response)
+	}
+	if response.Balance.Balance.Cmp(quantity.NewFromUint64(10)) != 0 {
+		return fmt.Errorf("unexpected OAS20 query contract balance response: %v", response.Balance)
 	}
 
 	return nil

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -3,7 +3,10 @@ set -o nounset -o pipefail -o errexit
 trap "exit 1" INT
 
 # Get the root directory of the tests dir inside the repository.
-TESTS_DIR="$(cd $(dirname $0); pwd -P)"
+TESTS_DIR="$(
+	cd $(dirname $0)
+	pwd -P
+)"
 
 # ANSI escape codes to brighten up the output.
 RED=$'\e[31;1m'
@@ -59,6 +62,11 @@ cd "${TESTS_DIR}"/contracts/hello
 cargo build --target wasm32-unknown-unknown --release
 cp "${TESTS_DIR}"/contracts/hello/target/wasm32-unknown-unknown/release/hello.wasm "${TESTS_DIR}"/e2e/contracts/
 
+printf "${CYAN}### Building oas20 contract...${OFF}\n"
+cd "${TESTS_DIR}"/../contract-sdk/specs/oas20/contract
+cargo build --target wasm32-unknown-unknown --release
+cp "${TESTS_DIR}"/../contract-sdk/specs/oas20/contract/target/wasm32-unknown-unknown/release/oas20.wasm "${TESTS_DIR}"/e2e/contracts/
+
 printf "${CYAN}### Building e2e test harness...${OFF}\n"
 cd "${TESTS_DIR}"/e2e
 go build
@@ -82,4 +90,3 @@ printf "${CYAN}### Running end-to-end tests...${OFF}\n"
 cd "${TESTS_DIR}"
 rm -rf "${TEST_BASE_DIR}"
 printf "${GRN}### Tests finished.${OFF}\n"
-


### PR DESCRIPTION
ERC-20/CW-20 like spec for contracts-sdk with an example implementation

TODO:
- [x] do we want so support Allowances and/or any additional token metadata (e.g. see CW-20 for examples), or anything else?
  - probably not needed for now, can add it later in a non-breaking way (as optional extensions)
- [x] cleanup the example code, currently it was more of a playground
- [x] add some more tests