### PR TITLE
EstimateGas: support ETH caller address

### DIFF
--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -20,7 +20,7 @@ type V1 interface {
 
 	// EstimateGasForCaller performs gas estimation for executing the given transaction as if the
 	// caller specified by address had executed it.
-	EstimateGasForCaller(ctx context.Context, round uint64, caller types.Address, tx *types.Transaction) (uint64, error)
+	EstimateGasForCaller(ctx context.Context, round uint64, caller types.CallerAddress, tx *types.Transaction) (uint64, error)
 
 	// MinGasPrice returns the minimum gas price.
 	MinGasPrice(ctx context.Context) (map[types.Denomination]types.Quantity, error)
@@ -41,7 +41,7 @@ func (a *v1) EstimateGas(ctx context.Context, round uint64, tx *types.Transactio
 }
 
 // Implements V1.
-func (a *v1) EstimateGasForCaller(ctx context.Context, round uint64, caller types.Address, tx *types.Transaction) (uint64, error) {
+func (a *v1) EstimateGasForCaller(ctx context.Context, round uint64, caller types.CallerAddress, tx *types.Transaction) (uint64, error) {
 	var gas uint64
 	args := EstimateGasQuery{
 		Caller: &caller,

--- a/client-sdk/go/modules/core/types.go
+++ b/client-sdk/go/modules/core/types.go
@@ -8,7 +8,7 @@ import (
 type EstimateGasQuery struct {
 	// Caller is the address of the caller for which to do estimation. If not specified the
 	// authentication information from the passed transaction is used.
-	Caller *types.Address `json:"caller,omitempty"`
+	Caller *types.CallerAddress `json:"caller,omitempty"`
 	// Tx is the unsigned transaction to estimate.
 	Tx *types.Transaction `json:"tx"`
 }

--- a/client-sdk/go/testing/testing_test.go
+++ b/client-sdk/go/testing/testing_test.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"encoding/hex"
 	"fmt"
 	"testing"
 )
@@ -10,4 +11,5 @@ func TestPrintTestKeys(t *testing.T) {
 	fmt.Printf("B: %v\n", Bob.Signer.Public().String())
 	fmt.Printf("C: %v\n", Charlie.Signer.Public().String())
 	fmt.Printf("D: %v\n", Dave.Signer.Public().String())
+	fmt.Printf("D(ETH): %v\n", hex.EncodeToString(Dave.EthAddress[:]))
 }

--- a/client-sdk/go/types/transaction.go
+++ b/client-sdk/go/types/transaction.go
@@ -250,6 +250,14 @@ type Fee struct {
 	ConsensusMessages uint32    `json:"consensus_messages,omitempty"`
 }
 
+// CallerAddress is a caller address.
+type CallerAddress struct {
+	// Address is an oasis address.
+	Address *Address `json:"address,omitempty"`
+	// EthAddress is an ethereum address.
+	EthAddress *[20]byte `json:"eth_address,omitempty"`
+}
+
 // AddressSpec is common information that specifies an address as well as how to authenticate.
 type AddressSpec struct {
 	// Signature is for signature authentication.

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -4,8 +4,16 @@ import * as oasis from '@oasisprotocol/client';
  * Arguments for the EstimateGas query.
  */
 export interface CoreEstimateGasQuery {
-    caller?: Uint8Array;
+    caller?: CallerAddress;
     tx: Transaction;
+}
+
+/**
+ * Caller address.
+ */
+export interface CallerAddress {
+    address?: Uint8Array;
+    eth_address?: Uint8Array;
 }
 
 /**

--- a/runtime-sdk/modules/contracts/src/results.rs
+++ b/runtime-sdk/modules/contracts/src/results.rs
@@ -11,7 +11,7 @@ use oasis_runtime_sdk::{
     dispatcher,
     event::tag_for_event,
     modules::core::{self, API as _},
-    types::{token, transaction},
+    types::{token, transaction, transaction::CallerAddress},
 };
 
 use crate::{
@@ -157,7 +157,7 @@ fn process_subcalls<Cfg: Config, C: TxContext>(
                             signer_info: vec![transaction::SignerInfo {
                                 // The call is being performed on the contract's behalf.
                                 address_spec: transaction::AddressSpec::Internal(
-                                    contract.instance_info.address(),
+                                    CallerAddress::Address(contract.instance_info.address()),
                                 ),
                                 nonce: 0,
                             }],

--- a/runtime-sdk/modules/evm/src/derive_caller.rs
+++ b/runtime-sdk/modules/evm/src/derive_caller.rs
@@ -4,7 +4,7 @@ use oasis_runtime_sdk::{
     crypto::signature::secp256k1,
     types::{
         address::SignatureAddressSpec,
-        transaction::{AddressSpec, AuthInfo},
+        transaction::{AddressSpec, AuthInfo, CallerAddress},
     },
 };
 
@@ -28,6 +28,7 @@ pub fn from_sigspec(spec: &SignatureAddressSpec) -> Result<H160, Error> {
 pub fn from_tx_auth_info(ai: &AuthInfo) -> Result<H160, Error> {
     match &ai.signer_info[0].address_spec {
         AddressSpec::Signature(spec) => from_sigspec(spec),
+        AddressSpec::Internal(CallerAddress::EthAddress(address)) => Ok(address.into()),
         _ => Err(Error::InvalidSignerType),
     }
 }

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -351,7 +351,7 @@ impl Module {
 
         // Update the address used within the transaction when caller address is passed.
         let mut extra_gas = 0;
-        if let Some(caller) = args.caller {
+        if let Some(caller) = args.caller.clone() {
             let address_spec = transaction::AddressSpec::Internal(caller);
             match args.tx.auth_info.signer_info.first_mut() {
                 Some(si) => si.address_spec = address_spec,

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -10,7 +10,10 @@ use crate::{
     module::{AuthHandler as _, BlockHandler, Module as _},
     runtime::Runtime,
     testing::{keys, mock},
-    types::{token, transaction, transaction::TransactionWeight},
+    types::{
+        token, transaction,
+        transaction::{CallerAddress, TransactionWeight},
+    },
 };
 
 use super::{types, Module as Core, Parameters, API as _, GAS_WEIGHT_NAME};
@@ -301,7 +304,7 @@ fn test_query_estimate_gas() {
 
     // Test estimation with specified caller.
     let args = types::EstimateGasQuery {
-        caller: Some(keys::alice::address()),
+        caller: Some(CallerAddress::Address(keys::alice::address())),
         tx,
     };
 

--- a/runtime-sdk/src/modules/core/types.rs
+++ b/runtime-sdk/src/modules/core/types.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::{
     keymanager::SignedPublicKey,
-    types::{address::Address, transaction::Transaction},
+    types::transaction::{CallerAddress, Transaction},
 };
 
 /// Key in the versions map used for the global state version.
@@ -21,7 +21,7 @@ pub struct EstimateGasQuery {
     /// The address of the caller for which to do estimation. If not specified the authentication
     /// information from the passed transaction is used.
     #[cbor(optional)]
-    pub caller: Option<Address>,
+    pub caller: Option<CallerAddress>,
     /// The unsigned transaction to estimate.
     pub tx: Transaction,
 }

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -122,7 +122,7 @@ func sendTx(rtc client.RuntimeClient, signer signature.Signer, tx *types.Transac
 	tx.AuthInfo.Fee.Gas = gas
 
 	// Estimate gas by passing the caller address.
-	gasForCaller, err := core.NewV1(rtc).EstimateGasForCaller(ctx, client.RoundLatest, caller, tx)
+	gasForCaller, err := core.NewV1(rtc).EstimateGasForCaller(ctx, client.RoundLatest, types.CallerAddress{Address: &caller}, tx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds support for specifying an ETH caller address in `EstimateGas`. This way `evm` module can derive the correct caller from the address. 

Before this change all `EstimateGas` requests for evm transactions were failing at the `derive_caller` step: https://github.com/oasisprotocol/oasis-sdk/blob/6f2ce9f81d41f8a394dd8490016ed6f73042338b/runtime-sdk/modules/evm/src/lib.rs#L237

TODO:
- [x] update TS client
- [x] tests