### PR TITLE
Fix emitting multiple of events of the same type

### DIFF
--- a/client-sdk/go/client/client.go
+++ b/client-sdk/go/client/client.go
@@ -93,7 +93,7 @@ type RuntimeClient interface {
 // EventDecoder is an event decoder interface.
 type EventDecoder interface {
 	// DecodeEvent decodes an event. In case the event is not relevant, `nil, nil` should be returned.
-	DecodeEvent(*types.Event) (DecodedEvent, error)
+	DecodeEvent(*types.Event) ([]DecodedEvent, error)
 }
 
 // DecodedEvent is a decoded event.
@@ -394,7 +394,7 @@ OUTER:
 				return nil, fmt.Errorf("failed to decode event: %w", err)
 			}
 			if decoded != nil {
-				evs = append(evs, decoded)
+				evs = append(evs, decoded...)
 				continue OUTER
 			}
 		}

--- a/client-sdk/go/modules/accounts/accounts.go
+++ b/client-sdk/go/modules/accounts/accounts.go
@@ -109,48 +109,49 @@ func (a *v1) GetEvents(ctx context.Context, round uint64) ([]*Event, error) {
 		if err != nil {
 			return nil, err
 		}
-		if ev == nil {
-			continue
+		for _, e := range ev {
+			evs = append(evs, e.(*Event))
 		}
-		evs = append(evs, ev.(*Event))
 	}
 
 	return evs, nil
 }
 
 // Implements client.EventDecoder.
-func (a *v1) DecodeEvent(event *types.Event) (client.DecodedEvent, error) {
+func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	if event.Module != ModuleName {
 		return nil, nil
 	}
+	var events []client.DecodedEvent
 	switch event.Code {
 	case TransferEventCode:
-		var ev *TransferEvent
-		if err := cbor.Unmarshal(event.Value, &ev); err != nil {
+		var evs []*TransferEvent
+		if err := cbor.Unmarshal(event.Value, &evs); err != nil {
 			return nil, fmt.Errorf("decode account transfer event value: %w", err)
 		}
-		return &Event{
-			Transfer: ev,
-		}, nil
+		for _, ev := range evs {
+			events = append(events, &Event{Transfer: ev})
+		}
 	case BurnEventCode:
-		var ev *BurnEvent
-		if err := cbor.Unmarshal(event.Value, &ev); err != nil {
+		var evs []*BurnEvent
+		if err := cbor.Unmarshal(event.Value, &evs); err != nil {
 			return nil, fmt.Errorf("decode account burn event value: %w", err)
 		}
-		return &Event{
-			Burn: ev,
-		}, nil
+		for _, ev := range evs {
+			events = append(events, &Event{Burn: ev})
+		}
 	case MintEventCode:
-		var ev *MintEvent
-		if err := cbor.Unmarshal(event.Value, &ev); err != nil {
+		var evs []*MintEvent
+		if err := cbor.Unmarshal(event.Value, &evs); err != nil {
 			return nil, fmt.Errorf("decode account mint event value: %w", err)
 		}
-		return &Event{
-			Mint: ev,
-		}, nil
+		for _, ev := range evs {
+			events = append(events, &Event{Mint: ev})
+		}
 	default:
 		return nil, fmt.Errorf("invalid accounts event code: %v", event.Code)
 	}
+	return events, nil
 }
 
 // NewV1 generates a V1 client helper for the accounts module.

--- a/client-sdk/go/modules/evm/evm.go
+++ b/client-sdk/go/modules/evm/evm.go
@@ -142,25 +142,28 @@ func (a *v1) GetEvents(ctx context.Context, round uint64) ([]*Event, error) {
 		if err != nil {
 			return nil, err
 		}
-		if ev == nil {
-			continue
+		for _, e := range ev {
+			evs = append(evs, e.(*Event))
 		}
-		evs = append(evs, ev.(*Event))
 	}
 
 	return evs, nil
 }
 
 // Implements client.EventDecoder.
-func (a *v1) DecodeEvent(event *types.Event) (client.DecodedEvent, error) {
+func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	if event.Module != ModuleName && event.Code != 1 {
 		return nil, nil
 	}
-	var ev *Event
-	if err := cbor.Unmarshal(event.Value, &ev); err != nil {
+	var evs []*Event
+	if err := cbor.Unmarshal(event.Value, &evs); err != nil {
 		return nil, fmt.Errorf("evm event value unmarshal failed: %w", err)
 	}
-	return ev, nil
+	events := make([]client.DecodedEvent, len(evs))
+	for i, ev := range evs {
+		events[i] = ev
+	}
+	return events, nil
 }
 
 // NewV1 generates a V1 client helper for the EVM module.

--- a/client-sdk/ts-web/rt/src/event.ts
+++ b/client-sdk/ts-web/rt/src/event.ts
@@ -30,8 +30,10 @@ export class Visitor {
     visit(e: oasis.types.RuntimeClientEvent) {
         const keyHex = oasis.misc.toHex(e.key);
         if (keyHex in this.handlers) {
-            const value = oasis.misc.fromCBOR(e.value);
-            this.handlers[keyHex](e, value);
+            const values = oasis.misc.fromCBOR(e.value) as Array<any>;
+            for (const value of values) {
+                this.handlers[keyHex](e, value);
+            }
             return true;
         }
         return false;

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -27,6 +27,7 @@ use crate::{
     callformat,
     context::{BatchContext, Context, RuntimeBatchContext, TxContext},
     error::{Error as _, RuntimeError},
+    event::IntoTags,
     keymanager::{KeyManagerClient, KeyManagerError},
     module::{self, AuthHandler, BlockHandler, MethodHandler},
     modules,
@@ -200,12 +201,11 @@ impl<R: Runtime> Dispatcher<R> {
             let weights = modules::core::Module::take_weights(&mut ctx);
 
             // Commit store and return emitted tags and messages.
-            let (tags, messages) = ctx.commit();
-
+            let (etags, messages) = ctx.commit();
             (
                 DispatchResult {
                     result,
-                    tags,
+                    tags: etags.into_tags(),
                     priority,
                     weights,
                     call_format_metadata,
@@ -450,7 +450,7 @@ impl<R: Runtime + Send + Sync> transaction::dispatcher::Dispatcher for Dispatche
         Ok(ExecuteBatchResult {
             results,
             messages,
-            block_tags,
+            block_tags: block_tags.into_tags(),
             batch_weight_limits: Some(block_weight_limits),
         })
     }

--- a/runtime-sdk/src/event.rs
+++ b/runtime-sdk/src/event.rs
@@ -1,5 +1,7 @@
 //! Event types for runtimes.
-use oasis_core_runtime::transaction::tags::Tag;
+use std::collections::BTreeMap;
+
+use oasis_core_runtime::transaction::tags::{Tag, Tags};
 
 /// An event emitted by the runtime.
 ///
@@ -29,7 +31,7 @@ pub trait Event: Sized + cbor::Encode {
     /// Code uniquely identifying the event.
     fn code(&self) -> u32;
 
-    /// Converts an emitted event into a tag that can be emitted by the runtime.
+    /// Converts an event into an event tag.
     ///
     /// # Key
     ///
@@ -41,8 +43,8 @@ pub trait Event: Sized + cbor::Encode {
     ///
     /// CBOR-serialized event value.
     ///
-    fn into_tag(self) -> Tag {
-        tag_for_event(Self::module_name(), self.code(), cbor::to_vec(self))
+    fn into_event_tag(self) -> EventTag {
+        etag_for_event(Self::module_name(), self.code(), cbor::to_value(self))
     }
 }
 
@@ -56,12 +58,35 @@ impl Event for () {
     }
 }
 
-/// Generate an Oasis Core tag corresponding to the passed event triple.
-pub fn tag_for_event(module_name: &str, code: u32, value: Vec<u8>) -> Tag {
-    Tag::new(
-        [module_name.as_bytes(), &code.to_be_bytes()]
+/// Generate an EventTag corresponding to the passed event triple.
+pub fn etag_for_event(module_name: &str, code: u32, value: cbor::Value) -> EventTag {
+    EventTag {
+        key: [module_name.as_bytes(), &code.to_be_bytes()]
             .concat()
             .to_vec(),
         value,
-    )
+    }
+}
+
+/// A key-value pair representing an emitted event that will be emitted as a tag.
+#[derive(Clone, Debug)]
+pub struct EventTag {
+    pub key: Vec<u8>,
+    pub value: cbor::Value,
+}
+
+/// Event tags with values accumulated by key.
+pub type EventTags = BTreeMap<Vec<u8>, Vec<cbor::Value>>;
+
+/// Provides method for converting event tags into events.
+pub trait IntoTags {
+    fn into_tags(self) -> Tags;
+}
+
+impl IntoTags for EventTags {
+    fn into_tags(self) -> Tags {
+        self.into_iter()
+            .map(|(k, v)| Tag::new(k, cbor::to_vec(v)))
+            .collect()
+    }
 }

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -427,15 +427,19 @@ WaitInsertLoop:
 			for _, ev := range events {
 				switch {
 				case kvInsertEventKey.IsEqual(ev.Key()):
-					var ie kvInsertEvent
-					if err = cbor.Unmarshal(ev.Value, &ie); err != nil {
+					var ies []*kvInsertEvent
+					if err = cbor.Unmarshal(ev.Value, &ies); err != nil {
 						log.Error("failed to unmarshal insert event",
 							"err", err,
 						)
 						continue
 					}
+					if len(ies) != 1 {
+						log.Error("unexpected number of insert events")
+						continue
+					}
 
-					if bytes.Equal(ie.KV.Key, testKey) && bytes.Equal(ie.KV.Value, testValue) {
+					if bytes.Equal(ies[0].KV.Key, testKey) && bytes.Equal(ies[0].KV.Value, testValue) {
 						gotEvent = true
 						log.Info("got our insert event")
 						break WaitInsertLoop
@@ -480,15 +484,19 @@ WaitRemoveLoop:
 			for _, ev := range events {
 				switch {
 				case kvRemoveEventKey.IsEqual(ev.Key()):
-					var re kvRemoveEvent
-					if err = cbor.Unmarshal(ev.Value, &re); err != nil {
+					var res []*kvRemoveEvent
+					if err = cbor.Unmarshal(ev.Value, &res); err != nil {
 						log.Error("failed to unmarshal remove event",
 							"err", err,
 						)
 						continue
 					}
+					if len(res) != 1 {
+						log.Error("unexpected number of remove events")
+						continue
+					}
 
-					if bytes.Equal(re.Key.Key, testKey) {
+					if bytes.Equal(res[0].Key.Key, testKey) {
 						gotEvent = true
 						log.Info("got our remove event")
 						break WaitRemoveLoop


### PR DESCRIPTION
Currently, the way sdk-events are mapped into tags causes the events of the same type to override and only the last emitted event is actually emitted as a transaction tag. 

For example, currently only the last emitted EVM log is emitted as a transaction tag and others are lost  https://github.com/oasisprotocol/oasis-sdk/blob/f5b7a5429342770dbf0ea464854cd9be49d03bd1/runtime-sdk/modules/evm/src/backend.rs#L250-L257

This changes the way events are mapped into transaction tags. The tag value is now an array of events.

Clients:
- [x] `go` client library is updated to internally handle the change, there should be no changes for library users of `WatchEvents/GetEvents` once the sdk is updated
- [x] `typescript` client library is updated internally to handle the change, there should be no changes for library users once updating the sdk
- [x] add a test