### PR TITLE
client-sdk/go: Add support for GetLastRetainedBlock query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-client"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.3#f599be7597caa6ef0e02817801f787f5ff4b0dcc"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.4#aa6167c56ed7fb9b2edb86adea69400cc4a9a22c"
 dependencies = [
  "anyhow",
  "futures",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-keymanager-api-common"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.3#f599be7597caa6ef0e02817801f787f5ff4b0dcc"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.4#aa6167c56ed7fb9b2edb86adea69400cc4a9a22c"
 dependencies = [
  "anyhow",
  "base64",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-keymanager-client"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.3#f599be7597caa6ef0e02817801f787f5ff4b0dcc"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.4#aa6167c56ed7fb9b2edb86adea69400cc4a9a22c"
 dependencies = [
  "futures",
  "io-context",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-runtime"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.3#f599be7597caa6ef0e02817801f787f5ff4b0dcc"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.4#aa6167c56ed7fb9b2edb86adea69400cc4a9a22c"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/client-sdk/go/client/client.go
+++ b/client-sdk/go/client/client.go
@@ -64,6 +64,9 @@ type RuntimeClient interface {
 	// GetBlock fetches the given runtime block.
 	GetBlock(ctx context.Context, round uint64) (*block.Block, error)
 
+	// GetLastRetainedBlock returns the last retained block.
+	GetLastRetainedBlock(ctx context.Context) (*block.Block, error)
+
 	// GetTransactions returns all transactions that are part of a given block.
 	GetTransactions(ctx context.Context, round uint64) ([]*types.UnverifiedTransaction, error)
 
@@ -290,6 +293,11 @@ func (rc *runtimeClient) GetBlock(ctx context.Context, round uint64) (*block.Blo
 		RuntimeID: rc.runtimeID,
 		Round:     round,
 	})
+}
+
+// Implements RuntimeClient.
+func (rc *runtimeClient) GetLastRetainedBlock(ctx context.Context) (*block.Block, error) {
+	return rc.cc.GetLastRetainedBlock(ctx, rc.runtimeID)
 }
 
 // Implements RuntimeClient.

--- a/client-sdk/go/go.mod
+++ b/client-sdk/go/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
-	github.com/oasisprotocol/oasis-core/go v0.2103.3
+	github.com/oasisprotocol/oasis-core/go v0.2103.4
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	google.golang.org/grpc v1.41.0

--- a/client-sdk/go/go.sum
+++ b/client-sdk/go/go.sum
@@ -817,8 +817,8 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84/go.mo
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.3 h1:bzj8e6Y71qiylvXld065GGWow0TSEY9Usq2aLsZv16w=
-github.com/oasisprotocol/oasis-core/go v0.2103.3/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.4 h1:LOdXcZkwOdMrBT8BHkI6ik2WFJKpZ/f6Kb4PXB2TXh4=
+github.com/oasisprotocol/oasis-core/go v0.2103.4/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2/go.mod h1:agEnj5cjmg55z8CtL/Nva9LqxR4402T1TFPC4kuNBMc=

--- a/client-sdk/ts-web/core/reflect-go/go.mod
+++ b/client-sdk/ts-web/core/reflect-go/go.mod
@@ -2,4 +2,4 @@ module github.com/oasisprotocol/oasis-sdk/client-sdk/ts-web/core/reflect-go
 
 go 1.16
 
-require github.com/oasisprotocol/oasis-core/go v0.2103.3
+require github.com/oasisprotocol/oasis-core/go v0.2103.4

--- a/client-sdk/ts-web/core/reflect-go/go.sum
+++ b/client-sdk/ts-web/core/reflect-go/go.sum
@@ -820,8 +820,8 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 h1:qnvTxmtjcuRH5NiI0Kiku6TXi2VReR/PxHFf3ahFYrg=
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2103.3 h1:bzj8e6Y71qiylvXld065GGWow0TSEY9Usq2aLsZv16w=
-github.com/oasisprotocol/oasis-core/go v0.2103.3/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.4 h1:LOdXcZkwOdMrBT8BHkI6ik2WFJKpZ/f6Kb4PXB2TXh4=
+github.com/oasisprotocol/oasis-core/go v0.2103.4/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -7,10 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 cbor = { version = "0.2.1", package = "oasis-cbor" }
-oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.3" }
-oasis-core-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.3" }
-oasis-core-keymanager-api-common = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.3" }
-oasis-core-keymanager-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.3" }
+oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.4" }
+oasis-core-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.4" }
+oasis-core-keymanager-api-common = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.4" }
+oasis-core-keymanager-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.4" }
 oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 
 # Third party.

--- a/tests/benchmark/go.mod
+++ b/tests/benchmark/go.mod
@@ -15,7 +15,7 @@ replace (
 )
 
 require (
-	github.com/oasisprotocol/oasis-core/go v0.2103.3
+	github.com/oasisprotocol/oasis-core/go v0.2103.4
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1

--- a/tests/benchmark/go.sum
+++ b/tests/benchmark/go.sum
@@ -923,8 +923,8 @@ github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.3 h1:bzj8e6Y71qiylvXld065GGWow0TSEY9Usq2aLsZv16w=
-github.com/oasisprotocol/oasis-core/go v0.2103.3/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.4 h1:LOdXcZkwOdMrBT8BHkI6ik2WFJKpZ/f6Kb4PXB2TXh4=
+github.com/oasisprotocol/oasis-core/go v0.2103.4/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=

--- a/tests/consts.sh
+++ b/tests/consts.sh
@@ -6,7 +6,7 @@
 
 # Released version from GitHub Releases.
 # e.g. '21.1.2'
-OASIS_CORE_VERSION='21.3.3'
+OASIS_CORE_VERSION='21.3.4'
 
 # Development version from GitHub Actions.
 # e.g. '58512799'
@@ -16,4 +16,4 @@ GITHUB_ARTIFACT_VERSION=''
 
 # Version from Buildkite.
 # e.g. '4759'
-BUILD_NUMBER='6426' # v21.3.3
+BUILD_NUMBER='6483' # v21.3.4

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -22,7 +22,7 @@ replace (
 require (
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
-	github.com/oasisprotocol/oasis-core/go v0.2103.3
+	github.com/oasisprotocol/oasis-core/go v0.2103.4
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.41.0
 )

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -930,8 +930,8 @@ github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.3 h1:bzj8e6Y71qiylvXld065GGWow0TSEY9Usq2aLsZv16w=
-github.com/oasisprotocol/oasis-core/go v0.2103.3/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.4 h1:LOdXcZkwOdMrBT8BHkI6ik2WFJKpZ/f6Kb4PXB2TXh4=
+github.com/oasisprotocol/oasis-core/go v0.2103.4/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -28,6 +28,7 @@ var (
 		ContractsTest,
 		ConfidentialTest,
 		TransactionsQueryTest,
+		BlockQueryTest,
 	})
 
 	// SimpleConsensusRuntime is the simple-consensus runtime test.

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -360,6 +360,27 @@ func TransactionsQueryTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.
 	return nil
 }
 
+// BlockQueryTest tests block queries.
+func BlockQueryTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+	ctx := context.Background()
+
+	genBlk, err := rtc.GetGenesisBlock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get genesis block: %w", err)
+	}
+
+	lrBlk, err := rtc.GetLastRetainedBlock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get last retained block: %w", err)
+	}
+
+	if genBlk.Header.Round != lrBlk.Header.Round {
+		return fmt.Errorf("expected genesis block round (%d) to equal last retained block round (%d)", genBlk.Header.Round, lrBlk.Header.Round)
+	}
+
+	return nil
+}
+
 // KVEventTest tests key insert/remove events.
 func KVEventTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
 	signer := testing.Alice.Signer


### PR DESCRIPTION
Blocked on support in Oasis Core, see https://github.com/oasisprotocol/oasis-core/issues/4334.