### PR TITLE
ts-web/core: compile proto for commonjs

### DIFF
--- a/client-sdk/ts-web/core/compile-proto.sh
+++ b/client-sdk/ts-web/core/compile-proto.sh
@@ -2,7 +2,7 @@
 pbjs \
     -t static-module \
     -o proto/index.js \
-    -w es6 \
+    -w commonjs \
     --no-create \
     --no-encode \
     --no-verify \


### PR DESCRIPTION
Our tsc output is also commonjs. This has better compatibility with other tools.

needed for #533