### PR TITLE
ts-web/core: reflect match oasis-core version with go sdk

### DIFF
--- a/client-sdk/ts-web/core/reflect-go/go.mod
+++ b/client-sdk/ts-web/core/reflect-go/go.mod
@@ -2,4 +2,4 @@ module github.com/oasisprotocol/oasis-sdk/client-sdk/ts-web/core/reflect-go
 
 go 1.16
 
-require github.com/oasisprotocol/oasis-core/go v0.2102.1-0.20210903173012-029cc2215bcf
+require github.com/oasisprotocol/oasis-core/go v0.2102.1-0.20210914094712-425f2a41f9c6

--- a/client-sdk/ts-web/core/reflect-go/go.sum
+++ b/client-sdk/ts-web/core/reflect-go/go.sum
@@ -787,8 +787,8 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 h1:qnvTxmtjcuRH5NiI0Kiku6TXi2VReR/PxHFf3ahFYrg=
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2102.1-0.20210903173012-029cc2215bcf h1:LGBq06ItRjCHOJcDqJEX+A1sVbjiH3t94PmEezubz5Q=
-github.com/oasisprotocol/oasis-core/go v0.2102.1-0.20210903173012-029cc2215bcf/go.mod h1:6LMJSpbDgWROuozzUxw5K8Knn4KtNnbJRZXN0k7ZNdo=
+github.com/oasisprotocol/oasis-core/go v0.2102.1-0.20210914094712-425f2a41f9c6 h1:chMfWYolTDQ8CcI7YrQjuBQ2fxnNkxa0hatsVQz81Lo=
+github.com/oasisprotocol/oasis-core/go v0.2102.1-0.20210914094712-425f2a41f9c6/go.mod h1:6LMJSpbDgWROuozzUxw5K8Knn4KtNnbJRZXN0k7ZNdo=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
to 425f2a41f, with the rest of the repo

no API changes during that range