### PR TITLE
contract-sdk: updates / improvements

### DIFF
--- a/contract-sdk/specs/oas20/types/src/helpers.rs
+++ b/contract-sdk/specs/oas20/types/src/helpers.rs
@@ -1,0 +1,251 @@
+use oasis_contract_sdk::{
+    self as sdk,
+    env::Env,
+    types::{
+        message::{Message, NotifyReply},
+        InstanceId,
+    },
+};
+use oasis_contract_sdk_storage::{cell::Cell, map::Map};
+use oasis_contract_sdk_types::address::Address;
+
+use crate::{Error, InitialBalance, ReceiverRequest, TokenInformation, TokenInstantiation};
+
+/// Instantiates the contract state.
+pub fn instantiate<C: sdk::Context>(
+    ctx: &mut C,
+    balances: Map<Address, u128>,
+    token_info: Cell<TokenInformation>,
+    instantiation: TokenInstantiation,
+) -> Result<TokenInformation, Error> {
+    // Setup initial balances and compute the total supply.
+    let mut total_supply: u128 = 0;
+    for InitialBalance { address, amount } in instantiation.initial_balances {
+        total_supply = total_supply
+            .checked_add(amount)
+            .ok_or(Error::TotalSupplyOverflow)?;
+        balances.insert(ctx.public_store(), address, amount);
+    }
+
+    let token_information = TokenInformation {
+        name: instantiation.name,
+        symbol: instantiation.symbol,
+        decimals: instantiation.decimals,
+        minting: instantiation.minting,
+        total_supply,
+    };
+    token_info.set(ctx.public_store(), token_information.clone());
+
+    Ok(token_information)
+}
+
+/// Transfer the `amount` of funds from `from` to `to` address.
+pub fn transfer<C: sdk::Context>(
+    ctx: &mut C,
+    balances: Map<Address, u128>,
+    from: Address,
+    to: Address,
+    amount: u128,
+) -> Result<(), Error> {
+    if amount == 0 {
+        return Err(Error::ZeroAmount);
+    }
+
+    let mut from_balance = balances.get(ctx.public_store(), from).unwrap_or_default();
+    let mut to_balance = balances.get(ctx.public_store(), to).unwrap_or_default();
+
+    from_balance = from_balance
+        .checked_sub(amount)
+        .ok_or(Error::InsufficientFunds)?;
+    to_balance += amount;
+
+    balances.insert(ctx.public_store(), from, from_balance);
+    balances.insert(ctx.public_store(), to, to_balance);
+
+    Ok(())
+}
+
+/// Burns the `amount` of funds from `from`.
+pub fn burn<C: sdk::Context>(
+    ctx: &mut C,
+    balances: Map<Address, u128>,
+    token_info: Cell<TokenInformation>,
+    from: Address,
+    amount: u128,
+) -> Result<(), Error> {
+    if amount == 0 {
+        return Err(Error::ZeroAmount);
+    }
+
+    // Remove from account balance.
+    let mut from_balance = balances.get(ctx.public_store(), from).unwrap_or_default();
+    from_balance = from_balance
+        .checked_sub(amount)
+        .ok_or(Error::InsufficientFunds)?;
+
+    // Decrease the supply.
+    // Token info should always be present.
+    let mut info = token_info.get(ctx.public_store()).unwrap();
+    // Shouldn't ever overflow.
+    info.total_supply = info.total_supply.checked_sub(amount).unwrap();
+
+    balances.insert(ctx.public_store(), from, from_balance);
+    token_info.set(ctx.public_store(), info);
+
+    Ok(())
+}
+
+/// Mints the `amount` of tokens to `to`.
+pub fn mint<C: sdk::Context>(
+    ctx: &mut C,
+    balances: Map<Address, u128>,
+    token_info_cell: Cell<TokenInformation>,
+    to: Address,
+    amount: u128,
+) -> Result<(), Error> {
+    if amount == 0 {
+        return Err(Error::ZeroAmount);
+    }
+    // Token info should always be present.
+    let mut token_info = token_info_cell.get(ctx.public_store()).unwrap();
+    // Ensure token supports minting and new supply cap is bellow mint cap.
+    match token_info.minting.as_ref() {
+        Some(info) => {
+            let cap = info.cap.unwrap_or(u128::MAX);
+            match token_info.total_supply.checked_add(amount) {
+                Some(new_cap) => {
+                    if new_cap > cap {
+                        return Err(Error::MintOverCap);
+                    }
+                }
+                None => return Err(Error::TotalSupplyOverflow),
+            }
+            if &info.minter != ctx.caller_address() {
+                return Err(Error::MintingForbidden);
+            }
+        }
+        None => return Err(Error::MintingForbidden),
+    }
+
+    // Add to account balance.
+    let mut to_balance = balances.get(ctx.public_store(), to).unwrap_or_default();
+    // Cannot overflow due to the total supply overflow check above.
+    to_balance = to_balance.checked_add(amount).unwrap();
+
+    // Increase the supply.
+    // Overflow already checked above.
+    token_info.total_supply = token_info.total_supply.checked_add(amount).unwrap();
+
+    balances.insert(ctx.public_store(), to, to_balance);
+    token_info_cell.set(ctx.public_store(), token_info);
+
+    Ok(())
+}
+
+/// Transfers the `amount` of funds from caller to `to` contract instance identifier
+/// and calls `ReceiveOas20` on the receiving contract.
+#[allow(clippy::too_many_arguments)]
+pub fn send<C: sdk::Context>(
+    ctx: &mut C,
+    balances: Map<Address, u128>,
+    from: Address,
+    to: InstanceId,
+    amount: u128,
+    data: cbor::Value,
+    id: u64,
+    notify: NotifyReply,
+) -> Result<(), Error> {
+    let to_address = ctx.env().address_for_instance(to);
+    transfer(ctx, balances, from, to_address, amount)?;
+
+    // There should be high-level helpers for calling methods of other contracts that follow a similar
+    // "standard" API - maybe define an API and helper methods in an OAS-0 document.
+
+    // Emit a message through which we instruct the runtime to make a call on the
+    // contract's behalf.
+    use cbor::cbor_map;
+    ctx.emit_message(Message::Call {
+        id,
+        reply: notify,
+        method: "contracts.Call".to_string(),
+        body: cbor::cbor_map! {
+            "id" => cbor::cbor_int!(to.as_u64() as i64),
+            "data" => cbor::cbor_bytes!(cbor::to_vec(
+                cbor::to_value(ReceiverRequest::Receive{sender: from, amount, data}),
+            )),
+            "tokens" => cbor::cbor_array![],
+        },
+        max_gas: None,
+        data: None,
+    });
+
+    Ok(())
+}
+
+/// Update the `beneficiary` allowance by the `amount`.
+pub fn allow<C: sdk::Context>(
+    ctx: &mut C,
+    allowances: Map<(Address, Address), u128>,
+    allower: Address,
+    beneficiary: Address,
+    negative: bool,
+    amount: u128,
+) -> Result<(u128, u128), Error> {
+    if amount == 0 {
+        return Err(Error::ZeroAmount);
+    }
+
+    if allower == beneficiary {
+        return Err(Error::SameAllowerAndBeneficiary);
+    }
+
+    let allowance = allowances
+        .get(ctx.public_store(), (allower, beneficiary))
+        .unwrap_or_default();
+
+    let (new_allowance, change) = match negative {
+        true => {
+            let new = allowance.saturating_sub(amount);
+            (new, allowance - new)
+        }
+        false => {
+            let new = allowance.saturating_add(amount);
+            (new, new - allowance)
+        }
+    };
+
+    allowances.insert(ctx.public_store(), (allower, beneficiary), new_allowance);
+
+    Ok((new_allowance, change))
+}
+
+/// Withdraw the `amount` of funds from `from` to `to`.
+pub fn withdraw<C: sdk::Context>(
+    ctx: &mut C,
+    balances: Map<Address, u128>,
+    allowances: Map<(Address, Address), u128>,
+    from: Address,
+    to: Address,
+    amount: u128,
+) -> Result<(), Error> {
+    if amount == 0 {
+        return Err(Error::ZeroAmount);
+    }
+
+    if from == to {
+        return Err(Error::SameAllowerAndBeneficiary);
+    }
+
+    let mut allowance = allowances
+        .get(ctx.public_store(), (from, to))
+        .unwrap_or_default();
+    allowance = allowance
+        .checked_sub(amount)
+        .ok_or(Error::InsufficientAllowance)?;
+
+    transfer(ctx, balances, from, to, amount)?;
+
+    allowances.insert(ctx.public_store(), (from, to), allowance);
+
+    Ok(())
+}

--- a/contract-sdk/specs/oas20/types/src/lib.rs
+++ b/contract-sdk/specs/oas20/types/src/lib.rs
@@ -1,6 +1,9 @@
+extern crate alloc;
+
 use oasis_contract_sdk::{self as sdk};
 use oasis_contract_sdk_types::{address::Address, InstanceId};
 
+pub mod helpers;
 #[cfg(test)]
 mod test;
 

--- a/contract-sdk/src/testing.rs
+++ b/contract-sdk/src/testing.rs
@@ -56,8 +56,15 @@ impl MockEnv {
 }
 
 impl Env for MockEnv {
-    fn query<Q: Into<QueryRequest>>(&self, _query: Q) -> QueryResponse {
-        unimplemented!()
+    fn query<Q: Into<QueryRequest>>(&self, query: Q) -> QueryResponse {
+        match query.into() {
+            QueryRequest::BlockInfo => QueryResponse::BlockInfo {
+                round: 42,
+                epoch: 2,
+                timestamp: 100_000,
+            },
+            _ => unimplemented!(),
+        }
     }
 
     fn address_for_instance(&self, instance_id: InstanceId) -> Address {
@@ -74,6 +81,8 @@ impl Env for MockEnv {
 pub struct MockContext {
     /// Execution context.
     pub ec: ExecutionContext,
+
+    pub deposited_tokens: Vec<token::BaseUnits>,
 
     /// Public store.
     pub public_store: MockStore,
@@ -92,6 +101,7 @@ impl From<ExecutionContext> for MockContext {
     fn from(ec: ExecutionContext) -> Self {
         Self {
             ec,
+            deposited_tokens: Vec::new(),
             public_store: MockStore::new(),
             confidential_store: MockStore::new(),
             env: MockEnv::new(),
@@ -119,7 +129,7 @@ impl Context for MockContext {
     }
 
     fn deposited_tokens(&self) -> &[token::BaseUnits] {
-        &self.ec.deposited_tokens
+        &self.deposited_tokens
     }
 
     fn emit_message(&mut self, msg: Message) {

--- a/contract-sdk/types/src/lib.rs
+++ b/contract-sdk/types/src/lib.rs
@@ -4,6 +4,7 @@ pub mod address;
 pub mod env;
 pub mod event;
 pub mod message;
+pub mod modules;
 pub mod storage;
 pub mod token;
 

--- a/contract-sdk/types/src/message.rs
+++ b/contract-sdk/types/src/message.rs
@@ -19,6 +19,8 @@ pub enum Message {
         body: cbor::Value,
         #[cbor(optional)]
         max_gas: Option<u64>,
+        #[cbor(optional)]
+        data: Option<cbor::Value>,
     },
 }
 
@@ -42,6 +44,8 @@ pub enum Reply {
         #[cbor(optional, default)]
         id: u64,
         result: CallResult,
+        #[cbor(optional)]
+        data: Option<cbor::Value>,
     },
 }
 

--- a/contract-sdk/types/src/modules/contracts.rs
+++ b/contract-sdk/types/src/modules/contracts.rs
@@ -1,0 +1,8 @@
+use crate::InstanceId;
+
+/// Instantiate call result.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct InstantiateResult {
+    /// Assigned instance identifier.
+    pub id: InstanceId,
+}

--- a/contract-sdk/types/src/modules/mod.rs
+++ b/contract-sdk/types/src/modules/mod.rs
@@ -1,0 +1,3 @@
+//!  A collection of types for easier calling into existing SDK modules.
+
+pub mod contracts;

--- a/runtime-sdk/modules/contracts/src/abi/oasis/test.rs
+++ b/runtime-sdk/modules/contracts/src/abi/oasis/test.rs
@@ -278,7 +278,7 @@ fn test_hello_contract_out_of_gas() {
     assert_eq!(result.code(), 12);
     assert_eq!(
         &result.to_string(),
-        "core: out of gas (limit: 1000 wanted: 1017)"
+        "core: out of gas (limit: 1000 wanted: 1004)"
     );
 }
 

--- a/runtime-sdk/modules/contracts/src/results.rs
+++ b/runtime-sdk/modules/contracts/src/results.rs
@@ -126,6 +126,7 @@ fn process_subcalls<Cfg: Config, C: TxContext>(
         match msg {
             Message::Call {
                 id,
+                data,
                 reply,
                 method,
                 body,
@@ -221,6 +222,7 @@ fn process_subcalls<Cfg: Config, C: TxContext>(
                         let reply = Reply::Call {
                             id,
                             result: result.into(),
+                            data,
                         };
                         let mut exec_ctx = ExecutionContext {
                             caller_address: ctx.tx_caller_address(),

--- a/runtime-sdk/src/context.rs
+++ b/runtime-sdk/src/context.rs
@@ -698,7 +698,7 @@ impl<'a, V: Any> ContextValue<'a, V> {
         }
     }
 
-    /// Gets a mutable reference to the specifeid per-context value.
+    /// Gets a mutable reference to the specified per-context value.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
-  add support for passing optional data to contract `reply_handlers`
- extract OAS20 methods logic to `types` crate helpers functions, so that these can be reused in contracts extending the OAS20-base (e.g.  creating a wrapped-oas20 token contract)
- add E2E test to `hello` contract for initializing a OAS20 token via the `hello` contract 