### PR TITLE
ts-web/rt: add SubmitTxNoWait to transaction wrapper

### DIFF
--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.2.0-alpha4:
+## Unreleased changes
+
+New features:
+
+- You can now use SubmitTxNoWait from a transaction wrapper.
+
+## v0.2.0-alpha4
 
 Spotlight change:
 

--- a/client-sdk/ts-web/rt/src/wrapper.ts
+++ b/client-sdk/ts-web/rt/src/wrapper.ts
@@ -75,6 +75,13 @@ export class TransactionWrapper<BODY, OK> {
         if (result.fail) throw result.fail;
         return result.ok as OK;
     }
+
+    async submitNoWait(nic: oasis.client.NodeInternal) {
+        await nic.runtimeClientSubmitTxNoWait({
+            runtime_id: this.runtimeID,
+            data: oasis.misc.toCBOR(this.unverifiedTransaction),
+        });
+    }
 }
 
 export class QueryWrapper<ARGS, DATA> {


### PR DESCRIPTION
people were saying SubmitTxNoWait was good, so let's add that to the transaction wrapper. no way to get the transaction result this way though.

no tests

reopening from #558