### PR TITLE
ts-web/signer-ledger: v0.1.0-alpha3

### DIFF
--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -8665,7 +8665,7 @@
         },
         "signer-ledger": {
             "name": "@oasisprotocol/client-signer-ledger",
-            "version": "0.1.0-alpha2",
+            "version": "0.1.0-alpha3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^6.11.0",

--- a/client-sdk/ts-web/signer-ledger/docs/changelog.md
+++ b/client-sdk/ts-web/signer-ledger/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.1.0-alpha3
+
+Spotlight change:
+
+- We're upgrading to a newer version of our Ledger library, which will support
+  the next version of the Oasis Ledger app.
+
 ## v0.1.0-alpha2
 
 Spotlight change:

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-signer-ledger",
-    "version": "0.1.0-alpha2",
+    "version": "0.1.0-alpha3",
     "license": "Apache-2.0",
     "files": [
         "dist"


### PR DESCRIPTION
this is so we can start using @oasisprotocol/ledger v2.x downstream