### PR TITLE
modules/evm: new chain_id implementation

### DIFF
--- a/runtime-sdk/modules/evm/src/evm_backend.rs
+++ b/runtime-sdk/modules/evm/src/evm_backend.rs
@@ -5,7 +5,6 @@ use evm::backend::{Apply, ApplyBackend, Backend as EVMBackend, Basic, Log};
 
 use oasis_runtime_sdk::{
     core::common::crypto::hash::Hash,
-    crypto,
     storage::{self, Store as _},
 };
 
@@ -14,14 +13,12 @@ use crate::{
     types::{H160, H256, U256},
 };
 
-/// EVM chain domain separation context.
-const EVM_CHAIN_CONTEXT: &[u8] = b"oasis-runtime-sdk/evm: chain id";
-
 /// Information required by the evm crate.
 #[derive(Clone, Default, PartialEq, Eq, cbor::Encode, cbor::Decode)]
 pub struct Vicinity {
     pub gas_price: U256,
     pub origin: H160,
+    pub chain_id: U256,
 }
 
 /// Details specific to Ethereum accounts.  Information managed by SDK modules
@@ -84,7 +81,7 @@ impl<'c, C: oasis_runtime_sdk::Context> EVMBackend for Backend<'c, C> {
         primitive_types::U256::zero()
     }
     fn chain_id(&self) -> primitive_types::U256 {
-        crypto::signature::context::get_chain_context_for(EVM_CHAIN_CONTEXT)[..32].into()
+        self.vicinity.chain_id.into()
     }
     fn exists(&self, address: primitive_types::H160) -> bool {
         let acct = self.basic(address);

--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -54,6 +54,9 @@ pub mod state {
 pub trait Config: 'static {
     /// Module that is used for accessing accounts.
     type Accounts: modules::accounts::API;
+
+    /// The chain ID to supply when a contract requests it.
+    const CHAIN_ID: u64;
 }
 
 pub struct Module<Cfg: Config> {
@@ -362,6 +365,7 @@ impl<Cfg: Config> Module<Cfg> {
         let vicinity = evm_backend::Vicinity {
             gas_price: gas_price.into(),
             origin: source,
+            chain_id: Cfg::CHAIN_ID.into(),
         };
 
         // The maximum gas fee has already been withdrawn in authenticate_tx().

--- a/runtime-sdk/modules/evm/src/test.rs
+++ b/runtime-sdk/modules/evm/src/test.rs
@@ -34,6 +34,8 @@ struct EVMConfig;
 
 impl Config for EVMConfig {
     type Accounts = Accounts;
+
+    const CHAIN_ID: u64 = 0xa515;
 }
 
 type EVM = EVMModule<EVMConfig>;

--- a/tests/runtimes/simple-evm/src/lib.rs
+++ b/tests/runtimes/simple-evm/src/lib.rs
@@ -12,6 +12,8 @@ pub struct EVMConfig;
 
 impl evm::Config for EVMConfig {
     type Accounts = modules::accounts::Module;
+
+    const CHAIN_ID: u64 = 0xa515;
 }
 
 impl sdk::Runtime for Runtime {


### PR DESCRIPTION
Take the chain ID from a configuration const. We'd like to be able
to use small numbers.