### PR TITLE
modules/consensus_accounts: substitute nonce for id in events

### DIFF
--- a/client-sdk/go/modules/consensusaccounts/types.go
+++ b/client-sdk/go/modules/consensusaccounts/types.go
@@ -47,8 +47,8 @@ const (
 
 // DepositEvent is a deposit event.
 type DepositEvent struct {
-	ID     uint64          `json:"id"`
 	From   types.Address   `json:"from"`
+	Nonce  uint64          `json:"nonce"`
 	To     types.Address   `json:"to"`
 	Amount types.BaseUnits `json:"amount"`
 	Error  *ConsensusError `json:"error,omitempty"`
@@ -61,8 +61,8 @@ func (de *DepositEvent) IsSuccess() bool {
 
 // WithdrawEvent is a withdraw event.
 type WithdrawEvent struct {
-	ID     uint64          `json:"id"`
 	From   types.Address   `json:"from"`
+	Nonce  uint64          `json:"nonce"`
 	To     types.Address   `json:"to"`
 	Amount types.BaseUnits `json:"amount"`
 	Error  *ConsensusError `json:"error,omitempty"`

--- a/client-sdk/ts-web/rt/src/consensus_accounts.ts
+++ b/client-sdk/ts-web/rt/src/consensus_accounts.ts
@@ -31,11 +31,11 @@ export class Wrapper extends wrapper.Base {
     }
 
     callDeposit() {
-        return this.call<types.ConsensusDeposit, number>(METHOD_DEPOSIT);
+        return this.call<types.ConsensusDeposit, void>(METHOD_DEPOSIT);
     }
 
     callWithdraw() {
-        return this.call<types.ConsensusWithdraw, number>(METHOD_WITHDRAW);
+        return this.call<types.ConsensusWithdraw, void>(METHOD_WITHDRAW);
     }
 
     queryBalance() {

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -307,16 +307,16 @@ export interface ConsensusAccountsConsensusError {
 }
 
 export interface ConsensusAccountsDepositEvent {
-    id: number;
     from: Uint8Array;
+    nonce: oasis.types.longnum;
     to: Uint8Array;
     amount: BaseUnits;
     error?: ConsensusAccountsConsensusError;
 }
 
 export interface ConsensusAccountsWithdrawEvent {
-    id: number;
     from: Uint8Array;
+    nonce: oasis.types.longnum;
     to: Uint8Array;
     amount: BaseUnits;
     error?: ConsensusAccountsConsensusError;

--- a/runtime-sdk/src/modules/consensus_accounts/types.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/types.rs
@@ -42,9 +42,9 @@ pub struct AccountBalance {
 /// Context for consensus transfer message handler.
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode, Default)]
 pub struct ConsensusTransferContext {
-    #[cbor(optional, default)]
-    pub id: u64,
     pub address: Address,
+    #[cbor(optional, default)]
+    pub nonce: u64,
     #[cbor(optional, default)]
     pub to: Address,
     pub amount: token::BaseUnits,
@@ -54,9 +54,9 @@ pub struct ConsensusTransferContext {
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode, Default)]
 pub struct ConsensusWithdrawContext {
     #[cbor(optional, default)]
-    pub id: u64,
-    #[cbor(optional, default)]
     pub from: Address,
+    #[cbor(optional, default)]
+    pub nonce: u64,
     pub address: Address,
     pub amount: token::BaseUnits,
 }


### PR DESCRIPTION
This is a PR replacing the synthetic withdraw/deposit ID (used to correlate a success/fail event with a transaction) with the sender's nonce. Then the sender and the nonce together should uniquely identify the operation.

We discussed this, and we liked that this way doesn't introduce its own state. Also clients won't need to wait for the transaction response this way.

Initiating a deposit/withdraw is part of the module's API. If we go on to use this in cases other than directly from these transactions, then the caller should come up with its own way of using this nonce. It should be okay as long as there aren't multiple identical deposits generated from a single outermost transaction. :shrug: 