### PR TITLE
contracts-sdk: add env.address_for_instance function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,6 +1635,7 @@ dependencies = [
 name = "oasis-contract-sdk-types"
 version = "0.1.0"
 dependencies = [
+ "bech32",
  "hex",
  "oasis-cbor",
  "oasis-runtime-sdk",

--- a/contract-sdk/src/env.rs
+++ b/contract-sdk/src/env.rs
@@ -1,8 +1,16 @@
 //! Smart contract environment query interface.
-use crate::types::env::{QueryRequest, QueryResponse};
+use oasis_contract_sdk_types::address::Address;
+
+use crate::types::{
+    env::{QueryRequest, QueryResponse},
+    InstanceId,
+};
 
 /// Environment query trait.
 pub trait Env {
     /// Perform an environment query.
     fn query<Q: Into<QueryRequest>>(&self, query: Q) -> QueryResponse;
+
+    /// Returns an address for the contract instance id.
+    fn address_for_instance(&self, instance_id: InstanceId) -> Address;
 }

--- a/contract-sdk/src/testing.rs
+++ b/contract-sdk/src/testing.rs
@@ -59,6 +59,10 @@ impl Env for MockEnv {
     fn query<Q: Into<QueryRequest>>(&self, _query: Q) -> QueryResponse {
         unimplemented!()
     }
+
+    fn address_for_instance(&self, _instance_id: InstanceId) -> Address {
+        unimplemented!()
+    }
 }
 
 /// A mock contract context suitable for testing.

--- a/contract-sdk/types/Cargo.toml
+++ b/contract-sdk/types/Cargo.toml
@@ -11,6 +11,7 @@ cbor = { version = "0.1.8", package = "oasis-cbor" }
 oasis-runtime-sdk = { path = "../../runtime-sdk", optional = true }
 
 # Third party.
+bech32 = "0.8.1"
 thiserror = "1.0.28"
 
 [dev-dependencies]

--- a/contract-sdk/types/src/address.rs
+++ b/contract-sdk/types/src/address.rs
@@ -1,11 +1,14 @@
 //! A minimal representation of an Oasis Runtime SDK address.
 use std::convert::TryFrom;
 
+use bech32::{self, ToBase32, Variant};
 use thiserror::Error;
 
 const ADDRESS_VERSION_SIZE: usize = 1;
 const ADDRESS_DATA_SIZE: usize = 20;
 const ADDRESS_SIZE: usize = ADDRESS_VERSION_SIZE + ADDRESS_DATA_SIZE;
+
+const ADDRESS_BECH32_HRP: &str = "oasis";
 
 /// Error.
 #[derive(Error, Debug)]
@@ -35,6 +38,11 @@ impl Address {
         a.copy_from_slice(data);
 
         Ok(Self(a))
+    }
+
+    /// Converts an address to Bech32 representation.
+    pub fn to_bech32(self) -> String {
+        bech32::encode(ADDRESS_BECH32_HRP, self.0.to_base32(), Variant::Bech32).unwrap()
     }
 }
 

--- a/runtime-sdk/modules/contracts/src/abi/oasis/memory.rs
+++ b/runtime-sdk/modules/contracts/src/abi/oasis/memory.rs
@@ -80,6 +80,19 @@ impl Region {
 
         Ok(&memory.as_slice()[self.offset..self.offset + self.length])
     }
+
+    /// Returns the memory region as a mutable slice.
+    pub fn as_slice_mut<'mem>(
+        &self,
+        memory: &'mem mut wasm3::Memory<'_>,
+    ) -> Result<&'mem mut [u8], RegionError> {
+        // Make sure the region fits in WASM memory.
+        if (self.offset + self.length) > memory.size() {
+            return Err(RegionError::BadPointer);
+        }
+
+        Ok(&mut memory.as_slice_mut()[self.offset..self.offset + self.length])
+    }
 }
 
 impl<Cfg: Config> OasisV1<Cfg> {

--- a/tests/contracts/hello/Cargo.lock
+++ b/tests/contracts/hello/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "bech32"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,7 @@ dependencies = [
 name = "oasis-contract-sdk-types"
 version = "0.1.0"
 dependencies = [
+ "bech32",
  "oasis-cbor",
  "thiserror",
 ]

--- a/tests/contracts/hello/src/lib.rs
+++ b/tests/contracts/hello/src/lib.rs
@@ -66,6 +66,9 @@ pub enum Request {
     #[cbor(rename = "increment_counter")]
     IncrementCounter,
 
+    #[cbor(rename = "query_address")]
+    QueryAddress,
+
     #[cbor(rename = "query_block_info")]
     QueryBlockInfo,
 
@@ -175,6 +178,13 @@ impl sdk::Contract for HelloWorld {
                 Self::increment_counter(ctx);
 
                 Ok(Response::Empty)
+            }
+            Request::QueryAddress => {
+                let address = ctx.env().address_for_instance(ctx.instance_id());
+
+                Ok(Response::Hello {
+                    greeting: format!("my address is: {}", address.to_bech32()),
+                })
             }
             Request::QueryBlockInfo => match ctx.env().query(QueryRequest::BlockInfo) {
                 QueryResponse::BlockInfo {


### PR DESCRIPTION
Adds `address_for_instance` function to the wasm contracts environment 