### PR TITLE
ts-web/rt: v0.2.0-alpha4

### DIFF
--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -20,7 +20,7 @@
         "@oasisprotocol/client": "^0.1.0-alpha6"
     },
     "devDependencies": {
-        "@oasisprotocol/client-rt": "^0.2.0-alpha3",
+        "@oasisprotocol/client-rt": "^0.2.0-alpha4",
         "buffer": "^6.0.3",
         "cypress": "^8.5.0",
         "prettier": "^2.4.1",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -87,7 +87,7 @@
                 "@oasisprotocol/client": "^0.1.0-alpha6"
             },
             "devDependencies": {
-                "@oasisprotocol/client-rt": "^0.2.0-alpha3",
+                "@oasisprotocol/client-rt": "^0.2.0-alpha4",
                 "buffer": "^6.0.3",
                 "cypress": "^8.5.0",
                 "prettier": "^2.4.1",
@@ -8629,7 +8629,7 @@
         },
         "rt": {
             "name": "@oasisprotocol/client-rt",
-            "version": "0.2.0-alpha3",
+            "version": "0.2.0-alpha4",
             "dependencies": {
                 "@oasisprotocol/client": "^0.1.0-alpha6",
                 "elliptic": "^6.5.3"
@@ -9516,7 +9516,7 @@
             "version": "file:ext-utils",
             "requires": {
                 "@oasisprotocol/client": "^0.1.0-alpha6",
-                "@oasisprotocol/client-rt": "^0.2.0-alpha3",
+                "@oasisprotocol/client-rt": "^0.2.0-alpha4",
                 "buffer": "^6.0.3",
                 "cypress": "^8.5.0",
                 "prettier": "^2.4.1",

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## Unreleased chanegs:
+## v0.2.0-alpha4:
+
+Spotlight change:
+
+- We made unitemized changes to track the (unversioned) runtime SDK itself.
 
 Documentation changes:
+
 - Added doc comments for some signing types and functions.
 
 ## v0.2.0-alpha3

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-rt",
-    "version": "0.2.0-alpha3",
+    "version": "0.2.0-alpha4",
     "files": [
         "dist"
     ],


### PR DESCRIPTION
the new oasis-core 21.3 will need these changes we made to the runtime transaction request/response bodies, where they changed from nested CBOR structures to flat byte arrays

a release to get that new functionality out to developers