### PR TITLE
Introspection endpoint for Core module

### DIFF
--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -15,6 +15,7 @@ const (
 	methodParameters  = "core.Parameters"
 	methodEstimateGas = "core.EstimateGas"
 	methodMinGasPrice = "core.MinGasPrice"
+	methodRuntimeInfo = "core.RuntimeInfo"
 )
 
 // V1 is the v1 core module interface.
@@ -34,6 +35,9 @@ type V1 interface {
 
 	// GetEvents returns all core events emitted in a given block.
 	GetEvents(ctx context.Context, round uint64) ([]*Event, error)
+
+	// RuntimeInfo returns basic info about the module and the containing runtime.
+	RuntimeInfo(ctx context.Context) (*RuntimeInfoResponse, error)
 }
 
 type v1 struct {
@@ -132,6 +136,16 @@ func DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 		return nil, fmt.Errorf("invalid core event code: %v", event.Code)
 	}
 	return events, nil
+}
+
+// Implements V1.
+func (a *v1) RuntimeInfo(ctx context.Context) (*RuntimeInfoResponse, error) {
+	var info RuntimeInfoResponse
+	err := a.rc.Query(ctx, client.RoundLatest, methodRuntimeInfo, nil, &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
 }
 
 // NewV1 generates a V1 client helper for the core module.

--- a/client-sdk/go/modules/core/types.go
+++ b/client-sdk/go/modules/core/types.go
@@ -1,8 +1,9 @@
 package core
 
 import (
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
-
+	"github.com/oasisprotocol/oasis-core/go/common/version"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
@@ -49,3 +50,40 @@ type GasUsedEvent struct {
 type Event struct {
 	GasUsed *GasUsedEvent
 }
+
+// RuntimeInfoResponse is the response of the core.RuntimeInfo query
+// and provides basic introspection information about the runtime.
+type RuntimeInfoResponse struct {
+	RuntimeVersion *version.Version `json:"runtime_version"`
+	// StateVersion is the version of the schema used by the runtime for keeping its state.
+	StateVersion uint32 `json:"state_version"`
+	// Modules are the SDK modules that comprise this runtime.
+	Modules map[string]ModuleInfo `json:"modules"`
+}
+
+// ModuleInfo is the information about a single module within the runtime.
+type ModuleInfo struct {
+	// Version is the version of the module.
+	Version uint32 `json:"version"`
+	// Params are the initial parameters of the module.
+	Params cbor.RawMessage `json:"params"`
+	// Methods are the RPC methods exposed by the module.
+	Methods []MethodHandlerInfo `json:"methods"`
+}
+
+// MethodHandlerInfo describes a single RPC.
+type MethodHandlerInfo struct {
+	// Name is the name of the RPC.
+	Name string `json:"name"`
+	// Kind is the kind of the RPC.
+	Kind methodHandlerKind `json:"kind"`
+}
+
+type methodHandlerKind string
+
+// These constants represent the kinds of methods that handlers handle.
+const (
+	MethodHandlerKindCall          methodHandlerKind = "call"
+	MethodHandlerKindQuery         methodHandlerKind = "query"
+	MethodHandlerKindMessageResult methodHandlerKind = "message_result"
+)

--- a/client-sdk/ts-web/rt/src/core.ts
+++ b/client-sdk/ts-web/rt/src/core.ts
@@ -34,9 +34,16 @@ export const METHOD_ESTIMATE_GAS = 'core.EstimateGas';
 export const METHOD_CHECK_INVARIANTS = 'core.CheckInvariants';
 export const METHOD_CALL_DATA_PUBLIC_KEY = 'core.CallDataPublicKey';
 export const METHOD_MIN_GAS_PRICE = 'core.MinGasPrice';
+export const METHOD_RUNTIME_INFO = 'core.RuntimeInfo';
 
 // Events.
 export const EVENT_GAS_USED = 1;
+
+// Introspection.
+// Keep these in sync with `CoreMethodHandlerInfo.kind`
+export const METHODHANDLERKIND_CALL = 'call';
+export const METHODHANDLERKIND_QUERY = 'query';
+export const METHODHANDLERKIND_MESSAGE_RESULT = 'message_result';
 
 export class Wrapper extends wrapper.Base {
     constructor(runtimeID: Uint8Array) {
@@ -59,6 +66,10 @@ export class Wrapper extends wrapper.Base {
 
     queryMinGasPrice() {
         return this.query<void, Map<Uint8Array, Uint8Array>>(METHOD_MIN_GAS_PRICE);
+    }
+
+    queryRuntimeInfo() {
+        return this.query<void, types.CoreRuntimeInfoQueryResponse>(METHOD_RUNTIME_INFO);
     }
 }
 

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -26,6 +26,30 @@ export interface CoreGasUsedEvent {
 }
 
 /**
+ * Response to the RuntimeInfo query.
+ */
+export interface CoreRuntimeInfoQueryResponse {
+    runtime_version: oasis.types.Version;
+    state_version: number;
+    modules: {[key: string]: CoreModuleInfo};
+}
+
+/**
+ * Metadata for an individual module within the runtime.
+ */
+export interface CoreModuleInfo {
+    version: number;
+    params: any;
+    methods: CoreMethodHandlerInfo[];
+}
+
+export interface CoreMethodHandlerInfo {
+    name: string;
+    // Keep these in sync with the `METHODHANDLERKIND_*` constants.
+    kind: 'call' | 'query' | 'message_result';
+}
+
+/**
  * Caller address.
  */
 export interface CallerAddress {
@@ -196,7 +220,7 @@ export interface AuthProof {
      * A flag to use module-controlled decoding. The string is an encoding scheme name that a
      * module must handle. When using this variant, the scheme name must not be empty.
      */
-    module?: String;
+    module?: string;
 }
 
 /**

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     callformat,
     context::{BatchContext, Context, TxContext},
     dispatcher,
-    module::{self, InvariantHandler as _, Module as _},
+    module::{self, InvariantHandler as _, Module as _, ModuleInfoHandler as _},
     types::{
         token,
         transaction::{
@@ -24,6 +24,8 @@ use crate::{
     },
     Runtime,
 };
+
+use self::types::RuntimeInfoResponse;
 
 #[cfg(test)]
 mod test;
@@ -468,6 +470,19 @@ impl<Cfg: Config> Module<Cfg> {
         }
 
         Ok(mgp)
+    }
+
+    /// Return basic information about the module and the containing runtime.
+    #[handler(query = "core.RuntimeInfo")]
+    fn query_runtime_info<C: Context>(
+        ctx: &mut C,
+        _args: (),
+    ) -> Result<RuntimeInfoResponse, Error> {
+        Ok(RuntimeInfoResponse {
+            runtime_version: <C::Runtime as Runtime>::VERSION,
+            state_version: <C::Runtime as Runtime>::STATE_VERSION,
+            modules: <C::Runtime as Runtime>::Modules::module_info(ctx),
+        })
     }
 }
 

--- a/runtime-sdk/src/modules/core/types.rs
+++ b/runtime-sdk/src/modules/core/types.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Key in the versions map used for the global state version.
 pub const VERSION_GLOBAL_KEY: &str = "";
 
-/// Per-module metadata.
+/// Basic per-module metadata; tracked in core module's state.
 #[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
 pub struct Metadata {
     /// A set of state versions for all supported modules.
@@ -31,4 +31,41 @@ pub struct EstimateGasQuery {
 pub struct CallDataPublicKeyQueryResponse {
     /// Public key used for deriving the shared secret for encrypting call data.
     pub public_key: SignedPublicKey,
+}
+
+#[derive(Debug, Copy, Clone, cbor::Encode, cbor::Decode)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub enum MethodHandlerKind {
+    #[cbor(rename = "call")]
+    Call,
+    // `Prefetch` is omitted because it is an implementation detail of handling `Call`s.
+    #[cbor(rename = "query")]
+    Query,
+    #[cbor(rename = "message_result")]
+    MessageResult,
+}
+
+#[derive(Debug, Clone, cbor::Encode, cbor::Decode)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct MethodHandlerInfo {
+    pub kind: MethodHandlerKind,
+    pub name: String,
+}
+
+/// Metadata for an individual module.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct ModuleInfo {
+    pub version: u32,
+    pub params: cbor::Value,
+    pub methods: Vec<MethodHandlerInfo>,
+}
+
+/// Response to the RuntimeInfo query.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct RuntimeInfoResponse {
+    pub runtime_version: oasis_core_runtime::common::version::Version,
+    pub state_version: u32,
+    pub modules: BTreeMap<String, ModuleInfo>,
 }

--- a/runtime-sdk/src/runtime.rs
+++ b/runtime-sdk/src/runtime.rs
@@ -16,7 +16,10 @@ use crate::{
     context::Context,
     crypto, dispatcher,
     keymanager::{KeyManagerClient, TrustedPolicySigners},
-    module::{BlockHandler, InvariantHandler, MethodHandler, MigrationHandler, TransactionHandler},
+    module::{
+        BlockHandler, InvariantHandler, MethodHandler, MigrationHandler, ModuleInfoHandler,
+        TransactionHandler,
+    },
     modules, storage,
 };
 
@@ -41,7 +44,8 @@ pub trait Runtime {
         + MigrationHandler
         + MethodHandler
         + BlockHandler
-        + InvariantHandler;
+        + InvariantHandler
+        + ModuleInfoHandler;
 
     /// Return the trusted policy signers for this runtime; if `None`, a key manager connection will
     /// not be established on startup.

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -30,6 +30,7 @@ var (
 		TransactionsQueryTest,
 		BlockQueryTest,
 		ParametersTest,
+		IntrospectionTest,
 	})
 
 	// SimpleConsensusRuntime is the simple-consensus runtime test.


### PR DESCRIPTION
Resolves #652 .

Adds a new `core.RuntimeInfo` query to the `core` module which provides basic information about the runtime and the modules it contains. See the bottom of `core/test.rs` for sample output.