### PR TITLE
runtime-sdk/modules/contracts: Wrap contract events

### DIFF
--- a/runtime-sdk/modules/contracts/src/results.rs
+++ b/runtime-sdk/modules/contracts/src/results.rs
@@ -16,6 +16,7 @@ use oasis_runtime_sdk::{
 
 use crate::{
     abi::{ExecutionContext, ExecutionResult},
+    types::ContractEvent,
     wasm, Config, Error, Parameters, MODULE_NAME,
 };
 
@@ -68,7 +69,10 @@ fn process_events<C: TxContext>(
                 )
             },
             event.code,
-            event.data,
+            cbor::to_vec(ContractEvent {
+                id: contract.instance_info.id,
+                data: event.data,
+            }),
         ));
     }
 

--- a/runtime-sdk/modules/contracts/src/test.rs
+++ b/runtime-sdk/modules/contracts/src/test.rs
@@ -273,7 +273,14 @@ fn test_hello_contract_call() {
         assert_eq!(tags.len(), 2, "two events should have been emitted");
         assert_eq!(tags[0].key, b"accounts\x00\x00\x00\x01"); // accounts.Transfer (code = 1) event
         assert_eq!(tags[1].key, b"contracts.0\x00\x00\x00\x01"); // contracts.1 (code = 1) event
-        assert_eq!(tags[1].value, b"\x65world"); // CBOR-encoded string "world"
+
+        let event: types::ContractEvent =
+            cbor::from_slice(&tags[1].value).expect("contract event should be wrapped");
+        assert_eq!(
+            event.id, instance_id,
+            "instance id in the event should match"
+        );
+        assert_eq!(event.data, b"\x65world"); // CBOR-encoded string "world"
     });
 
     // Second call should increment the counter.

--- a/runtime-sdk/modules/contracts/src/types.rs
+++ b/runtime-sdk/modules/contracts/src/types.rs
@@ -243,3 +243,13 @@ pub struct CustomQuery {
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 #[cbor(transparent)]
 pub struct CustomQueryResult(pub Vec<u8>);
+
+/// An event emitted from a contract, wrapped to include additional metadata.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct ContractEvent {
+    /// Identifier of the instance that emitted the event.
+    pub id: InstanceId,
+    /// Raw event data emitted by the instance.
+    #[cbor(optional, default, skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<u8>,
+}


### PR DESCRIPTION
Fixes #457 

This allows the module to include additional metadata like the instance
identifier of the contract that emitted the given event.