### PR TITLE
tests/e2e: Add test for transaction ordering by priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,15 +1495,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
-name = "lru"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
@@ -1849,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-client"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.6#bfd2892412c8e6e06ec3a766a6687c9fc25c81f8"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
 dependencies = [
  "anyhow",
  "futures",
@@ -1863,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-keymanager-api-common"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.6#bfd2892412c8e6e06ec3a766a6687c9fc25c81f8"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
 dependencies = [
  "anyhow",
  "base64",
@@ -1880,11 +1871,11 @@ dependencies = [
 [[package]]
 name = "oasis-core-keymanager-client"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.6#bfd2892412c8e6e06ec3a766a6687c9fc25c81f8"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
 dependencies = [
  "futures",
  "io-context",
- "lru 0.6.6",
+ "lru",
  "oasis-cbor",
  "oasis-core-client",
  "oasis-core-keymanager-api-common",
@@ -1895,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-runtime"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.6#bfd2892412c8e6e06ec3a766a6687c9fc25c81f8"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1917,7 +1908,7 @@ dependencies = [
  "io-context",
  "lazy_static",
  "log",
- "lru 0.6.6",
+ "lru",
  "num-bigint",
  "num-traits",
  "oasis-cbor",
@@ -1985,7 +1976,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake3",
- "lru 0.7.2",
+ "lru",
  "num-traits",
  "oasis-cbor",
  "oasis-contract-sdk-crypto",

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
-	github.com/oasisprotocol/oasis-core/go v0.2103.6
+	github.com/oasisprotocol/oasis-core/go v0.2103.8
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.3.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -880,8 +880,8 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84 h1:VG
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2103.6 h1:w6XhwnEOTAgDxAxz8FxOh36+EafH7NM233R68uUISJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.6/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
+github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/client-sdk/go/go.mod
+++ b/client-sdk/go/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
-	github.com/oasisprotocol/oasis-core/go v0.2103.6
+	github.com/oasisprotocol/oasis-core/go v0.2103.8
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5

--- a/client-sdk/go/go.sum
+++ b/client-sdk/go/go.sum
@@ -817,8 +817,8 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84/go.mo
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.6 h1:w6XhwnEOTAgDxAxz8FxOh36+EafH7NM233R68uUISJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.6/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
+github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2/go.mod h1:agEnj5cjmg55z8CtL/Nva9LqxR4402T1TFPC4kuNBMc=

--- a/client-sdk/go/types/transaction.go
+++ b/client-sdk/go/types/transaction.go
@@ -256,6 +256,26 @@ type Fee struct {
 	ConsensusMessages uint32    `json:"consensus_messages,omitempty"`
 }
 
+// GasPrice returns the gas price implied by the amount and gas.
+func (f *Fee) GasPrice() *quantity.Quantity {
+	if f.Amount.Amount.IsZero() || f.Gas == 0 {
+		return quantity.NewQuantity()
+	}
+
+	var gasQ quantity.Quantity
+	if err := gasQ.FromUint64(f.Gas); err != nil {
+		// Should never happen.
+		panic(err)
+	}
+
+	amt := f.Amount.Amount.Clone()
+	if err := amt.Quo(&gasQ); err != nil {
+		// Should never happen.
+		panic(err)
+	}
+	return amt
+}
+
 // CallerAddress is a caller address.
 type CallerAddress struct {
 	// Address is an oasis address.

--- a/client-sdk/ts-web/core/reflect-go/go.mod
+++ b/client-sdk/ts-web/core/reflect-go/go.mod
@@ -2,7 +2,7 @@ module github.com/oasisprotocol/oasis-sdk/client-sdk/ts-web/core/reflect-go
 
 go 1.17
 
-require github.com/oasisprotocol/oasis-core/go v0.2103.6
+require github.com/oasisprotocol/oasis-core/go v0.2103.8
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/client-sdk/ts-web/core/reflect-go/go.sum
+++ b/client-sdk/ts-web/core/reflect-go/go.sum
@@ -820,8 +820,8 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 h1:qnvTxmtjcuRH5NiI0Kiku6TXi2VReR/PxHFf3ahFYrg=
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2103.6 h1:w6XhwnEOTAgDxAxz8FxOh36+EafH7NM233R68uUISJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.6/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
+github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -7,10 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 cbor = { version = "0.2.1", package = "oasis-cbor" }
-oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.6" }
-oasis-core-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.6" }
-oasis-core-keymanager-api-common = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.6" }
-oasis-core-keymanager-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.6" }
+oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
+oasis-core-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
+oasis-core-keymanager-api-common = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
+oasis-core-keymanager-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
 oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 
 # Third party.

--- a/runtime-sdk/src/modules/accounts/test.rs
+++ b/runtime-sdk/src/modules/accounts/test.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use crate::{
     context::{BatchContext, Context},
     module::{AuthHandler, BlockHandler, InvariantHandler, MethodHandler},
-    modules::core,
+    modules::{core, core::API as _},
     testing::{keys, mock},
     types::{
         token::{BaseUnits, Denomination},
@@ -441,6 +441,9 @@ fn test_authenticate_tx() {
     let nonce = Accounts::get_nonce(ctx.runtime_state(), keys::alice::address())
         .expect("get_nonce should succeed");
     assert_eq!(nonce, 1, "nonce should be incremented");
+    // Check priority.
+    let priority = core::Module::<mock::Config>::take_priority(&mut ctx);
+    assert_eq!(priority, 1, "priority should be equal to gas price");
 
     // Should fail with an invalid nonce.
     let result = Accounts::authenticate_tx(&mut ctx, &tx);

--- a/tests/benchmark/go.mod
+++ b/tests/benchmark/go.mod
@@ -15,7 +15,7 @@ replace (
 )
 
 require (
-	github.com/oasisprotocol/oasis-core/go v0.2103.6
+	github.com/oasisprotocol/oasis-core/go v0.2103.8
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1

--- a/tests/benchmark/go.sum
+++ b/tests/benchmark/go.sum
@@ -923,8 +923,8 @@ github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.6 h1:w6XhwnEOTAgDxAxz8FxOh36+EafH7NM233R68uUISJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.6/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
+github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=
@@ -1050,6 +1050,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=

--- a/tests/consts.sh
+++ b/tests/consts.sh
@@ -6,7 +6,7 @@
 
 # Released version from GitHub Releases.
 # e.g. '21.1.2'
-OASIS_CORE_VERSION='21.3.6'
+OASIS_CORE_VERSION='21.3.8'
 
 # Development version from GitHub Actions.
 # e.g. '58512799'
@@ -16,4 +16,4 @@ GITHUB_ARTIFACT_VERSION=''
 
 # Version from Buildkite.
 # e.g. '4759'
-BUILD_NUMBER='6585' # v21.3.6
+BUILD_NUMBER='6985' # v21.3.8

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -22,7 +22,7 @@ replace (
 require (
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
-	github.com/oasisprotocol/oasis-core/go v0.2103.6
+	github.com/oasisprotocol/oasis-core/go v0.2103.8
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.41.0
 )

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -930,8 +930,8 @@ github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.6 h1:w6XhwnEOTAgDxAxz8FxOh36+EafH7NM233R68uUISJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.6/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
+github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=
@@ -1057,6 +1057,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -50,7 +50,7 @@ func RegisterScenarios() error {
 	cmd.RegisterScenarioParams(RuntimeParamsDummy.Name(), RuntimeParamsDummy.Parameters())
 
 	SimpleKVRuntime.Flags.Int(CfgTxGenNumAccounts, 10, "number of accounts to use in txgen test")
-	SimpleKVRuntime.Flags.Uint64(CfgTxGenCoinsPerAcct, 200, "number of coins to allocate to each account in txgen test")
+	SimpleKVRuntime.Flags.Uint64(CfgTxGenCoinsPerAcct, 1_000_000, "number of coins to allocate to each account in txgen test")
 	SimpleKVRuntime.Flags.Duration(CfgTxGenDuration, 60*time.Second, "duration of txgen test")
 
 	for _, s := range []scenario.Scenario{

--- a/tests/e2e/txgen/txgen.go
+++ b/tests/e2e/txgen/txgen.go
@@ -176,7 +176,7 @@ func CreateAndFundAccount(ctx context.Context, rtc client.RuntimeClient, funder 
 
 // RandomizeFee generates random fee parameters for the transaction.
 func RandomizeFee(ctx context.Context, rng *rand.Rand, tx *types.Transaction) error {
-	const maxBaseUnits = 10
+	const maxBaseUnits = 20_000
 	feeAmount := rng.Uint64() % maxBaseUnits
 
 	tx.AuthInfo.Fee.Amount = types.NewBaseUnits(*quantity.NewFromUint64(feeAmount), types.NativeDenomination)

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -88,7 +88,7 @@ impl sdk::Runtime for Runtime {
                     // Alice.
                     b.insert(sdk::testing::keys::alice::address(), {
                         let mut d = BTreeMap::new();
-                        d.insert(Denomination::NATIVE, 10_003_000);
+                        d.insert(Denomination::NATIVE, 100_003_000);
                         d
                     });
                     // Bob.
@@ -119,7 +119,7 @@ impl sdk::Runtime for Runtime {
                 },
                 total_supplies: {
                     let mut ts = BTreeMap::new();
-                    ts.insert(Denomination::NATIVE, 10_016_100);
+                    ts.insert(Denomination::NATIVE, 100_016_100);
                     ts
                 },
                 ..Default::default()


### PR DESCRIPTION
Inspired by #738.

Also bumps Oasis Core to 21.3.8 as otherwise the test wouldn't pass due to the query returning incorrect results.