### PR TITLE
runtime-sdk: Support consensus denomination scaling

### DIFF
--- a/client-sdk/go/modules/accounts/accounts.go
+++ b/client-sdk/go/modules/accounts/accounts.go
@@ -15,9 +15,10 @@ const (
 	methodTransfer = "accounts.Transfer"
 
 	// Queries.
-	methodNonce     = "accounts.Nonce"
-	methodBalances  = "accounts.Balances"
-	methodAddresses = "accounts.Addresses"
+	methodNonce            = "accounts.Nonce"
+	methodBalances         = "accounts.Balances"
+	methodAddresses        = "accounts.Addresses"
+	methodDenominationInfo = "accounts.DenominationInfo"
 )
 
 // V1 is the v1 accounts module interface.
@@ -35,6 +36,9 @@ type V1 interface {
 
 	// Addresses queries all account addresses.
 	Addresses(ctx context.Context, round uint64, denomination types.Denomination) (Addresses, error)
+
+	// DenominationInfo queries the information about a given denomination.
+	DenominationInfo(ctx context.Context, round uint64, denomination types.Denomination) (*DenominationInfo, error)
 
 	// GetEvents returns all account events emitted in a given block.
 	GetEvents(ctx context.Context, round uint64) ([]*Event, error)
@@ -80,6 +84,16 @@ func (a *v1) Addresses(ctx context.Context, round uint64, denomination types.Den
 		return nil, err
 	}
 	return addresses, nil
+}
+
+// Implements V1.
+func (a *v1) DenominationInfo(ctx context.Context, round uint64, denomination types.Denomination) (*DenominationInfo, error) {
+	var info DenominationInfo
+	err := a.rc.Query(ctx, round, methodDenominationInfo, &DenominationInfoQuery{Denomination: denomination}, &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/accounts/types.go
+++ b/client-sdk/go/modules/accounts/types.go
@@ -30,6 +30,17 @@ type AddressesQuery struct {
 	Denomination types.Denomination `json:"denomination"`
 }
 
+// DenominationInfoQuery are the arguments for the accounts.DenominationInfo query.
+type DenominationInfoQuery struct {
+	Denomination types.Denomination `json:"denomination"`
+}
+
+// DenominationInfo represents information about a denomination.
+type DenominationInfo struct {
+	// Decimals is the number of decimals that the denomination is using.
+	Decimals uint8 `json:"decimals"`
+}
+
 // Addresses is the response of the accounts.Addresses query.
 type Addresses []types.Address
 

--- a/client-sdk/go/modules/consensus/consensus.go
+++ b/client-sdk/go/modules/consensus/consensus.go
@@ -1,0 +1,37 @@
+package consensus
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+)
+
+const (
+	// Queries.
+	methodParameters = "consensus.Parameters"
+)
+
+// V1 is the v1 consensus module interface.
+type V1 interface {
+	// Parameters queries the consensus module parameters.
+	Parameters(ctx context.Context, round uint64) (*Parameters, error)
+}
+
+type v1 struct {
+	rc client.RuntimeClient
+}
+
+// Implements V1.
+func (a *v1) Parameters(ctx context.Context, round uint64) (*Parameters, error) {
+	var params Parameters
+	err := a.rc.Query(ctx, round, methodParameters, nil, &params)
+	if err != nil {
+		return nil, err
+	}
+	return &params, nil
+}
+
+// NewV1 generates a V1 client helper for the consensus module.
+func NewV1(rc client.RuntimeClient) V1 {
+	return &v1{rc: rc}
+}

--- a/client-sdk/go/modules/consensus/types.go
+++ b/client-sdk/go/modules/consensus/types.go
@@ -1,0 +1,9 @@
+package consensus
+
+import "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+// Parameters are the parameters for the consensus module.
+type Parameters struct {
+	ConsensusDenomination  types.Denomination `json:"consensus_denomination"`
+	ConsensusScalingFactor uint64             `json:"consensus_scaling_factor"`
+}

--- a/client-sdk/ts-web/rt/playground/src/consensus.js
+++ b/client-sdk/ts-web/rt/playground/src/consensus.js
@@ -87,9 +87,22 @@ export const playground = (async function () {
 
         const consensusChainContext = await nic.consensusGetChainContext();
 
+        console.log('query denomination info');
+        const di = await accountsWrapper
+            .queryDenominationInfo()
+            .setArgs({
+                denomination: oasis.misc.fromString('TEST'),
+            })
+            .query(nic);
+        if (di.decimals !== 12) {
+            throw new Error(`unexpected number of decimals (expected: 12 got: ${di.decimals})`);
+        }
+
         console.log('alice deposit into runtime');
+        // NOTE: The test runtime uses a scaling factor of 1000 so all balances in the runtime are
+        //       1000x larger than in the consensus layer.
         const DEPOSIT_AMNT = /** @type {oasisRT.types.BaseUnits} */ ([
-            oasis.quantity.fromBigInt(50n),
+            oasis.quantity.fromBigInt(50_000n),
             oasis.misc.fromString('TEST'),
         ]);
         const twDeposit = consensusWrapper
@@ -195,7 +208,7 @@ export const playground = (async function () {
             nonce: nonce2,
         });
         const WITHDRAW_AMNT = /** @type {oasisRT.types.BaseUnits} */ ([
-            oasis.quantity.fromBigInt(25n),
+            oasis.quantity.fromBigInt(25_000n),
             oasis.misc.fromString('TEST'),
         ]);
         const twWithdraw = consensusWrapper

--- a/client-sdk/ts-web/rt/src/accounts.ts
+++ b/client-sdk/ts-web/rt/src/accounts.ts
@@ -13,6 +13,7 @@ export const MODULE_NAME = 'accounts';
 export const ERR_INVALID_ARGUMENT_CODE = 1;
 export const ERR_INSUFFICIENT_BALANCE_CODE = 2;
 export const ERR_FORBIDDEN_CODE = 3;
+export const ERR_NOT_FOUND_CODE = 4;
 
 // Callable methods.
 export const METHOD_TRANSFER = 'accounts.Transfer';
@@ -20,6 +21,7 @@ export const METHOD_TRANSFER = 'accounts.Transfer';
 export const METHOD_NONCE = 'accounts.Nonce';
 export const METHOD_BALANCES = 'accounts.Balances';
 export const METHOD_ADDRESSES = 'accounts.Addresses';
+export const METHOD_DENOMINATION_INFO = 'accounts.DenominationInfo';
 
 export const EVENT_TRANSFER_CODE = 1;
 export const EVENT_BURN_CODE = 2;
@@ -46,6 +48,12 @@ export class Wrapper extends wrapper.Base {
 
     queryAddresses() {
         return this.query<types.AccountsAddressesQuery, Uint8Array[]>(METHOD_ADDRESSES);
+    }
+
+    queryDenominationInfo() {
+        return this.query<types.AccountsDenominationInfoQuery, types.AccountsDenominationInfo>(
+            METHOD_DENOMINATION_INFO,
+        );
     }
 }
 

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -47,6 +47,20 @@ export interface AccountsAddressesQuery {
 }
 
 /**
+ * Arguments for the DenominationInfo query.
+ */
+export interface AccountsDenominationInfoQuery {
+    denomination: Uint8Array;
+}
+
+/**
+ * Information about a denomination.
+ */
+export interface AccountsDenominationInfo {
+    decimals: number;
+}
+
+/**
  * Transfer call.
  */
 export interface AccountsTransfer {

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -1,6 +1,7 @@
 //! Oasis runtime SDK.
 #![deny(rust_2018_idioms, unreachable_pub)]
 #![forbid(unsafe_code)]
+#![feature(int_log)]
 
 pub mod callformat;
 pub mod context;

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -206,7 +206,7 @@ fn test_api_tx_transfer_disabled() {
             parameters: Parameters {
                 transfers_disabled: true,
                 debug_disable_nonce_check: false,
-                gas_costs: Default::default(),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -310,6 +310,15 @@ pub(crate) fn init_accounts<C: Context>(ctx: &mut C) {
                 let mut total_supplies = BTreeMap::new();
                 total_supplies.insert(Denomination::NATIVE, 1_000_000);
                 total_supplies
+            },
+            parameters: Parameters {
+                denomination_infos: {
+                    let mut denomination_infos = BTreeMap::new();
+                    denomination_infos
+                        .insert(Denomination::NATIVE, DenominationInfo { decimals: 9 });
+                    denomination_infos
+                },
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -1124,4 +1133,30 @@ fn test_get_set_balance() {
     )
     .unwrap();
     assert_eq!(balance, 500_000);
+}
+
+#[test]
+fn test_query_denomination_info() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    init_accounts(&mut ctx);
+
+    let di = Accounts::query_denomination_info(
+        &mut ctx,
+        DenominationInfoQuery {
+            denomination: Denomination::NATIVE,
+        },
+    )
+    .unwrap();
+    assert_eq!(di.decimals, 9);
+
+    // Query for missing info should fail.
+    Accounts::query_denomination_info(
+        &mut ctx,
+        DenominationInfoQuery {
+            denomination: "MISSING".parse().unwrap(),
+        },
+    )
+    .unwrap_err();
 }

--- a/runtime-sdk/src/modules/accounts/types.rs
+++ b/runtime-sdk/src/modules/accounts/types.rs
@@ -44,3 +44,16 @@ pub struct BalancesQuery {
 pub struct AccountBalances {
     pub balances: BTreeMap<token::Denomination, u128>,
 }
+
+/// Arguments for the DenominationInfo query.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct DenominationInfoQuery {
+    pub denomination: token::Denomination,
+}
+
+/// Information about a denomination.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct DenominationInfo {
+    /// Number of decimals that the denomination is using.
+    pub decimals: u8,
+}

--- a/runtime-sdk/src/modules/consensus/test.rs
+++ b/runtime-sdk/src/modules/consensus/test.rs
@@ -10,6 +10,7 @@ use oasis_core_runtime::{
 
 use crate::{
     context::{BatchContext, Context},
+    module::Module as _,
     modules::consensus::Module as Consensus,
     testing::{keys, mock},
     types::{
@@ -18,7 +19,7 @@ use crate::{
     },
 };
 
-use super::API as _;
+use super::{Genesis, Parameters, API as _};
 
 #[test]
 fn test_api_transfer_invalid_denomination() {
@@ -80,6 +81,83 @@ fn test_api_transfer() {
 }
 
 #[test]
+fn test_api_transfer_scaling_unrepresentable() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::set_params(
+        ctx.runtime_state(),
+        Parameters {
+            consensus_scaling_factor: 1_000, // Everything is multiplied by 1000.
+            ..Default::default()
+        },
+    );
+
+    ctx.with_tx(0, mock::transaction(), |mut tx_ctx, _call| {
+        let hook_name = "test_event_handler";
+        // Amount is not representable as it must be in multiples of 1000.
+        let amount = BaseUnits::new(500, Denomination::from_str("TEST").unwrap());
+
+        assert!(Consensus::transfer(
+            &mut tx_ctx,
+            keys::alice::address(),
+            &amount,
+            MessageEventHookInvocation::new(hook_name.to_string(), 0),
+        )
+        .is_err());
+    });
+}
+
+#[test]
+fn test_api_transfer_scaling() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::set_params(
+        ctx.runtime_state(),
+        Parameters {
+            consensus_scaling_factor: 1_000, // Everything is multiplied by 1000.
+            ..Default::default()
+        },
+    );
+
+    ctx.with_tx(0, mock::transaction(), |mut tx_ctx, _call| {
+        let hook_name = "test_event_handler";
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap());
+        Consensus::transfer(
+            &mut tx_ctx,
+            keys::alice::address(),
+            &amount,
+            MessageEventHookInvocation::new(hook_name.to_string(), 0),
+        )
+        .expect("transfer should succeed");
+
+        let (_, msgs) = tx_ctx.commit();
+        assert_eq!(1, msgs.len(), "one message should be emitted");
+        let (msg, hook) = msgs.first().unwrap();
+
+        assert_eq!(
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::Transfer(staking::Transfer {
+                    to: keys::alice::address().into(),
+                    // Amount should be properly scaled.
+                    amount: 1u128.into(),
+                })
+            )),
+            msg,
+            "emitted message should match"
+        );
+
+        assert_eq!(
+            hook_name.to_string(),
+            hook.hook_name,
+            "emitted hook should match"
+        )
+    });
+}
+
+#[test]
 fn test_api_withdraw() {
     let mut mock = mock::Mock::default();
     let mut ctx = mock.create_ctx();
@@ -105,6 +183,54 @@ fn test_api_withdraw() {
                 StakingMessage::Withdraw(staking::Withdraw {
                     from: keys::alice::address().into(),
                     amount: amount.amount().into(),
+                })
+            )),
+            msg,
+            "emitted message should match"
+        );
+
+        assert_eq!(
+            hook_name.to_string(),
+            hook.hook_name,
+            "emitted hook should match"
+        )
+    });
+}
+
+#[test]
+fn test_api_withdraw_scaling() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::set_params(
+        ctx.runtime_state(),
+        Parameters {
+            consensus_scaling_factor: 1_000, // Everything is multiplied by 1000.
+            ..Default::default()
+        },
+    );
+
+    ctx.with_tx(0, mock::transaction(), |mut tx_ctx, _call| {
+        let hook_name = "test_event_handler";
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap());
+        Consensus::withdraw(
+            &mut tx_ctx,
+            keys::alice::address(),
+            &amount,
+            MessageEventHookInvocation::new(hook_name.to_string(), 0),
+        )
+        .expect("withdraw should succeed");
+
+        let (_, msgs) = tx_ctx.commit();
+        assert_eq!(1, msgs.len(), "one message should be emitted");
+        let (msg, hook) = msgs.first().unwrap();
+
+        assert_eq!(
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::Withdraw(staking::Withdraw {
+                    from: keys::alice::address().into(),
+                    amount: 1u128.into(),
                 })
             )),
             msg,
@@ -160,20 +286,28 @@ fn test_api_escrow() {
 }
 
 #[test]
-fn test_api_reclaim_escrow() {
+fn test_api_escrow_scaling() {
     let mut mock = mock::Mock::default();
     let mut ctx = mock.create_ctx();
 
+    Consensus::set_params(
+        ctx.runtime_state(),
+        Parameters {
+            consensus_scaling_factor: 1_000, // Everything is multiplied by 1000.
+            ..Default::default()
+        },
+    );
+
     ctx.with_tx(0, mock::transaction(), |mut tx_ctx, _call| {
         let hook_name = "test_event_handler";
-        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap()); // TODO: shares.
-        Consensus::reclaim_escrow(
+        let amount = BaseUnits::new(1_000, Denomination::from_str("TEST").unwrap());
+        Consensus::escrow(
             &mut tx_ctx,
             keys::alice::address(),
             &amount,
             MessageEventHookInvocation::new(hook_name.to_string(), 0),
         )
-        .expect("reclaim escrow should succeed");
+        .expect("escrow should succeed");
 
         let (_, msgs) = tx_ctx.commit();
         assert_eq!(1, msgs.len(), "one message should be emitted");
@@ -182,9 +316,9 @@ fn test_api_reclaim_escrow() {
         assert_eq!(
             &Message::Staking(Versioned::new(
                 0,
-                StakingMessage::ReclaimEscrow(staking::ReclaimEscrow {
+                StakingMessage::AddEscrow(staking::Escrow {
                     account: keys::alice::address().into(),
-                    shares: amount.amount().into(),
+                    amount: 1u128.into(),
                 })
             )),
             msg,
@@ -198,6 +332,55 @@ fn test_api_reclaim_escrow() {
         )
     });
 }
+
+#[test]
+fn test_api_reclaim_escrow() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::set_params(
+        ctx.runtime_state(),
+        Parameters {
+            consensus_scaling_factor: 1_000, // NOTE: Should be ignored for share amounts.
+            ..Default::default()
+        },
+    );
+
+    ctx.with_tx(0, mock::transaction(), |mut tx_ctx, _call| {
+        let hook_name = "test_event_handler";
+        let amount = 1_000u128;
+        Consensus::reclaim_escrow(
+            &mut tx_ctx,
+            keys::alice::address(),
+            amount,
+            MessageEventHookInvocation::new(hook_name.to_string(), 0),
+        )
+        .expect("reclaim escrow should succeed");
+
+        let (_, msgs) = tx_ctx.commit();
+        assert_eq!(1, msgs.len(), "one message should be emitted");
+        let (msg, hook) = msgs.first().unwrap();
+
+        assert_eq!(
+            &Message::Staking(Versioned::new(
+                0,
+                StakingMessage::ReclaimEscrow(staking::ReclaimEscrow {
+                    account: keys::alice::address().into(),
+                    shares: amount.into(),
+                })
+            )),
+            msg,
+            "emitted message should match"
+        );
+
+        assert_eq!(
+            hook_name.to_string(),
+            hook.hook_name,
+            "emitted hook should match"
+        )
+    });
+}
+
 #[test]
 fn test_api_account() {
     let mut mock = mock::Mock::default();
@@ -211,4 +394,101 @@ fn test_api_account() {
         acc.general.balance,
         "consensus balance should be zero"
     )
+}
+
+#[test]
+fn test_api_scaling() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::set_params(
+        ctx.runtime_state(),
+        Parameters {
+            consensus_scaling_factor: 1_000, // Everything is multiplied by 1000.
+            ..Default::default()
+        },
+    );
+
+    // Not representable.
+    Consensus::amount_to_consensus(&mut ctx, 100).unwrap_err();
+    Consensus::amount_to_consensus(&mut ctx, 1100).unwrap_err();
+    Consensus::amount_to_consensus(&mut ctx, 2500).unwrap_err();
+    Consensus::amount_to_consensus(&mut ctx, 2500).unwrap_err();
+    Consensus::amount_to_consensus(&mut ctx, 1_000_250).unwrap_err();
+    Consensus::amount_to_consensus(&mut ctx, 1_000_001).unwrap_err();
+    // Scaling.
+    assert_eq!(Consensus::amount_to_consensus(&mut ctx, 0).unwrap(), 0);
+    assert_eq!(Consensus::amount_to_consensus(&mut ctx, 1000).unwrap(), 1);
+    assert_eq!(Consensus::amount_to_consensus(&mut ctx, 2000).unwrap(), 2);
+    assert_eq!(
+        Consensus::amount_to_consensus(&mut ctx, 1_000_000).unwrap(),
+        1000
+    );
+    assert_eq!(
+        Consensus::amount_to_consensus(&mut ctx, 1_234_000).unwrap(),
+        1234
+    );
+    assert_eq!(Consensus::amount_from_consensus(&mut ctx, 0).unwrap(), 0);
+    assert_eq!(Consensus::amount_from_consensus(&mut ctx, 1).unwrap(), 1000);
+    assert_eq!(
+        Consensus::amount_from_consensus(&mut ctx, 10).unwrap(),
+        10_000
+    );
+    assert_eq!(
+        Consensus::amount_from_consensus(&mut ctx, 1000).unwrap(),
+        1_000_000
+    );
+}
+
+#[test]
+fn test_query_parameters() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    let params = Parameters {
+        consensus_denomination: Denomination::NATIVE,
+        consensus_scaling_factor: 1_000,
+    };
+    Consensus::set_params(ctx.runtime_state(), params.clone());
+
+    let queried_params = Consensus::query_parameters(&mut ctx, ()).unwrap();
+    assert_eq!(queried_params, params);
+}
+
+#[test]
+#[should_panic]
+fn test_init_bad_scaling_factor_1() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::init(
+        &mut ctx,
+        Genesis {
+            parameters: Parameters {
+                consensus_denomination: Denomination::NATIVE,
+                // Zero scaling factor is invalid.
+                consensus_scaling_factor: 0,
+            },
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_init_bad_scaling_factor_2() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    Consensus::init(
+        &mut ctx,
+        Genesis {
+            parameters: Parameters {
+                consensus_denomination: Denomination::NATIVE,
+                // Scaling factor that is not a power of 10 is invalid.
+                consensus_scaling_factor: 1230,
+            },
+            ..Default::default()
+        },
+    );
 }

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -11,13 +11,36 @@ impl sdk::Runtime for Runtime {
 
     type Modules = (
         modules::accounts::Module,
+        modules::consensus::Module,
         modules::consensus_accounts::Module<modules::accounts::Module, modules::consensus::Module>,
         modules::core::Module,
     );
 
     fn genesis_state() -> <Self::Modules as sdk::module::MigrationHandler>::Genesis {
         (
-            Default::default(),
+            modules::accounts::Genesis {
+                parameters: modules::accounts::Parameters {
+                    denomination_infos: {
+                        let mut denomination_infos = BTreeMap::new();
+                        denomination_infos.insert(
+                            "TEST".parse().unwrap(),
+                            modules::accounts::types::DenominationInfo {
+                                decimals: 12, // Consensus layer has 9 and we use a scaling factor of 1000.
+                            },
+                        );
+                        denomination_infos
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            modules::consensus::Genesis {
+                parameters: modules::consensus::Parameters {
+                    consensus_denomination: "TEST".parse().unwrap(),
+                    // Test scaling consensus base units when transferring them into the runtime.
+                    consensus_scaling_factor: 1000,
+                },
+            },
             modules::consensus_accounts::Genesis {
                 parameters: modules::consensus_accounts::Parameters {
                     // These are free, in order to simplify testing. We do test gas accounting


### PR DESCRIPTION
TODO
* [x] More unit tests.
* [x] E2E tests.
* [x] Queries for retrieving the consensus module parameters (e.g. the scaling factor).
* [x] Support specifying `DenominationInfo` in accounts module.
* [x] Queries for retrieving the `DenominationInfo` in accounts module.