### PR TITLE
modules/evm: refactor derive_caller_*

### DIFF
--- a/runtime-sdk/modules/evm/src/derive_caller.rs
+++ b/runtime-sdk/modules/evm/src/derive_caller.rs
@@ -1,0 +1,44 @@
+use tiny_keccak::{Hasher, Keccak};
+
+use oasis_runtime_sdk::{
+    crypto::signature::{secp256k1, PublicKey},
+    types::{
+        address::Address,
+        transaction::{AddressSpec, AuthInfo},
+    },
+};
+
+use crate::types::H160;
+
+pub fn from_bytes(b: &[u8]) -> H160 {
+    // Caller address is derived by doing Keccak-256 on the
+    // secp256k1 public key and taking the last 20 bytes
+    // of the result.
+    let mut k = Keccak::v256();
+    let mut out = [0u8; 32];
+    k.update(b);
+    k.finalize(&mut out);
+    H160::from_slice(&out[32 - 20..])
+}
+
+pub fn from_secp256k1_public_key(public_key: &secp256k1::PublicKey) -> H160 {
+    from_bytes(&public_key.to_uncompressed_untagged_bytes())
+}
+
+pub fn from_non_secp256k1_address(address: &Address) -> H160 {
+    from_bytes(&address.as_ref()[1..])
+}
+
+pub fn from_public_key(pk: &PublicKey) -> H160 {
+    match pk {
+        PublicKey::Secp256k1(pk) => from_secp256k1_public_key(pk),
+        pk => from_non_secp256k1_address(&Address::from_pk(pk)),
+    }
+}
+
+pub fn from_tx_auth_info(ai: &AuthInfo) -> H160 {
+    match &ai.signer_info[0].address_spec {
+        AddressSpec::Signature(PublicKey::Secp256k1(pk)) => from_secp256k1_public_key(pk),
+        address_spec => from_non_secp256k1_address(&address_spec.address()),
+    }
+}

--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -1,4 +1,5 @@
 //! EVM module.
+pub mod derive_caller;
 pub mod evm_backend;
 pub mod precompile;
 pub mod types;
@@ -11,11 +12,9 @@ use evm::{
 };
 use once_cell::sync::Lazy;
 use thiserror::Error;
-use tiny_keccak::{Hasher, Keccak};
 
 use oasis_runtime_sdk::{
     context::{Context, TxContext},
-    crypto::signature::{secp256k1, PublicKey},
     error,
     module::{self, CallResult, Module as _},
     modules::{
@@ -24,11 +23,7 @@ use oasis_runtime_sdk::{
         core::{self, Error as CoreError, API as _},
     },
     storage,
-    types::{
-        address::Address,
-        token,
-        transaction::{AddressSpec, AuthInfo, Transaction},
-    },
+    types::{address::Address, token, transaction::Transaction},
 };
 
 use evm::backend::ApplyBackend;
@@ -423,47 +418,11 @@ impl<Cfg: Config> Module<Cfg> {
         Ok(exit_value)
     }
 
-    fn derive_caller_from_bytes(b: &[u8]) -> H160 {
-        // Caller address is derived by doing Keccak-256 on the
-        // secp256k1 public key and taking the last 20 bytes
-        // of the result.
-        let mut k = Keccak::v256();
-        let mut out = [0u8; 32];
-        k.update(b);
-        k.finalize(&mut out);
-        H160::from_slice(&out[32 - 20..])
-    }
-
-    fn derive_caller_from_secp256k1_public_key(public_key: &secp256k1::PublicKey) -> H160 {
-        Self::derive_caller_from_bytes(&public_key.to_uncompressed_untagged_bytes())
-    }
-
-    fn derive_caller_from_non_secp256k1_address(address: &Address) -> H160 {
-        Self::derive_caller_from_bytes(&address.as_ref()[1..])
-    }
-
-    #[cfg(test)]
-    fn derive_caller_from_public_key(pk: &PublicKey) -> H160 {
-        match pk {
-            PublicKey::Secp256k1(pk) => Self::derive_caller_from_secp256k1_public_key(pk),
-            pk => Self::derive_caller_from_non_secp256k1_address(&Address::from_pk(pk)),
-        }
-    }
-
-    fn derive_caller_from_tx_auth_info(ai: &AuthInfo) -> H160 {
-        match &ai.signer_info[0].address_spec {
-            AddressSpec::Signature(PublicKey::Secp256k1(pk)) => {
-                Self::derive_caller_from_secp256k1_public_key(pk)
-            }
-            address_spec => Self::derive_caller_from_non_secp256k1_address(&address_spec.address()),
-        }
-    }
-
     fn derive_caller<C>(ctx: &mut C) -> H160
     where
         C: TxContext,
     {
-        Self::derive_caller_from_tx_auth_info(ctx.tx_auth_info())
+        derive_caller::from_tx_auth_info(ctx.tx_auth_info())
     }
 
     fn tx_create<C: TxContext>(ctx: &mut C, body: types::Create) -> Result<Vec<u8>, Error> {
@@ -579,7 +538,7 @@ impl<Cfg: Config> module::AuthHandler for Module<Cfg> {
         let params = Self::params(ctx.runtime_state());
         let den = params.token_denomination;
 
-        let evm_acct_addr = Self::derive_caller_from_tx_auth_info(&tx.auth_info);
+        let evm_acct_addr = derive_caller::from_tx_auth_info(&tx.auth_info);
 
         // Check nonces on all signer accounts.
         // Note that we can ignore the return value because the payee is already

--- a/runtime-sdk/modules/evm/src/test.rs
+++ b/runtime-sdk/modules/evm/src/test.rs
@@ -21,6 +21,7 @@ use oasis_runtime_sdk::{
 };
 
 use crate::{
+    derive_caller,
     types::{self, H160},
     Config, GasCosts, Genesis, Module as EVMModule, Parameters,
 };
@@ -56,7 +57,7 @@ fn check_derivation(seed: &str, priv_hex: &str, addr_hex: &str) {
     let pub_key = priv_key.verifying_key();
     let sdk_pub_key =
         secp256k1::PublicKey::from_bytes(k256::EncodedPoint::from(&pub_key).as_bytes()).unwrap();
-    let addr = EVM::derive_caller_from_public_key(&PublicKey::Secp256k1(sdk_pub_key));
+    let addr = derive_caller::from_public_key(&PublicKey::Secp256k1(sdk_pub_key));
     assert_eq!(addr.as_bytes(), Vec::from_hex(addr_hex).unwrap().as_slice());
 }
 
@@ -76,7 +77,7 @@ fn test_evm_caller_addr_derivation() {
 
     let expected =
         H160::from_slice(&Vec::<u8>::from_hex("dce075e1c39b1ae0b75d554558b6451a226ffe00").unwrap());
-    let derived = EVM::derive_caller_from_public_key(&keys::dave::pk());
+    let derived = derive_caller::from_public_key(&keys::dave::pk());
     assert_eq!(derived, expected);
 }
 
@@ -139,7 +140,7 @@ fn test_evm_calls() {
             format: transaction::CallFormat::Plain,
             method: "evm.Deposit".to_owned(),
             body: cbor::to_value(types::Deposit {
-                to: EVM::derive_caller_from_public_key(&keys::dave::pk()),
+                to: derive_caller::from_public_key(&keys::dave::pk()),
                 amount: BaseUnits::new(999_000, Denomination::NATIVE),
             }),
         },
@@ -323,7 +324,7 @@ fn test_evm_runtime() {
             format: transaction::CallFormat::Plain,
             method: "evm.Deposit".to_owned(),
             body: cbor::to_value(types::Deposit {
-                to: EVM::derive_caller_from_public_key(&keys::dave::pk()),
+                to: derive_caller::from_public_key(&keys::dave::pk()),
                 amount: BaseUnits::new(999_000, Denomination::NATIVE),
             }),
         },


### PR DESCRIPTION
~~adds a new ...from_public_key, for tests were we don't have an entire auth_info struct~~ partially split into #491 

extract some smaller common logic

moves these to a new mod so that we don't have to configure an entire evm module to use it. mostly for testing

wanted for #452