### PR TITLE
OAS20 request handler helpers

### DIFF
--- a/contract-sdk/storage/src/map.rs
+++ b/contract-sdk/storage/src/map.rs
@@ -61,6 +61,12 @@ pub trait MapKey {
     fn key(&self) -> Vec<&[u8]>;
 }
 
+impl<const N: usize> MapKey for [u8; N] {
+    fn key(&self) -> Vec<&[u8]> {
+        vec![self]
+    }
+}
+
 impl MapKey for &[u8] {
     fn key(&self) -> Vec<&[u8]> {
         vec![self]


### PR DESCRIPTION
- adds `handle_query` and `handle_call` methods to OAS20 helpers, so that standard handling of OAS20 requests can be easily reused. The per-call helpers are also kept, as those might be useful for contracts implementing only parts of the OAS20 spec 
- implements `MapKey` for byte arrays