### PR TITLE
contract-sdk: use C abi instead of wasm

### DIFF
--- a/contract-sdk/specs/oas20/contract/src/lib.rs
+++ b/contract-sdk/specs/oas20/contract/src/lib.rs
@@ -1,6 +1,4 @@
 //! An OAS20 contract.
-#![feature(wasm_abi)]
-
 extern crate alloc;
 
 use oasis_contract_sdk::{self as sdk};

--- a/contract-sdk/src/abi/crypto.rs
+++ b/contract-sdk/src/abi/crypto.rs
@@ -1,7 +1,7 @@
 //! Crypto helpers ABI.
 
 #[link(wasm_import_module = "crypto")]
-extern "wasm" {
+extern "C" {
     #[link_name = "ecdsa_recover"]
     pub(crate) fn crypto_ecdsa_recover(
         input_ptr: u32,

--- a/contract-sdk/src/abi/env.rs
+++ b/contract-sdk/src/abi/env.rs
@@ -14,9 +14,9 @@ use crate::{
 };
 
 #[link(wasm_import_module = "env")]
-extern "wasm" {
+extern "C" {
     #[link_name = "query"]
-    fn env_query(query_ptr: u32, query_len: u32) -> HostRegion;
+    fn env_query(query_ptr: u32, query_len: u32) -> *const HostRegion;
 
     #[link_name = "address_for_instance"]
     fn env_address_for_instance(instance_id: u64, dst_ptr: u32, dst_len: u32);
@@ -26,7 +26,8 @@ extern "wasm" {
 pub fn query(query: QueryRequest) -> QueryResponse {
     let query_data = cbor::to_vec(query);
     let query_region = HostRegionRef::from_slice(&query_data);
-    let rsp_region = unsafe { env_query(query_region.offset, query_region.length) };
+    let rsp_ptr = unsafe { env_query(query_region.offset, query_region.length) };
+    let rsp_region = unsafe { HostRegion::deref(rsp_ptr) };
 
     // We expect the host to produce valid responses and abort otherwise.
     cbor::from_slice(&rsp_region.into_vec()).unwrap()

--- a/contract-sdk/src/abi/mod.rs
+++ b/contract-sdk/src/abi/mod.rs
@@ -7,11 +7,11 @@ pub mod env;
 pub mod storage;
 
 #[no_mangle]
-pub extern "wasm" fn allocate(length: u32) -> u32 {
+pub extern "C" fn allocate(length: u32) -> u32 {
     memory::allocate_host(length)
 }
 
 #[no_mangle]
-pub extern "wasm" fn deallocate(offset: u32, length: u32) {
+pub extern "C" fn deallocate(offset: u32, length: u32) {
     memory::deallocate_host(offset, length)
 }

--- a/contract-sdk/src/memory.rs
+++ b/contract-sdk/src/memory.rs
@@ -48,6 +48,21 @@ impl HostRegion {
 
         unsafe { Vec::from_raw_parts(ptr, self.length as usize, self.length as usize) }
     }
+
+    /// Returns a new region by dereferencing a pointer to the region.
+    ///
+    /// This does not yet transfer memory ownership from the host.
+    ///
+    /// # Safety
+    ///
+    /// This is safe as long as the pointer is a valid pointer to the region struct.
+    pub unsafe fn deref(arg: *const HostRegion) -> Self {
+        let hr = &*arg;
+        HostRegion {
+            offset: hr.offset,
+            length: hr.length,
+        }
+    }
 }
 
 /// Reference to a host region.

--- a/runtime-sdk/modules/contracts/src/abi/oasis/env.rs
+++ b/runtime-sdk/modules/contracts/src/abi/oasis/env.rs
@@ -24,7 +24,7 @@ impl<Cfg: Config> OasisV1<Cfg> {
         let _ = instance.link_function(
             "env",
             "query",
-            |ctx, query: (u32, u32)| -> Result<(u32, u32), wasm3::Trap> {
+            |ctx, query: (u32, u32)| -> Result<u32, wasm3::Trap> {
                 // Make sure function was called in valid context.
                 let ec = ctx.context.ok_or(wasm3::Trap::Abort)?;
 
@@ -51,9 +51,7 @@ impl<Cfg: Config> OasisV1<Cfg> {
                 //
                 // This makes sure that the call context is unset to avoid any potential issues
                 // with reentrancy as attempting to re-enter one of the linked function will fail.
-                let result_region = Self::serialize_and_allocate(ctx.instance, result)?;
-
-                Ok(result_region.to_arg())
+                Self::serialize_and_allocate_as_ptr(ctx.instance, result).map_err(|err| err.into())
             },
         );
 

--- a/tests/contracts/hello/src/lib.rs
+++ b/tests/contracts/hello/src/lib.rs
@@ -1,6 +1,4 @@
 //! An example hello world contract also used in unit tests.
-#![feature(wasm_abi)]
-
 extern crate alloc;
 
 use oasis_contract_sdk::{


### PR DESCRIPTION
The WASM abi seems quite broken, there are various problems with it:
- problems with u128 https://github.com/rust-lang/rust/issues/88207
- problems with compiling multivalue functions https://github.com/ptrus/wasm-bug

Switch to using C abi. This requires modifying the exported functions to not use multivalue returns (which was only used for returning `HostRegion`s currently). 