### PR TITLE
ts-web/core: fix runtime client SubmitTxNoWait return type

### DIFF
--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -382,7 +382,7 @@ const methodDescriptorRuntimeClientSubmitTxMeta = createMethodDescriptorUnary<
 >('RuntimeClient', 'SubmitTxMeta');
 const methodDescriptorRuntimeClientSubmitTxNoWait = createMethodDescriptorUnary<
     types.RuntimeClientSubmitTxRequest,
-    Uint8Array
+    void
 >('RuntimeClient', 'SubmitTxNoWait');
 const methodDescriptorRuntimeClientCheckTx = createMethodDescriptorUnary<
     types.RuntimeClientCheckTxRequest,


### PR DESCRIPTION
had mistakenly been Uint8Array, probably from copy-pasting the SubmitTx declaration