### PR TITLE
ts-web/core: playground show how to avoid eval

### DIFF
--- a/client-sdk/ts-web/core/playground/src/errata/inquire.js
+++ b/client-sdk/ts-web/core/playground/src/errata/inquire.js
@@ -1,0 +1,4 @@
+// We intend to run in browsers, which don't support runtime `require`.
+// https://github.com/protobufjs/protobuf.js/pull/1548/files#r588874248
+// Stub this out to prevent CSP spam.
+module.exports = () => null;

--- a/client-sdk/ts-web/core/playground/webpack.config.js
+++ b/client-sdk/ts-web/core/playground/webpack.config.js
@@ -2,7 +2,14 @@ const webpack = require('webpack');
 
 module.exports = {
     mode: 'development',
-    resolve: { fallback: { stream: require.resolve('stream-browserify') } },
+    resolve: {
+        alias: {
+            '@protobufjs/inquire': require.resolve('./src/errata/inquire'),
+        },
+        fallback: {
+            stream: require.resolve('stream-browserify'),
+        },
+    },
     plugins: [
         new webpack.ProvidePlugin({
             process: 'process/browser',

--- a/client-sdk/ts-web/ext-utils/sample-ext/src/errata/inquire.js
+++ b/client-sdk/ts-web/ext-utils/sample-ext/src/errata/inquire.js
@@ -1,0 +1,4 @@
+// We intend to run in browsers, which don't support runtime `require`.
+// https://github.com/protobufjs/protobuf.js/pull/1548/files#r588874248
+// Stub this out to prevent CSP spam.
+module.exports = () => null;

--- a/client-sdk/ts-web/ext-utils/sample-ext/webpack.config.js
+++ b/client-sdk/ts-web/ext-utils/sample-ext/webpack.config.js
@@ -2,7 +2,14 @@ const webpack = require('webpack');
 
 module.exports = {
     mode: 'development',
-    resolve: { fallback: { stream: require.resolve('stream-browserify') } },
+    resolve: {
+        alias: {
+            '@protobufjs/inquire': require.resolve('./src/errata/inquire'),
+        },
+        fallback: {
+            stream: require.resolve('stream-browserify'),
+        },
+    },
     devtool: false,
     plugins: [
         new webpack.ProvidePlugin({

--- a/client-sdk/ts-web/ext-utils/sample-page/src/errata/inquire.js
+++ b/client-sdk/ts-web/ext-utils/sample-page/src/errata/inquire.js
@@ -1,0 +1,4 @@
+// We intend to run in browsers, which don't support runtime `require`.
+// https://github.com/protobufjs/protobuf.js/pull/1548/files#r588874248
+// Stub this out to prevent CSP spam.
+module.exports = () => null;

--- a/client-sdk/ts-web/ext-utils/sample-page/webpack.config.js
+++ b/client-sdk/ts-web/ext-utils/sample-page/webpack.config.js
@@ -1,6 +1,13 @@
 module.exports = {
     mode: 'development',
-    resolve: { fallback: { stream: require.resolve('stream-browserify') } },
+    resolve: {
+        alias: {
+            '@protobufjs/inquire': require.resolve('./src/errata/inquire'),
+        },
+        fallback: {
+            stream: require.resolve('stream-browserify'),
+        },
+    },
     output: {
         library: {
             name: 'playground',

--- a/client-sdk/ts-web/rt/playground/src/errata/inquire.js
+++ b/client-sdk/ts-web/rt/playground/src/errata/inquire.js
@@ -1,0 +1,4 @@
+// We intend to run in browsers, which don't support runtime `require`.
+// https://github.com/protobufjs/protobuf.js/pull/1548/files#r588874248
+// Stub this out to prevent CSP spam.
+module.exports = () => null;

--- a/client-sdk/ts-web/rt/playground/webpack.config.js
+++ b/client-sdk/ts-web/rt/playground/webpack.config.js
@@ -6,7 +6,14 @@ module.exports = {
         main: './src/index.js',
         consensus: './src/consensus.js',
     },
-    resolve: {fallback: {stream: require.resolve('stream-browserify')}},
+    resolve: {
+        alias: {
+            '@protobufjs/inquire': require.resolve('./src/errata/inquire'),
+        },
+        fallback: {
+            stream: require.resolve('stream-browserify'),
+        },
+    },
     plugins: [
         new webpack.ProvidePlugin({
             process: 'process/browser',

--- a/client-sdk/ts-web/signer-ledger/playground/src/errata/inquire.js
+++ b/client-sdk/ts-web/signer-ledger/playground/src/errata/inquire.js
@@ -1,0 +1,4 @@
+// We intend to run in browsers, which don't support runtime `require`.
+// https://github.com/protobufjs/protobuf.js/pull/1548/files#r588874248
+// Stub this out to prevent CSP spam.
+module.exports = () => null;

--- a/client-sdk/ts-web/signer-ledger/playground/webpack.config.js
+++ b/client-sdk/ts-web/signer-ledger/playground/webpack.config.js
@@ -2,7 +2,14 @@ const webpack = require('webpack');
 
 module.exports = {
     mode: 'development',
-    resolve: { fallback: { stream: require.resolve('stream-browserify') } },
+    resolve: {
+        alias: {
+            '@protobufjs/inquire': require.resolve('./src/errata/inquire'),
+        },
+        fallback: {
+            stream: require.resolve('stream-browserify'),
+        },
+    },
     plugins: [
         new webpack.ProvidePlugin({
             process: 'process/browser',


### PR DESCRIPTION
protobufjs's 'inquire' library will always fail

not sure if we should really merge this:

- it's really downstream users that will need to do this
- this particular 'playground' page runs in dev mode with the 'eval devtool' anyway

cc #608 