### PR TITLE
ts-web/rt: v0.2.0-alpha5

### DIFF
--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -20,7 +20,7 @@
         "@oasisprotocol/client": "^0.1.0-alpha7"
     },
     "devDependencies": {
-        "@oasisprotocol/client-rt": "^0.2.0-alpha4",
+        "@oasisprotocol/client-rt": "^0.2.0-alpha5",
         "buffer": "^6.0.3",
         "cypress": "^8.7.0",
         "prettier": "^2.4.1",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -47,7 +47,7 @@
                 "@oasisprotocol/client": "^0.1.0-alpha7"
             },
             "devDependencies": {
-                "@oasisprotocol/client-rt": "^0.2.0-alpha4",
+                "@oasisprotocol/client-rt": "^0.2.0-alpha5",
                 "buffer": "^6.0.3",
                 "cypress": "^8.7.0",
                 "prettier": "^2.4.1",
@@ -8641,7 +8641,7 @@
         },
         "rt": {
             "name": "@oasisprotocol/client-rt",
-            "version": "0.2.0-alpha4",
+            "version": "0.2.0-alpha5",
             "dependencies": {
                 "@oasisprotocol/client": "^0.1.0-alpha7",
                 "elliptic": "^6.5.3",
@@ -9514,7 +9514,7 @@
             "version": "file:ext-utils",
             "requires": {
                 "@oasisprotocol/client": "^0.1.0-alpha7",
-                "@oasisprotocol/client-rt": "^0.2.0-alpha4",
+                "@oasisprotocol/client-rt": "^0.2.0-alpha5",
                 "buffer": "^6.0.3",
                 "cypress": "^8.7.0",
                 "prettier": "^2.4.1",

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased changes
+## v0.2.0-alpha5
+
+Spotlight change:
+
+- We usually don't itemize changes that come from the SDK itself in this
+  client package's release notes, but the new `address.fromSigspec` is here,
+  and it's kind of a big deal.
 
 New features:
 

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-rt",
-    "version": "0.2.0-alpha4",
+    "version": "0.2.0-alpha5",
     "files": [
         "dist"
     ],


### PR DESCRIPTION
We want to start using the ethereum-compatible addresses in downstream wallet projects.