### PR TITLE
modules/accounts: Add internal method for setting total supply

### DIFF
--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -161,6 +161,10 @@ pub trait API {
     fn get_nonce<S: storage::Store>(state: S, address: Address) -> Result<u64, Error>;
 
     /// Sets an account's balance of the given denomination.
+    ///
+    /// # Warning
+    ///
+    /// This method is dangerous as it can result in invariant violations.
     fn set_balance<S: storage::Store>(state: S, address: Address, amount: &token::BaseUnits);
 
     /// Fetch an account's balance of the given denomination.
@@ -186,6 +190,13 @@ pub trait API {
     fn get_total_supplies<S: storage::Store>(
         state: S,
     ) -> Result<BTreeMap<token::Denomination, u128>, Error>;
+
+    /// Sets the total supply for the given denomination.
+    ///
+    /// # Warning
+    ///
+    /// This method is dangerous as it can result in invariant violations.
+    fn set_total_supply<S: storage::Store>(state: S, amount: &token::BaseUnits);
 
     /// Fetch information about a denomination.
     fn get_denomination_info<S: storage::Store>(
@@ -535,6 +546,13 @@ impl API for Module {
         let ts = storage::TypedStore::new(storage::PrefixStore::new(store, &state::TOTAL_SUPPLY));
 
         Ok(ts.iter().collect())
+    }
+
+    fn set_total_supply<S: storage::Store>(state: S, amount: &token::BaseUnits) {
+        let store = storage::PrefixStore::new(state, &MODULE_NAME);
+        let mut total_supplies =
+            storage::TypedStore::new(storage::PrefixStore::new(store, &state::TOTAL_SUPPLY));
+        total_supplies.insert(amount.denomination(), amount.amount());
     }
 
     fn get_denomination_info<S: storage::Store>(

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -1136,6 +1136,54 @@ fn test_get_set_balance() {
 }
 
 #[test]
+fn test_get_set_total_supply() {
+    let mut mock = mock::Mock::default();
+    let mut ctx = mock.create_ctx();
+
+    init_accounts(&mut ctx);
+
+    let ts = Accounts::get_total_supplies(ctx.runtime_state())
+        .expect("get_total_supplies should succeed");
+    assert_eq!(
+        ts.len(),
+        1,
+        "exactly one denomination should be present in total supplies"
+    );
+    assert!(
+        ts.contains_key(&Denomination::NATIVE),
+        "only native denomination should be present in total supplies"
+    );
+    assert_eq!(
+        ts[&Denomination::NATIVE],
+        1_000_000,
+        "total supply should be 1000000"
+    );
+
+    // Set total supply to 2m, note that this violates invariants.
+    Accounts::set_total_supply(
+        ctx.runtime_state(),
+        &BaseUnits::new(2_000_000, Denomination::NATIVE),
+    );
+
+    let ts = Accounts::get_total_supplies(ctx.runtime_state())
+        .expect("get_total_supplies should succeed");
+    assert_eq!(
+        ts.len(),
+        1,
+        "exactly one denomination should be present in total supplies"
+    );
+    assert!(
+        ts.contains_key(&Denomination::NATIVE),
+        "only native denomination should be present in total supplies"
+    );
+    assert_eq!(
+        ts[&Denomination::NATIVE],
+        2_000_000,
+        "total supply should be 2000000"
+    );
+}
+
+#[test]
 fn test_query_denomination_info() {
     let mut mock = mock::Mock::default();
     let mut ctx = mock.create_ctx();


### PR DESCRIPTION
This is needed for migrations that scale base units.