### PR TITLE
Change secp256k1 address derivation

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -388,6 +388,31 @@ jobs:
         working-directory: client-sdk/ts-web/core
         run: npm test
 
+  jest-ts-web-rt:
+    name: jest-ts-web-rt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js LTS
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: "14.x"
+          cache: npm
+          cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
+
+      - name: Set up npm
+        run: npm install npm@7 -g
+
+      - name: Install dependencies and build
+        working-directory: client-sdk/ts-web
+        run: npm ci --foreground-scripts
+
+      - name: Run tests
+        working-directory: client-sdk/ts-web/rt
+        run: npm test
+
   ts-web-core-reflect:
     # NOTE: This name appears in GitHub's Checks API.
     name: ts-web-core-reflect

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "once_cell",
  "schnorrkel",
  "sha2",
+ "sha3 0.9.1",
  "slog",
  "thiserror",
  "tiny-keccak 2.0.2",

--- a/client-sdk/go/client/transaction.go
+++ b/client-sdk/go/client/transaction.go
@@ -70,8 +70,8 @@ func (tb *TransactionBuilder) SetCallFormat(ctx context.Context, format types.Ca
 
 // AppendAuthSignature appends a new transaction signer information with a signature address
 // specification to the transaction.
-func (tb *TransactionBuilder) AppendAuthSignature(pk signature.PublicKey, nonce uint64) *TransactionBuilder {
-	tb.tx.AppendAuthSignature(pk, nonce)
+func (tb *TransactionBuilder) AppendAuthSignature(spec types.SignatureAddressSpec, nonce uint64) *TransactionBuilder {
+	tb.tx.AppendAuthSignature(spec, nonce)
 	return tb
 }
 

--- a/client-sdk/go/crypto/signature/ed25519/ed25519.go
+++ b/client-sdk/go/crypto/signature/ed25519/ed25519.go
@@ -2,9 +2,7 @@ package ed25519
 
 import (
 	"encoding"
-	"encoding/json"
 
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 
 	sdkSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
@@ -19,18 +17,6 @@ var (
 
 // PublicKey is an Ed25519 public key.
 type PublicKey signature.PublicKey
-
-type serializedPublicKey struct {
-	Ed25519 signature.PublicKey `json:"ed25519"`
-}
-
-func (pk PublicKey) MarshalCBOR() ([]byte, error) {
-	return cbor.Marshal(serializedPublicKey{Ed25519: signature.PublicKey(pk)}), nil
-}
-
-func (pk PublicKey) MarshalJSON() ([]byte, error) {
-	return json.Marshal(serializedPublicKey{Ed25519: signature.PublicKey(pk)})
-}
 
 // MarshalBinary encodes a public key into binary form.
 func (pk PublicKey) MarshalBinary() ([]byte, error) {

--- a/client-sdk/go/crypto/signature/secp256k1/secp256k1.go
+++ b/client-sdk/go/crypto/signature/secp256k1/secp256k1.go
@@ -2,11 +2,8 @@ package secp256k1
 
 import (
 	"encoding/base64"
-	"encoding/json"
 
 	"github.com/btcsuite/btcd/btcec"
-
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 
 	sdkSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
 )
@@ -14,24 +11,16 @@ import (
 // PublicKey is a Secp256k1 public key.
 type PublicKey btcec.PublicKey
 
-type serializedPublicKey struct {
-	Secp256k1 []byte `json:"secp256k1"`
-}
-
-func (pk PublicKey) MarshalCBOR() ([]byte, error) {
-	bpk := btcec.PublicKey(pk)
-	return cbor.Marshal(serializedPublicKey{Secp256k1: bpk.SerializeCompressed()}), nil
-}
-
-func (pk PublicKey) MarshalJSON() ([]byte, error) {
-	bpk := btcec.PublicKey(pk)
-	return json.Marshal(serializedPublicKey{Secp256k1: bpk.SerializeCompressed()})
-}
-
 // MarshalBinary encodes a public key into binary form.
 func (pk PublicKey) MarshalBinary() ([]byte, error) {
 	bpk := btcec.PublicKey(pk)
 	return bpk.SerializeCompressed(), nil
+}
+
+// MarshalBinaryUncompressedUntagged encodes a public key into an uncompressed untagged binary form.
+func (pk PublicKey) MarshalBinaryUncompressedUntagged() ([]byte, error) {
+	bpk := btcec.PublicKey(pk)
+	return bpk.SerializeUncompressed()[1:], nil
 }
 
 // UnmarshalBinary decodes a binary marshaled public key.
@@ -88,4 +77,12 @@ func (pk PublicKey) Verify(context, message, signature []byte) bool {
 	}
 	bpk := btcec.PublicKey(pk)
 	return sig.Verify(data, &bpk)
+}
+
+// NewPublicKey creates a new public key from the given Base64 representation or panics.
+func NewPublicKey(text string) (pk PublicKey) {
+	if err := pk.UnmarshalText([]byte(text)); err != nil {
+		panic(err)
+	}
+	return
 }

--- a/client-sdk/go/crypto/signature/secp256k1/secp256k1_test.go
+++ b/client-sdk/go/crypto/signature/secp256k1/secp256k1_test.go
@@ -87,14 +87,6 @@ func TestSecp256k1PubKeySerDes(t *testing.T) {
 	pk, ok := spk.(PublicKey)
 	require.True(ok, "signer public key should be a secp256k1 public key")
 
-	mcbor, err := pk.MarshalCBOR()
-	require.NoError(err, "MarshalCBOR")
-	require.NotNil(mcbor, "MarshalCBOR")
-
-	mjson, err := pk.MarshalJSON()
-	require.NoError(err, "MarshalJSON")
-	require.NotNil(mjson, "MarshalJSON")
-
 	mstr := pk.String()
 	require.NotNil(mstr, "String")
 

--- a/client-sdk/go/crypto/signature/sr25519/sr25519.go
+++ b/client-sdk/go/crypto/signature/sr25519/sr25519.go
@@ -3,10 +3,8 @@ package sr25519
 import (
 	"crypto/sha512"
 	"encoding/base64"
-	"encoding/json"
 
 	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
 )
@@ -14,20 +12,6 @@ import (
 // PublicKey is an Sr25519 public key.
 type PublicKey struct {
 	inner *sr25519.PublicKey
-}
-
-type serializedPublicKey struct {
-	Sr25519 []byte `json:"sr25519"`
-}
-
-func (pk PublicKey) MarshalCBOR() ([]byte, error) {
-	b, _ := pk.MarshalBinary()
-	return cbor.Marshal(serializedPublicKey{Sr25519: b}), nil
-}
-
-func (pk PublicKey) MarshalJSON() ([]byte, error) {
-	b, _ := pk.MarshalBinary()
-	return json.Marshal(serializedPublicKey{Sr25519: b})
 }
 
 // MarshalBinary encodes a public key into binary form.

--- a/client-sdk/go/go.mod
+++ b/client-sdk/go/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
 	github.com/oasisprotocol/oasis-core/go v0.2103.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	google.golang.org/grpc v1.41.0
 )

--- a/client-sdk/go/testing/testing.go
+++ b/client-sdk/go/testing/testing.go
@@ -15,22 +15,27 @@ import (
 type TestKey struct {
 	Signer  signature.Signer
 	Address types.Address
+	SigSpec types.SignatureAddressSpec
 }
 
 func newEd25519TestKey(seed string) TestKey {
 	signer := ed25519.WrapSigner(memorySigner.NewTestSigner(seed))
+	sigspec := types.NewSignatureAddressSpecEd25519(signer.Public().(ed25519.PublicKey))
 	return TestKey{
 		Signer:  signer,
-		Address: types.NewAddress(signer.Public()),
+		Address: types.NewAddress(sigspec),
+		SigSpec: sigspec,
 	}
 }
 
 func newSecp256k1TestKey(seed string) TestKey {
 	pk := sha512.Sum512_256([]byte(seed))
 	signer := secp256k1.NewSigner(pk[:])
+	sigspec := types.NewSignatureAddressSpecSecp256k1Eth(signer.Public().(secp256k1.PublicKey))
 	return TestKey{
 		Signer:  signer,
-		Address: types.NewAddress(signer.Public()),
+		Address: types.NewAddress(sigspec),
+		SigSpec: sigspec,
 	}
 }
 

--- a/client-sdk/go/types/address.go
+++ b/client-sdk/go/types/address.go
@@ -3,12 +3,13 @@ package types
 import (
 	"encoding"
 
+	"golang.org/x/crypto/sha3"
+
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
 	"github.com/oasisprotocol/oasis-core/go/common/encoding/bech32"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/ed25519"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/secp256k1"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/sr25519"
@@ -18,8 +19,8 @@ var (
 	// AddressV0Ed25519Context is the unique context for v0 Ed25519-based addresses.
 	// It is shared with the consensus layer addresses on purpose.
 	AddressV0Ed25519Context = staking.AddressV0Context
-	// AddressV0Secp256k1Context is the unique context for v0 secp256k1-based addresses.
-	AddressV0Secp256k1Context = address.NewContext("oasis-runtime-sdk/address: secp256k1", 0)
+	// AddressV0Secp256k1EthContext is the unique context for v0 secp256k1-based addresses.
+	AddressV0Secp256k1EthContext = address.NewContext("oasis-runtime-sdk/address: secp256k1eth", 0)
 	// AddressV0Sr25519Context is the unique context for v0 Sr25519-based addresses.
 	AddressV0Sr25519Context = address.NewContext("oasis-runtime-sdk/address: sr25519", 0)
 	// AddressV0MultisigContext is the unique context for v0 multisig addresses.
@@ -35,6 +36,48 @@ var (
 	_ encoding.TextMarshaler     = Address{}
 	_ encoding.TextUnmarshaler   = (*Address)(nil)
 )
+
+// SignatureAddressSpec is information for signature-based authentication and public key-based
+// address derivation.
+type SignatureAddressSpec struct {
+	// Ed25519 address derivation compatible with the consensus layer.
+	Ed25519 *ed25519.PublicKey `json:"ed25519,omitempty"`
+
+	// Secp256k1Eth is ethereum-compatible address derivation from Secp256k1 public keys.
+	Secp256k1Eth *secp256k1.PublicKey `json:"secp256k1eth,omitempty"`
+
+	// Sr25519 address derivation.
+	Sr25519 *sr25519.PublicKey `json:"sr25519,omitempty"`
+}
+
+// PublicKey returns the public key of the authentication/address derivation specification.
+func (as *SignatureAddressSpec) PublicKey() PublicKey {
+	switch {
+	case as.Ed25519 != nil:
+		return PublicKey{PublicKey: as.Ed25519}
+	case as.Secp256k1Eth != nil:
+		return PublicKey{PublicKey: as.Secp256k1Eth}
+	case as.Sr25519 != nil:
+		return PublicKey{PublicKey: as.Sr25519}
+	}
+	return PublicKey{}
+}
+
+// NewSignatureAddressSpecEd25519 creates a new address specification for an Ed25519 public key.
+func NewSignatureAddressSpecEd25519(pk ed25519.PublicKey) SignatureAddressSpec {
+	return SignatureAddressSpec{Ed25519: &pk}
+}
+
+// NewSignatureAddressSpecSecp256k1Eth creates a new Ethereum-compatible address specification for
+// an Secp256k1 public key.
+func NewSignatureAddressSpecSecp256k1Eth(pk secp256k1.PublicKey) SignatureAddressSpec {
+	return SignatureAddressSpec{Secp256k1Eth: &pk}
+}
+
+// NewSignatureAddressSpecSr25519 creates a new address specification for an Sr25519 public key.
+func NewSignatureAddressSpecSr25519(pk sr25519.PublicKey) SignatureAddressSpec {
+	return SignatureAddressSpec{Sr25519: &pk}
+}
 
 // Address is the account address.
 type Address address.Address
@@ -73,22 +116,27 @@ func (a Address) String() string {
 	return bech32Addr
 }
 
-// NewAddress creates a new address from the given public key.
-func NewAddress(pk signature.PublicKey) (a Address) {
+// NewAddress creates a new address from the given signature address specification.
+func NewAddress(spec SignatureAddressSpec) (a Address) {
 	var (
 		ctx    address.Context
 		pkData []byte
 	)
-	switch pk := pk.(type) {
-	case ed25519.PublicKey:
+	switch {
+	case spec.Ed25519 != nil:
 		ctx = AddressV0Ed25519Context
-		pkData, _ = pk.MarshalBinary()
-	case secp256k1.PublicKey:
-		ctx = AddressV0Secp256k1Context
-		pkData, _ = pk.MarshalBinary()
-	case sr25519.PublicKey:
+		pkData, _ = spec.Ed25519.MarshalBinary()
+	case spec.Secp256k1Eth != nil:
+		ctx = AddressV0Secp256k1EthContext
+		// Use a scheme such that we can compute Secp256k1 addresses from Ethereum
+		// addresses as this makes things more interoperable.
+		h := sha3.NewLegacyKeccak256()
+		untaggedPk, _ := spec.Secp256k1Eth.MarshalBinaryUncompressedUntagged()
+		h.Write(untaggedPk)
+		pkData = h.Sum(nil)[32-20:]
+	case spec.Sr25519 != nil:
 		ctx = AddressV0Sr25519Context
-		pkData, _ = pk.MarshalBinary()
+		pkData, _ = spec.Sr25519.MarshalBinary()
 	default:
 		panic("address: unsupported public key type")
 	}

--- a/client-sdk/go/types/address_test.go
+++ b/client-sdk/go/types/address_test.go
@@ -7,32 +7,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/ed25519"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/secp256k1"
 )
 
 func TestAddressEd25519(t *testing.T) {
 	require := require.New(t)
 
 	pk := ed25519.NewPublicKey("utrdHlX///////////////////////////////////8=")
-	addr := NewAddress(pk)
+	addr := NewAddress(NewSignatureAddressSpecEd25519(pk))
 
 	require.EqualValues("oasis1qryqqccycvckcxp453tflalujvlf78xymcdqw4vz", addr.String())
 }
 
-func TestAddressSecp256k1(t *testing.T) {
-	/*
-			#[test]
-		    fn test_address_secp256k1() {
-		        let pk = PublicKey::Secp256k1(
-		            "02badadd1e55ffffffffffffffffffffffffffffffffffffffffffffffffffffff".into(),
-		        );
+func TestAddressSecp256k1Eth(t *testing.T) {
+	require := require.New(t)
 
-		        let addr = Address::from_pk(&pk);
-		        assert_eq!(
-		            addr.to_bech32(),
-		            "oasis1qr4cd0sr32m3xcez37ym7rmjp5g88muu8sdfx8u3"
-		        );
-		    }
-	*/
+	pk := secp256k1.NewPublicKey("Arra3R5V////////////////////////////////////")
+	addr := NewAddress(NewSignatureAddressSpecSecp256k1Eth(pk))
+
+	require.EqualValues("oasis1qzd7akz24n6fxfhdhtk977s5857h3c6gf5583mcg", addr.String())
 }
 
 func TestAddressMultisig(t *testing.T) {

--- a/client-sdk/go/types/transaction_test.go
+++ b/client-sdk/go/types/transaction_test.go
@@ -47,8 +47,8 @@ func TestTransactionSigning(t *testing.T) {
 	signer2 := ed25519.WrapSigner(memorySigner.NewTestSigner("oasis-runtime-sdk/test-keys: tx signing 2"))
 
 	tx := NewTransaction(nil, "hello.World", nil)
-	tx.AppendAuthSignature(signer.Public(), 42)
-	tx.AppendAuthSignature(signer2.Public(), 43)
+	tx.AppendAuthSignature(NewSignatureAddressSpecEd25519(signer.Public().(ed25519.PublicKey)), 42)
+	tx.AppendAuthSignature(NewSignatureAddressSpecEd25519(signer2.Public().(ed25519.PublicKey)), 43)
 	tx.AppendAuthMultisig(&MultisigConfig{
 		Signers: []MultisigSigner{
 			{PublicKey: PublicKey{PublicKey: signer.Public()}, Weight: 1},

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -2032,7 +2032,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2265,7 +2264,6 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
             "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -4346,7 +4344,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7310,6 +7307,14 @@
                 "sha.js": "bin.js"
             }
         },
+        "node_modules/sha3": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+            "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+            "dependencies": {
+                "buffer": "6.0.3"
+            }
+        },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -7831,6 +7836,46 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/ts-jest": {
+            "version": "27.0.5",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.5.tgz",
+            "integrity": "sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==",
+            "dev": true,
+            "dependencies": {
+                "bs-logger": "0.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^27.0.0",
+                "json5": "2.x",
+                "lodash": "4.x",
+                "make-error": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
+            },
+            "bin": {
+                "ts-jest": "cli.js"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0-beta.0 <8",
+                "@types/jest": "^27.0.0",
+                "babel-jest": ">=27.0.0 <28",
+                "jest": "^27.0.0",
+                "typescript": ">=3.8 <5.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "@types/jest": {
+                    "optional": true
+                },
+                "babel-jest": {
+                    "optional": true
+                }
             }
         },
         "node_modules/tslib": {
@@ -8632,15 +8677,19 @@
             "version": "0.2.0-alpha4",
             "dependencies": {
                 "@oasisprotocol/client": "^0.1.0-alpha6",
-                "elliptic": "^6.5.3"
+                "elliptic": "^6.5.3",
+                "sha3": "^2.1.4"
             },
             "devDependencies": {
                 "@types/elliptic": "^6.4.13",
+                "@types/jest": "^27.0.2",
                 "buffer": "^6.0.3",
                 "cypress": "^8.6.0",
+                "jest": "^27.2.5",
                 "prettier": "^2.4.1",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
+                "ts-jest": "^27.0.5",
                 "typescript": "^4.4.4",
                 "webpack": "^5.58.2",
                 "webpack-cli": "^4.9.0",
@@ -9533,12 +9582,16 @@
             "requires": {
                 "@oasisprotocol/client": "^0.1.0-alpha6",
                 "@types/elliptic": "^6.4.13",
+                "@types/jest": "^27.0.2",
                 "buffer": "^6.0.3",
                 "cypress": "^8.6.0",
                 "elliptic": "^6.5.3",
+                "jest": "^27.2.5",
                 "prettier": "^2.4.1",
                 "process": "^0.11.10",
+                "sha3": "^2.1.4",
                 "stream-browserify": "^3.0.0",
+                "ts-jest": "^27.0.5",
                 "typescript": "^4.4.4",
                 "webpack": "^5.58.2",
                 "webpack-cli": "^4.9.0",
@@ -10340,8 +10393,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "batch": {
             "version": "0.6.1",
@@ -10538,7 +10590,6 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
             "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -12192,8 +12243,7 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "ignore": {
             "version": "5.1.8",
@@ -14432,6 +14482,14 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "sha3": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+            "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+            "requires": {
+                "buffer": "6.0.3"
+            }
+        },
         "shallow-clone": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -14843,6 +14901,22 @@
             "dev": true,
             "requires": {
                 "punycode": "^2.1.1"
+            }
+        },
+        "ts-jest": {
+            "version": "27.0.5",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.5.tgz",
+            "integrity": "sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==",
+            "dev": true,
+            "requires": {
+                "bs-logger": "0.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^27.0.0",
+                "json5": "2.x",
+                "lodash": "4.x",
+                "make-error": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
             }
         },
         "tslib": {

--- a/client-sdk/ts-web/rt/jest.config.js
+++ b/client-sdk/ts-web/rt/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    testMatch: ['**/test/**/*.ts'],
+    testEnvironment: 'node',
+    preset: 'ts-jest'
+};

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -10,19 +10,24 @@
         "check-playground": "cd playground && tsc -p jsconfig.json",
         "fmt": "prettier --write playground/src src",
         "lint": "prettier --check playground/src src",
-        "playground": "cd playground && webpack s -c webpack.config.js"
+        "playground": "cd playground && webpack s -c webpack.config.js",
+        "test": "jest"
     },
     "dependencies": {
         "@oasisprotocol/client": "^0.1.0-alpha6",
-        "elliptic": "^6.5.3"
+        "elliptic": "^6.5.3",
+        "sha3": "^2.1.4"
     },
     "devDependencies": {
         "@types/elliptic": "^6.4.13",
+        "@types/jest": "^27.0.2",
         "buffer": "^6.0.3",
         "cypress": "^8.6.0",
+        "jest": "^27.2.5",
         "prettier": "^2.4.1",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
+        "ts-jest": "^27.0.5",
         "typescript": "^4.4.4",
         "webpack": "^5.58.2",
         "webpack-cli": "^4.9.0",

--- a/client-sdk/ts-web/rt/src/address.ts
+++ b/client-sdk/ts-web/rt/src/address.ts
@@ -1,18 +1,36 @@
 import * as oasis from '@oasisprotocol/client';
+import * as elliptic from 'elliptic';
+import {Keccak} from 'sha3';
 
 import * as types from './types';
 
-export const V0_SECP256K1_CONTEXT_IDENTIFIER = 'oasis-runtime-sdk/address: secp256k1';
-export const V0_SECP256K1_CONTEXT_VERSION = 0;
+export const V0_SECP256K1ETH_CONTEXT_IDENTIFIER = 'oasis-runtime-sdk/address: secp256k1eth';
+export const V0_SECP256K1ETH_CONTEXT_VERSION = 0;
 export const V0_MULTISIG_CONTEXT_IDENTIFIER = 'oasis-runtime-sdk/address: multisig';
 export const V0_MULTISIG_CONTEXT_VERSION = 0;
 
-export async function fromSecp256k1PublicKey(pk: Uint8Array) {
-    return await oasis.address.fromData(
-        V0_SECP256K1_CONTEXT_IDENTIFIER,
-        V0_SECP256K1_CONTEXT_VERSION,
-        pk,
-    );
+const SECP256K1 = new elliptic.ec('secp256k1');
+
+export async function fromSigspec(spec: types.SignatureAddressSpec) {
+    if ('ed25519' in spec) {
+        return await oasis.staking.addressFromPublicKey(spec.ed25519);
+    } else if ('secp256k1eth' in spec) {
+        // Use a scheme such that we can compute Secp256k1 addresses from Ethereum
+        // addresses as this makes things more interoperable.
+        const untaggedPk = SECP256K1.keyFromPublic(Array.from(spec.secp256k1eth))
+            .getPublic(false, 'array')
+            .slice(1);
+        const hash = new Keccak(256);
+        hash.update(Buffer.from(untaggedPk));
+        const pkData = hash.digest().slice(32 - 20);
+        return await oasis.address.fromData(
+            V0_SECP256K1ETH_CONTEXT_IDENTIFIER,
+            V0_SECP256K1ETH_CONTEXT_VERSION,
+            pkData,
+        );
+    } else {
+        throw new Error('unsupported signature address specification type');
+    }
 }
 
 export async function fromMultisigConfig(config: types.MultisigConfig) {
@@ -22,4 +40,12 @@ export async function fromMultisigConfig(config: types.MultisigConfig) {
         V0_MULTISIG_CONTEXT_VERSION,
         configU8,
     );
+}
+
+export function toBech32(addr: Uint8Array) {
+    return oasis.staking.addressToBech32(addr);
+}
+
+export function fromBech32(str: string) {
+    return oasis.staking.addressFromBech32(str);
 }

--- a/client-sdk/ts-web/rt/src/transaction.ts
+++ b/client-sdk/ts-web/rt/src/transaction.ts
@@ -68,12 +68,18 @@ export async function signAny(
 }
 
 export async function proveSignature(
-    pk: types.PublicKey,
+    spec: types.SignatureAddressSpec,
     signer: AnySigner,
     context: string,
     body: Uint8Array,
 ) {
-    return {signature: await signAny(pk, signer, context, body)};
+    if ('ed25519' in spec) {
+        return {signature: await (signer as oasis.signature.ContextSigner).sign(context, body)};
+    } else if ('secp256k1eth' in spec) {
+        return {signature: await (signer as signatureSecp256k1.ContextSigner).sign(context, body)};
+    } else {
+        throw new Error('unsupported signature address specification type');
+    }
 }
 
 export async function proveMultisig(

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -84,11 +84,25 @@ export interface AddressSpec {
     /**
      * For _signature_ authentication.
      */
-    signature?: PublicKey;
+    signature?: SignatureAddressSpec;
     /**
      * For _multisig_ authentication.
      */
     multisig?: MultisigConfig;
+}
+
+/**
+ * Information for signature-based authentication and public key-based address derivation.
+ */
+export interface SignatureAddressSpec {
+    /**
+     * Ed25519 address derivation compatible with the consensus layer.
+     */
+    ed25519?: Uint8Array;
+    /**
+     * Ethereum-compatible address derivation from Secp256k1 public keys.
+     */
+    secp256k1eth?: Uint8Array;
 }
 
 /**

--- a/client-sdk/ts-web/rt/test/address.test.ts
+++ b/client-sdk/ts-web/rt/test/address.test.ts
@@ -1,0 +1,19 @@
+import * as oasisRT from './../src';
+
+describe('address', () => {
+    describe('ed25519', () => {
+        it('Should derive the address correctly', async () => {
+            const pk = Buffer.from('utrdHlX///////////////////////////////////8=', 'base64');
+            const address = await oasisRT.address.fromSigspec({ed25519: new Uint8Array(pk)});
+            expect(oasisRT.address.toBech32(address)).toEqual('oasis1qryqqccycvckcxp453tflalujvlf78xymcdqw4vz');
+        });
+    });
+
+    describe('secp256k1eth', () => {
+        it('Should derive the address correctly', async () => {
+            const pk = Buffer.from('Arra3R5V////////////////////////////////////', 'base64');
+            const address = await oasisRT.address.fromSigspec({secp256k1eth: new Uint8Array(pk)});
+            expect(oasisRT.address.toBech32(address)).toEqual('oasis1qzd7akz24n6fxfhdhtk977s5857h3c6gf5583mcg');
+        });
+    });
+});

--- a/client-sdk/ts-web/rt/tsconfig.json
+++ b/client-sdk/ts-web/rt/tsconfig.json
@@ -5,5 +5,8 @@
         "module": "CommonJS",
         "target": "ES2020",
         "declaration": true
-    }
+    },
+    "include": [
+        "src/**/*"
+    ]
 }

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -18,6 +18,7 @@ byteorder = "1.4.3"
 curve25519-dalek = "3.2.0"
 digest = "0.9.0"
 sha2 = "0.9.8"
+sha3 = { version = "0.9", default-features = false }
 k256 = { version = "0.9.6" }
 schnorrkel = "0.10.1"
 thiserror = "1.0.28"

--- a/runtime-sdk/modules/contracts/src/test.rs
+++ b/runtime-sdk/modules/contracts/src/test.rs
@@ -51,7 +51,10 @@ fn upload_hello_contract<C: BatchContext>(ctx: &mut C) -> types::CodeId {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -96,7 +99,10 @@ fn deploy_hello_contract<C: BatchContext>(
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1_000_000,
@@ -212,7 +218,10 @@ fn test_hello_contract_call() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1_000_000,
@@ -301,7 +310,10 @@ fn test_hello_contract_call() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1_000_000,
@@ -449,7 +461,10 @@ fn test_hello_contract_subcalls() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 2_000_000,
@@ -495,7 +510,10 @@ fn test_hello_contract_query() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1_000_000,
@@ -532,7 +550,10 @@ fn test_hello_contract_query() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1_000_000,
@@ -569,7 +590,10 @@ fn test_hello_contract_query() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1_000_000,
@@ -618,7 +642,10 @@ fn test_hello_contract_upgrade() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 2_000_000,
@@ -658,7 +685,10 @@ fn test_hello_contract_upgrade_fail_policy() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::bob::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::bob::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 2_000_000,
@@ -700,7 +730,10 @@ fn test_hello_contract_upgrade_fail_pre() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 2_000_000,
@@ -745,7 +778,10 @@ fn test_hello_contract_upgrade_fail_post() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 2_000_000,

--- a/runtime-sdk/modules/evm/src/derive_caller.rs
+++ b/runtime-sdk/modules/evm/src/derive_caller.rs
@@ -1,9 +1,9 @@
 use sha3::Digest as _;
 
 use oasis_runtime_sdk::{
-    crypto::signature::{secp256k1, PublicKey},
+    crypto::signature::secp256k1,
     types::{
-        address::Address,
+        address::{Address, SignatureAddressSpec},
         transaction::{AddressSpec, AuthInfo},
     },
 };
@@ -22,16 +22,18 @@ pub fn from_non_secp256k1_address(address: &Address) -> H160 {
     from_bytes(&address.as_ref()[1..])
 }
 
-pub fn from_public_key(pk: &PublicKey) -> H160 {
-    match pk {
-        PublicKey::Secp256k1(pk) => from_secp256k1_public_key(pk),
-        pk => from_non_secp256k1_address(&Address::from_pk(pk)),
+pub fn from_sigspec(spec: &SignatureAddressSpec) -> H160 {
+    match spec {
+        SignatureAddressSpec::Secp256k1Eth(pk) => from_secp256k1_public_key(pk),
+        spec => from_non_secp256k1_address(&Address::from_sigspec(spec)),
     }
 }
 
 pub fn from_tx_auth_info(ai: &AuthInfo) -> H160 {
     match &ai.signer_info[0].address_spec {
-        AddressSpec::Signature(PublicKey::Secp256k1(pk)) => from_secp256k1_public_key(pk),
+        AddressSpec::Signature(SignatureAddressSpec::Secp256k1Eth(pk)) => {
+            from_secp256k1_public_key(pk)
+        }
         address_spec => from_non_secp256k1_address(&address_spec.address()),
     }
 }

--- a/runtime-sdk/modules/evm/src/raw_tx.rs
+++ b/runtime-sdk/modules/evm/src/raw_tx.rs
@@ -7,7 +7,7 @@ use sha3::{self, Digest as _};
 
 use oasis_runtime_sdk::{
     crypto::signature,
-    types::{token, transaction},
+    types::{address, token, transaction},
 };
 
 use crate::types;
@@ -198,12 +198,14 @@ fn decode_enveloped(
         },
         auth_info: transaction::AuthInfo {
             signer_info: vec![transaction::SignerInfo {
-                address_spec: transaction::AddressSpec::Signature(signature::PublicKey::Secp256k1(
-                    signature::secp256k1::PublicKey::from_bytes(
-                        k256::EncodedPoint::from(&key).as_bytes(),
-                    )
-                    .with_context(|| "sdk secp256k1 public key from bytes")?,
-                )),
+                address_spec: transaction::AddressSpec::Signature(
+                    address::SignatureAddressSpec::Secp256k1Eth(
+                        signature::secp256k1::PublicKey::from_bytes(
+                            k256::EncodedPoint::from(&key).as_bytes(),
+                        )
+                        .with_context(|| "sdk secp256k1 public key from bytes")?,
+                    ),
+                ),
                 nonce,
             }],
             fee: transaction::Fee {

--- a/runtime-sdk/modules/evm/src/test.rs
+++ b/runtime-sdk/modules/evm/src/test.rs
@@ -6,7 +6,7 @@ use uint::hex::FromHex;
 
 use oasis_runtime_sdk::{
     context,
-    crypto::signature::{secp256k1, PublicKey},
+    crypto::signature::secp256k1,
     module::{self, InvariantHandler as _},
     modules::{
         accounts::{self, Module as Accounts},
@@ -14,6 +14,7 @@ use oasis_runtime_sdk::{
     },
     testing::{keys, mock},
     types::{
+        address::SignatureAddressSpec,
         token::{BaseUnits, Denomination},
         transaction,
     },
@@ -59,7 +60,7 @@ fn check_derivation(seed: &str, priv_hex: &str, addr_hex: &str) {
     let pub_key = priv_key.verifying_key();
     let sdk_pub_key =
         secp256k1::PublicKey::from_bytes(k256::EncodedPoint::from(&pub_key).as_bytes()).unwrap();
-    let addr = derive_caller::from_public_key(&PublicKey::Secp256k1(sdk_pub_key));
+    let addr = derive_caller::from_sigspec(&SignatureAddressSpec::Secp256k1Eth(sdk_pub_key));
     assert_eq!(addr.as_bytes(), Vec::from_hex(addr_hex).unwrap().as_slice());
 }
 
@@ -79,7 +80,7 @@ fn test_evm_caller_addr_derivation() {
 
     let expected =
         H160::from_slice(&Vec::<u8>::from_hex("dce075e1c39b1ae0b75d554558b6451a226ffe00").unwrap());
-    let derived = derive_caller::from_public_key(&keys::dave::pk());
+    let derived = derive_caller::from_sigspec(&keys::dave::sigspec());
     assert_eq!(derived, expected);
 }
 
@@ -142,12 +143,15 @@ fn test_evm_calls() {
             format: transaction::CallFormat::Plain,
             method: "evm.Deposit".to_owned(),
             body: cbor::to_value(types::Deposit {
-                to: derive_caller::from_public_key(&keys::dave::pk()),
+                to: derive_caller::from_sigspec(&keys::dave::sigspec()),
                 amount: BaseUnits::new(999_000, Denomination::NATIVE),
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 100,
@@ -176,7 +180,10 @@ fn test_evm_calls() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000000,
@@ -211,7 +218,10 @@ fn test_evm_calls() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 25000,
@@ -245,7 +255,10 @@ fn test_evm_calls() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 100,
@@ -326,12 +339,15 @@ fn test_evm_runtime() {
             format: transaction::CallFormat::Plain,
             method: "evm.Deposit".to_owned(),
             body: cbor::to_value(types::Deposit {
-                to: derive_caller::from_public_key(&keys::dave::pk()),
+                to: derive_caller::from_sigspec(&keys::dave::sigspec()),
                 amount: BaseUnits::new(999_000, Denomination::NATIVE),
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 100,
@@ -360,7 +376,10 @@ fn test_evm_runtime() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000000,
@@ -395,7 +414,10 @@ fn test_evm_runtime() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 25000,
@@ -439,7 +461,10 @@ fn test_evm_runtime() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 64000,
@@ -474,7 +499,10 @@ fn test_evm_runtime() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::dave::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::dave::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 100,

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -11,7 +11,6 @@ use thiserror::Error;
 use crate::{
     context::{Context, TxContext},
     core::common::quantity::Quantity,
-    crypto::signature::PublicKey,
     error, module,
     module::{CallResult, Module as _, Parameters as _},
     modules,
@@ -19,7 +18,7 @@ use crate::{
     storage,
     storage::Prefix,
     types::{
-        address::Address,
+        address::{Address, SignatureAddressSpec},
         token,
         transaction::{AuthInfo, Transaction},
     },
@@ -822,7 +821,7 @@ impl module::BlockHandler for Module {
             .runtime_round_results()
             .good_compute_entities
             .iter()
-            .map(|pk| Address::from_pk(&PublicKey::Ed25519(pk.into())))
+            .map(|pk| Address::from_sigspec(&SignatureAddressSpec::Ed25519(pk.into())))
             .collect();
 
         if !addrs.is_empty() {

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -223,7 +223,10 @@ fn test_api_tx_transfer_disabled() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -250,7 +253,10 @@ fn test_prefetch() {
     let mut ctx = mock.create_ctx();
 
     let auth_info = transaction::AuthInfo {
-        signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+        signer_info: vec![transaction::SignerInfo::new_sigspec(
+            keys::alice::sigspec(),
+            0,
+        )],
         fee: transaction::Fee {
             amount: Default::default(),
             gas: 1000,
@@ -395,7 +401,10 @@ fn test_authenticate_tx() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: BaseUnits::new(1_000, Denomination::NATIVE),
                 gas: 1000,
@@ -453,7 +462,10 @@ fn test_tx_transfer() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -522,7 +534,10 @@ fn test_fee_disbursement() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 // Use an amount that does not split nicely among the good compute entities.
                 amount: BaseUnits::new(1_001, Denomination::NATIVE),

--- a/runtime-sdk/src/modules/consensus/mod.rs
+++ b/runtime-sdk/src/modules/consensus/mod.rs
@@ -17,13 +17,12 @@ use oasis_core_runtime::{
 
 use crate::{
     context::{Context, TxContext},
-    crypto::signature::PublicKey,
     module,
     module::Module as _,
     modules,
     modules::core::{Module as Core, API as _},
     types::{
-        address::Address,
+        address::{Address, SignatureAddressSpec},
         message::MessageEventHookInvocation,
         token,
         transaction::{AddressSpec, TransactionWeight},
@@ -266,7 +265,7 @@ impl API for Module {
 
     fn ensure_compatible_tx_signer<C: TxContext>(ctx: &C) -> Result<(), Error> {
         match ctx.tx_auth_info().signer_info[0].address_spec {
-            AddressSpec::Signature(PublicKey::Ed25519(_)) => Ok(()),
+            AddressSpec::Signature(SignatureAddressSpec::Ed25519(_)) => Ok(()),
             _ => Err(Error::ConsensusIncompatibleSigner),
         }
     }

--- a/runtime-sdk/src/modules/consensus_accounts/test.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/test.rs
@@ -63,7 +63,10 @@ fn test_api_deposit_invalid_denomination() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -102,7 +105,10 @@ fn test_api_deposit() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -165,7 +171,10 @@ fn test_api_withdraw_invalid_denomination() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -204,7 +213,10 @@ fn test_api_withdraw_insufficient_balance() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -265,7 +277,10 @@ fn test_api_withdraw() {
             }),
         },
         auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+            signer_info: vec![transaction::SignerInfo::new_sigspec(
+                keys::alice::sigspec(),
+                0,
+            )],
             fee: transaction::Fee {
                 amount: Default::default(),
                 gas: 1000,
@@ -408,7 +423,10 @@ fn test_prefetch() {
     let mut ctx = mock.create_ctx();
 
     let auth_info = transaction::AuthInfo {
-        signer_info: vec![transaction::SignerInfo::new(keys::alice::pk(), 0)],
+        signer_info: vec![transaction::SignerInfo::new_sigspec(
+            keys::alice::sigspec(),
+            0,
+        )],
         fee: transaction::Fee {
             amount: Default::default(),
             gas: 1000,

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -202,7 +202,7 @@ fn test_reject_txs() {
         },
         auth_info: transaction::AuthInfo {
             signer_info: vec![
-                transaction::SignerInfo::new(keys::alice::pk(), 0),
+                transaction::SignerInfo::new_sigspec(keys::alice::sigspec(), 0),
                 transaction::SignerInfo::new_multisig(
                     multisig::Config {
                         signers: vec![multisig::Signer {
@@ -241,7 +241,7 @@ fn test_query_estimate_gas() {
         },
         auth_info: transaction::AuthInfo {
             signer_info: vec![
-                transaction::SignerInfo::new(keys::alice::pk(), 0),
+                transaction::SignerInfo::new_sigspec(keys::alice::sigspec(), 0),
                 transaction::SignerInfo::new_multisig(
                     multisig::Config {
                         signers: vec![multisig::Signer {
@@ -513,7 +513,7 @@ fn test_min_gas_price() {
         },
         auth_info: transaction::AuthInfo {
             signer_info: vec![
-                transaction::SignerInfo::new(keys::alice::pk(), 0),
+                transaction::SignerInfo::new_sigspec(keys::alice::sigspec(), 0),
                 transaction::SignerInfo::new_multisig(
                     multisig::Config {
                         signers: vec![multisig::Signer {

--- a/runtime-sdk/src/modules/rewards/mod.rs
+++ b/runtime-sdk/src/modules/rewards/mod.rs
@@ -8,11 +8,10 @@ use thiserror::Error;
 use crate::{
     context::Context,
     core::consensus::beacon,
-    crypto::signature::PublicKey,
     error,
     module::{self, Module as _, Parameters as _},
     modules, storage,
-    types::address::Address,
+    types::address::{Address, SignatureAddressSpec},
 };
 
 #[cfg(test)]
@@ -173,13 +172,13 @@ impl<Accounts: modules::accounts::API> module::BlockHandler for Module<Accounts>
 
         // Reward each good entity.
         for entity_id in &ctx.runtime_round_results().good_compute_entities {
-            let address = Address::from_pk(&PublicKey::Ed25519(entity_id.into()));
+            let address = Address::from_sigspec(&SignatureAddressSpec::Ed25519(entity_id.into()));
             rewards.pending.entry(address).or_default().increment();
         }
 
         // Punish each bad entity by forbidding rewards for this epoch.
         for entity_id in &ctx.runtime_round_results().bad_compute_entities {
-            let address = Address::from_pk(&PublicKey::Ed25519(entity_id.into()));
+            let address = Address::from_sigspec(&SignatureAddressSpec::Ed25519(entity_id.into()));
             rewards.pending.entry(address).or_default().forbid();
         }
 

--- a/runtime-sdk/src/testing/keys.rs
+++ b/runtime-sdk/src/testing/keys.rs
@@ -11,7 +11,7 @@ macro_rules! test_key_ed25519 {
         pub mod $name {
             use crate::{
                 crypto::signature::{ed25519, PublicKey},
-                types::address::Address,
+                types::address::{Address, SignatureAddressSpec},
             };
 
             #[doc = " Test public key "]
@@ -28,11 +28,18 @@ macro_rules! test_key_ed25519 {
                 $pk.into()
             }
 
+            #[doc = " Test address derivation information "]
+            #[doc=$doc]
+            #[doc = "."]
+            pub fn sigspec() -> SignatureAddressSpec {
+                SignatureAddressSpec::Ed25519(pk_ed25519())
+            }
+
             #[doc = " Test address "]
             #[doc=$doc]
             #[doc = "."]
             pub fn address() -> Address {
-                Address::from_pk(&pk())
+                Address::from_sigspec(&sigspec())
             }
         }
     };
@@ -47,7 +54,7 @@ macro_rules! test_key_secp256k1 {
         pub mod $name {
             use crate::{
                 crypto::signature::{secp256k1, PublicKey},
-                types::address::Address,
+                types::address::{Address, SignatureAddressSpec},
             };
 
             #[doc = " Test public key "]
@@ -64,11 +71,18 @@ macro_rules! test_key_secp256k1 {
                 $pk.into()
             }
 
+            #[doc = " Test address derivation information "]
+            #[doc=$doc]
+            #[doc = "."]
+            pub fn sigspec() -> SignatureAddressSpec {
+                SignatureAddressSpec::Secp256k1Eth(pk_secp256k1())
+            }
+
             #[doc = " Test address "]
             #[doc=$doc]
             #[doc = "."]
             pub fn address() -> Address {
-                Address::from_pk(&pk())
+                Address::from_sigspec(&sigspec())
             }
         }
     };

--- a/tests/benchmark/cmd/benchmarks.go
+++ b/tests/benchmark/cmd/benchmarks.go
@@ -220,5 +220,4 @@ func benchmarkInit(cmd *cobra.Command) {
 	} {
 		fn(cmd)
 	}
-
 }

--- a/tests/e2e/contracts.go
+++ b/tests/e2e/contracts.go
@@ -42,14 +42,14 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 	signer := testing.Alice.Signer
 
 	// Upload hello contract code.
-	nonce, err := ac.Nonce(ctx, client.RoundLatest, types.NewAddress(signer.Public()))
+	nonce, err := ac.Nonce(ctx, client.RoundLatest, testing.Alice.Address)
 	if err != nil {
 		return fmt.Errorf("failed to get nonce: %w", err)
 	}
 
 	tb := ct.Upload(contracts.ABIOasisV1, contracts.Policy{Everyone: &struct{}{}}, helloContractCode).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce)
 	_ = tb.AppendSign(ctx, signer)
 	var upload contracts.UploadResult
 	if err = tb.SubmitTx(ctx, &upload); err != nil {
@@ -67,7 +67,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+1)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+1)
 	_ = tb.AppendSign(ctx, signer)
 	var instance contracts.InstantiateResult
 	if err = tb.SubmitTx(ctx, &instance); err != nil {
@@ -85,7 +85,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+2)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+2)
 	_ = tb.AppendSign(ctx, signer)
 	var rawResult contracts.CallResult
 	if err = tb.SubmitTx(ctx, &rawResult); err != nil {
@@ -106,7 +106,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 	// Upload OAS20 contract code.
 	tb = ct.Upload(contracts.ABIOasisV1, contracts.Policy{Everyone: &struct{}{}}, oas20ContractCode).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+3)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+3)
 	_ = tb.AppendSign(ctx, signer)
 	var uploadOas20 contracts.UploadResult
 	if err = tb.SubmitTx(ctx, &uploadOas20); err != nil {
@@ -125,7 +125,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 				Decimals: 2,
 				InitialBalances: []oas20.InitialBalance{
 					{
-						Address: types.NewAddress(signer.Public()),
+						Address: testing.Alice.Address,
 						Amount:  *quantity.NewFromUint64(10_000),
 					},
 				},
@@ -134,7 +134,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+4)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+4)
 	_ = tb.AppendSign(ctx, signer)
 	var meta *client.TransactionMeta
 	var instanceOas20 contracts.InstantiateResult
@@ -181,7 +181,7 @@ func ContractsTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientCo
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+5)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+5)
 	_ = tb.AppendSign(ctx, signer)
 	if meta, err = tb.SubmitTxMeta(ctx, &rawResult); err != nil {
 		return fmt.Errorf("failed to call OAS20 transfer: %w", err)
@@ -251,7 +251,7 @@ OUTER:
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+6)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+6)
 	_ = tb.AppendSign(ctx, signer)
 	if err = tb.SubmitTx(ctx, &rawResult); err != nil {
 		return fmt.Errorf("failed to call OAS20 send: %w", err)
@@ -270,7 +270,7 @@ OUTER:
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+7)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+7)
 	_ = tb.AppendSign(ctx, signer)
 	if err = tb.SubmitTx(ctx, &rawResult); err != nil {
 		return fmt.Errorf("failed to call hello contract: %w", err)
@@ -319,7 +319,7 @@ OUTER:
 					Decimals: 2,
 					InitialBalances: []oas20.InitialBalance{
 						{
-							Address: types.NewAddress(signer.Public()),
+							Address: testing.Alice.Address,
 							Amount:  *quantity.NewFromUint64(10_000),
 						},
 					},
@@ -331,7 +331,7 @@ OUTER:
 		},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+8)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+8)
 	_ = tb.AppendSign(ctx, signer)
 	if err = tb.SubmitTx(ctx, &rawResult); err != nil {
 		return fmt.Errorf("failed to call hello contract: %w", err)
@@ -391,7 +391,7 @@ OUTER:
 		[]types.BaseUnits{},
 	).
 		SetFeeGas(1_000_000).
-		AppendAuthSignature(signer.Public(), nonce+9)
+		AppendAuthSignature(testing.Alice.SigSpec, nonce+9)
 	_ = tb.AppendSign(ctx, signer)
 	if err = tb.SubmitTx(ctx, &rawResult); err != nil {
 		return fmt.Errorf("failed to call hello contract: %w", err)

--- a/tests/e2e/simple_consensus.go
+++ b/tests/e2e/simple_consensus.go
@@ -55,13 +55,12 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 	consAccounts := consensusAccounts.NewV1(rtc)
 	ac := accounts.NewV1(rtc)
 
-	signer := testing.Alice.Signer
 	log.Info("alice depositing into runtime")
 	amount := types.NewBaseUnits(*quantity.NewFromUint64(50), consDenomination)
 	tb := consAccounts.Deposit(amount).
 		SetFeeConsensusMessages(1).
-		AppendAuthSignature(signer.Public(), 0)
-	_ = tb.AppendSign(ctx, signer)
+		AppendAuthSignature(testing.Alice.SigSpec, 0)
+	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		return err
 	}
@@ -85,7 +84,7 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 	log.Info("bob depositing into runtime")
 	tb = consAccounts.Deposit(amount).
 		SetFeeConsensusMessages(1).
-		AppendAuthSignature(testing.Bob.Signer.Public(), 0)
+		AppendAuthSignature(testing.Bob.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Bob.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		return err
@@ -109,7 +108,7 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 	log.Info("alice withdrawing")
 	tb = consAccounts.Withdraw(amount).
 		SetFeeConsensusMessages(1).
-		AppendAuthSignature(testing.Alice.Signer.Public(), 1)
+		AppendAuthSignature(testing.Alice.SigSpec, 1)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		return err
@@ -133,7 +132,7 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 	log.Info("charlie withdrawing")
 	tb = consAccounts.Withdraw(amount).
 		SetFeeConsensusMessages(1).
-		AppendAuthSignature(testing.Charlie.Signer.Public(), 0)
+		AppendAuthSignature(testing.Charlie.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Charlie.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		log.Info("charlie withdrawing failed (as expected)", "err", err)
@@ -144,7 +143,7 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 	log.Info("alice withdrawing with invalid nonce")
 	tb = consAccounts.Withdraw(amount).
 		SetFeeConsensusMessages(1).
-		AppendAuthSignature(testing.Alice.Signer.Public(), 1)
+		AppendAuthSignature(testing.Alice.SigSpec, 1)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		log.Info("alice invalid nonce failed request failed (as expected)", "err", err)
@@ -180,7 +179,7 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 	amount.Amount = *quantity.NewFromUint64(50)
 	tb = consAccounts.Deposit(amount).
 		SetFeeConsensusMessages(1).
-		AppendAuthSignature(testing.Dave.Signer.Public(), 0)
+		AppendAuthSignature(testing.Dave.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Dave.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		log.Info("dave depositing failed (as expected)", "err", err)

--- a/tests/e2e/txgen/generators.go
+++ b/tests/e2e/txgen/generators.go
@@ -32,7 +32,7 @@ func GenTransfer(
 	// First, query account balance.
 	var balance uint64
 	ac := accounts.NewV1(rtc)
-	b, err := ac.Balances(ctx, client.RoundLatest, types.NewAddress(acct.Public()))
+	b, err := ac.Balances(ctx, client.RoundLatest, types.NewAddress(sigspecForSigner(acct)))
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func GenTransfer(
 		To     types.Address   `json:"to"`
 		Amount types.BaseUnits `json:"amount"`
 	}{
-		To:     types.NewAddress(accts[rng.Intn(len(accts))].Public()),
+		To:     types.NewAddress(sigspecForSigner(accts[rng.Intn(len(accts))])),
 		Amount: types.NewBaseUnits(*quantity.NewFromUint64(uint64(rng.Int63n(int64(balance)))), types.NativeDenomination),
 	})
 	return tx, nil
@@ -61,7 +61,9 @@ func GenNonce(ctx context.Context, rtc client.RuntimeClient, rng *rand.Rand, acc
 	// We already have a helper for this, but do it manually here just to
 	// illustrate the concept.
 	var nonce uint64
-	if err := rtc.Query(ctx, client.RoundLatest, "accounts.Nonce", accounts.NonceQuery{Address: types.NewAddress(acct.Public())}, &nonce); err != nil {
+	if err := rtc.Query(ctx, client.RoundLatest, "accounts.Nonce", accounts.NonceQuery{
+		Address: types.NewAddress(sigspecForSigner(acct)),
+	}, &nonce); err != nil {
 		return nil, err
 	}
 	return nil, nil

--- a/tests/runtimes/simple-keyvalue/src/keyvalue.rs
+++ b/tests/runtimes/simple-keyvalue/src/keyvalue.rs
@@ -6,7 +6,6 @@ use oasis_runtime_sdk::{
     self as sdk,
     context::{Context, TxContext},
     core::common::crypto::hash::Hash,
-    crypto::signature,
     error::RuntimeError,
     keymanager::KeyPairId,
     module::{CallResult, Module as _},
@@ -14,7 +13,7 @@ use oasis_runtime_sdk::{
         core,
         core::{Error as CoreError, Module as Core, API as _},
     },
-    types::transaction,
+    types::{address, transaction},
 };
 
 pub mod types;
@@ -126,7 +125,7 @@ impl sdk::module::AuthHandler for Module {
                     auth_info: transaction::AuthInfo {
                         signer_info: vec![transaction::SignerInfo {
                             address_spec: transaction::AddressSpec::Signature(
-                                signature::PublicKey::Ed25519(special_greeting.from),
+                                address::SignatureAddressSpec::Ed25519(special_greeting.from),
                             ),
                             nonce: params.nonce,
                         }],


### PR DESCRIPTION
This separates public key types from address derivation schemes and changes secp256k1 into secp256k1eth.

TODO
* [x] Fix newly added ts-web/rt unit tests.