### PR TITLE
ts-web/rt: playground don't poll if tx submission fails

### DIFF
--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -47,7 +47,7 @@
                 "@oasisprotocol/client": "^0.1.0-alpha7"
             },
             "devDependencies": {
-                "@oasisprotocol/client-rt": "^0.2.0-alpha5",
+                "@oasisprotocol/client-rt": "^0.2.0-alpha8",
                 "buffer": "^6.0.3",
                 "cypress": "^8.7.0",
                 "prettier": "^2.4.1",
@@ -9514,7 +9514,7 @@
             "version": "file:ext-utils",
             "requires": {
                 "@oasisprotocol/client": "^0.1.0-alpha7",
-                "@oasisprotocol/client-rt": "^0.2.0-alpha5",
+                "@oasisprotocol/client-rt": "^0.2.0-alpha8",
                 "buffer": "^6.0.3",
                 "cypress": "^8.7.0",
                 "prettier": "^2.4.1",


### PR DESCRIPTION
let's make it not start polling until the tx submission succeeds, after all.

this makes us more flexible if we later do something that needs the tx result to poll. but in the big picture, this polling is because we kind of don't want to have long lived connections to the grpc-web proxy :shrug:. the manual polling allows us to read up from a known starting point, beginning from a later time. the real streaming APIs don's support this, so it's also good that we don't need the tx result.

and there's a little added thing that makes it poll fast until the first 'block not found' response, in case it takes a while to submit and multiple blocks come out during that time.

changes are to sample/test code only, no need for a new release