### PR TITLE
junk: test unrecognized transactions

### DIFF
--- a/client-sdk/ts-web/ext-utils/sample-page/src/index.js
+++ b/client-sdk/ts-web/ext-utils/sample-page/src/index.js
@@ -20,29 +20,29 @@ export const playground = (async function () {
     const conn = await oasisExt.connection.connect(extOrigin, extPath);
     console.log('connected');
 
-    // Receive one keys change event to test the library code for it. Web
-    // developers should handle this separately if they wish to react to
-    // changes to the keys list.
-    console.log('waiting for keys change event');
-    const keys = await new Promise((resolve, reject) => {
-        // Note: Due to the structure of sample-ext calling `ready` and
-        // `keysChanged` in quick succession, keep this in the same task as
-        // when the ready message is received (above in
-        // `await ...connect(...)`). Intervening microtasks are fine.
-        oasisExt.keys.setKeysChangeHandler(conn, (event) => {
-            console.log('keys change', event);
-            resolve(event.keys);
-        });
-    });
-    console.log('received');
-    console.log('keys', keys);
+    // // Receive one keys change event to test the library code for it. Web
+    // // developers should handle this separately if they wish to react to
+    // // changes to the keys list.
+    // console.log('waiting for keys change event');
+    // const keys = await new Promise((resolve, reject) => {
+    //     // Note: Due to the structure of sample-ext calling `ready` and
+    //     // `keysChanged` in quick succession, keep this in the same task as
+    //     // when the ready message is received (above in
+    //     // `await ...connect(...)`). Intervening microtasks are fine.
+    //     oasisExt.keys.setKeysChangeHandler(conn, (event) => {
+    //         console.log('keys change', event);
+    //         resolve(event.keys);
+    //     });
+    // });
+    // console.log('received');
+    // console.log('keys', keys);
 
     console.log('requesting keys again');
     const keys2 = await oasisExt.keys.list(conn);
     console.log('keys', keys2);
 
     console.log('requesting signer');
-    const signer = await oasisExt.signature.ExtContextSigner.request(conn, keys[0].which);
+    const signer = await oasisExt.signature.ExtContextSigner.request(conn, keys2[0].which);
     console.log('got signer');
     const publicKey = signer.public();
     console.log('public key base64', toBase64(publicKey));
@@ -61,10 +61,28 @@ export const playground = (async function () {
             to: await oasis.staking.addressFromPublicKey(dst.public()),
             amount: oasis.quantity.fromBigInt(104n),
         });
+    tw.transaction.method = 'staking.XUnknown'; // %%%
     console.log('requesting signature');
-    await tw.sign(signer, 'fake-chain-context-for-testing');
+    await tw.sign(signer, '5ba68bc5e01e06f755c4c044dd11ec508e4c17f1faf40c0e67874388437a9e55');
     console.log('got signature');
     console.log('signature base64', toBase64(tw.signedTransaction.signature.signature));
+
+    const twl = new oasisRT.wrapper.TransactionWrapper(new Uint8Array(32), 'bridge.Lock')
+        .setBody({
+            target: oasis.misc.fromString('test-target'),
+            amount: [oasis.quantity.fromBigInt(109n), oasis.misc.fromString('TEST')],
+        })
+        .setSignerInfo([{
+            address_spec: {signature: {ed25519: signer.public()}},
+            nonce: 110n,
+        }])
+        .setFeeAmount([oasis.quantity.fromBigInt(111n), oasisRT.token.NATIVE_DENOMINATION])
+        .setFeeGas(112n);
+    console.log('requesting sig');
+    await twl.sign([signer], 'oasis-runtime-sdk/tx: v0 for chain 986e609a59a8ad2fbcb374eba737a271d0bf231034cadbe4e5bb6bf50e3260a2');
+    console.log(twl.unverifiedTransaction);
+
+    throw 'bailing'; // %%%
 
     const rtw = new oasisRT.accounts.Wrapper(oasis.misc.fromString('fake-runtime-id-for-testing'))
         .callTransfer()


### PR DESCRIPTION
some changes I made to adapt the ext-utils test to exercise unrecognized transactions in the extension signer https://github.com/oasisprotocol/oasis-wallet-ext/pull/110