### PR TITLE
runtime-sdk: Add support for runtime schedule control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-client"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.9#eb029c8d31ff4d026c46497a6d17aae5b2e26caf"
 dependencies = [
  "anyhow",
  "futures",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-keymanager-api-common"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.9#eb029c8d31ff4d026c46497a6d17aae5b2e26caf"
 dependencies = [
  "anyhow",
  "base64",
@@ -1871,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-keymanager-client"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.9#eb029c8d31ff4d026c46497a6d17aae5b2e26caf"
 dependencies = [
  "futures",
  "io-context",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "oasis-core-runtime"
 version = "0.0.0"
-source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.8#1d50e3c6630678c80fd61e41bed7feee160fe23c"
+source = "git+https://github.com/oasisprotocol/oasis-core?tag=v21.3.9#eb029c8d31ff4d026c46497a6d17aae5b2e26caf"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,6 +3065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-runtime-simple-contracts"
+version = "0.1.0"
+dependencies = [
+ "oasis-cbor",
+ "oasis-runtime-sdk",
+ "oasis-runtime-sdk-contracts",
+ "thiserror",
+]
+
+[[package]]
 name = "test-runtime-simple-evm"
 version = "0.1.0"
 dependencies = [
@@ -3082,7 +3092,6 @@ dependencies = [
  "futures",
  "oasis-cbor",
  "oasis-runtime-sdk",
- "oasis-runtime-sdk-contracts",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "tests/runtimes/simple-keyvalue",
     "tests/runtimes/simple-consensus",
     "tests/runtimes/simple-evm",
+    "tests/runtimes/simple-contracts",
 ]
 exclude = [
     # Test contracts.

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
-	github.com/oasisprotocol/oasis-core/go v0.2103.8
+	github.com/oasisprotocol/oasis-core/go v0.2103.9
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.3.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -880,8 +880,8 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84 h1:VG
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.9 h1:d2V2EaMCYcE1lksolS0CdP8mn8tWlcjd0sGaW9n6zkI=
+github.com/oasisprotocol/oasis-core/go v0.2103.9/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/client-sdk/go/go.mod
+++ b/client-sdk/go/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
 	github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956
-	github.com/oasisprotocol/oasis-core/go v0.2103.8
+	github.com/oasisprotocol/oasis-core/go v0.2103.9
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5

--- a/client-sdk/go/go.sum
+++ b/client-sdk/go/go.sum
@@ -817,8 +817,8 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84/go.mo
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.9 h1:d2V2EaMCYcE1lksolS0CdP8mn8tWlcjd0sGaW9n6zkI=
+github.com/oasisprotocol/oasis-core/go v0.2103.9/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2/go.mod h1:agEnj5cjmg55z8CtL/Nva9LqxR4402T1TFPC4kuNBMc=

--- a/client-sdk/ts-web/core/reflect-go/go.mod
+++ b/client-sdk/ts-web/core/reflect-go/go.mod
@@ -2,7 +2,7 @@ module github.com/oasisprotocol/oasis-sdk/client-sdk/ts-web/core/reflect-go
 
 go 1.17
 
-require github.com/oasisprotocol/oasis-core/go v0.2103.8
+require github.com/oasisprotocol/oasis-core/go v0.2103.9
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/client-sdk/ts-web/core/reflect-go/go.sum
+++ b/client-sdk/ts-web/core/reflect-go/go.sum
@@ -820,8 +820,8 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 h1:qnvTxmtjcuRH5NiI0Kiku6TXi2VReR/PxHFf3ahFYrg=
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.9 h1:d2V2EaMCYcE1lksolS0CdP8mn8tWlcjd0sGaW9n6zkI=
+github.com/oasisprotocol/oasis-core/go v0.2103.9/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/client-sdk/ts-web/rt/playground/src/index.js
+++ b/client-sdk/ts-web/rt/playground/src/index.js
@@ -12,7 +12,7 @@ const FEE_FREE = /** @type {oasisRT.types.BaseUnits} */ ([
     oasis.quantity.fromBigInt(0n),
     oasisRT.token.NATIVE_DENOMINATION,
 ]);
-const GAS_HIGH = 1_000_000n;
+const GAS_HIGH = 800n;
 
 /**
  * The name of our module.

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -7,10 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 cbor = { version = "0.2.1", package = "oasis-cbor" }
-oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
-oasis-core-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
-oasis-core-keymanager-api-common = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
-oasis-core-keymanager-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.8" }
+oasis-core-runtime = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.9" }
+oasis-core-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.9" }
+oasis-core-keymanager-api-common = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.9" }
+oasis-core-keymanager-client = { git = "https://github.com/oasisprotocol/oasis-core", tag = "v21.3.9" }
 oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 
 # Third party.

--- a/runtime-sdk/src/config.rs
+++ b/runtime-sdk/src/config.rs
@@ -1,0 +1,16 @@
+//! Configuration types.
+
+/// Runtime schedule control configuration.
+pub struct ScheduleControl {
+    /// Size of the initial batch that the node should provide to the runtime.
+    pub initial_batch_size: u32,
+    /// Size of each extra batch that the runtime should fetch.
+    pub batch_size: u32,
+    /// Minimum amount of gas that needs to be remaining in a batch in order to still consider
+    /// including new transactions.
+    pub min_remaining_gas: u64,
+    /// Maximum number of transactions that can go in a batch.
+    ///
+    /// This is only used as a last resort to avoid the batch going over the runtime's limit.
+    pub max_tx_count: usize,
+}

--- a/runtime-sdk/src/lib.rs
+++ b/runtime-sdk/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(int_log)]
 
 pub mod callformat;
+pub mod config;
 pub mod context;
 pub mod crypto;
 pub mod dispatcher;
@@ -13,6 +14,7 @@ pub mod keymanager;
 pub mod module;
 pub mod modules;
 pub mod runtime;
+pub mod schedule_control;
 pub mod storage;
 pub mod testing;
 pub mod types;

--- a/runtime-sdk/src/schedule_control.rs
+++ b/runtime-sdk/src/schedule_control.rs
@@ -1,0 +1,37 @@
+//! Types related to schedule control.
+use oasis_core_runtime::{
+    common::crypto::hash::Hash, transaction::types::TxnBatch, types::Body, Protocol,
+};
+
+/// Unique module name.
+const MODULE_NAME: &str = "schedule_control";
+
+/// Schedule control errors.
+#[derive(Debug, thiserror::Error, oasis_runtime_sdk_macros::Error)]
+pub enum Error {
+    #[error("failed to fetch batch from host")]
+    #[sdk_error(code = 1)]
+    FailedToFetchBatch,
+}
+
+/// Interface to the runtime host that supports schedule control features.
+pub trait ScheduleControlHost: Send + Sync {
+    /// Fetch the specified set of transactions from the host's transaction queue.
+    ///
+    /// Offset specifies the transaction hash that should serve as an offset when returning
+    /// transactions from the pool. Transactions will be skipped until the given hash is encountered
+    /// and only following transactions will be returned.
+    fn fetch_tx_batch(&self, offset: Option<Hash>, limit: u32) -> Result<Option<TxnBatch>, Error>;
+}
+
+impl ScheduleControlHost for Protocol {
+    fn fetch_tx_batch(&self, offset: Option<Hash>, limit: u32) -> Result<Option<TxnBatch>, Error> {
+        match self.call_host(
+            io_context::Context::background(),
+            Body::HostFetchTxBatchRequest { offset, limit },
+        ) {
+            Ok(Body::HostFetchTxBatchResponse { batch }) => Ok(batch),
+            _ => Err(Error::FailedToFetchBatch),
+        }
+    }
+}

--- a/tests/benchmark/go.mod
+++ b/tests/benchmark/go.mod
@@ -15,7 +15,7 @@ replace (
 )
 
 require (
-	github.com/oasisprotocol/oasis-core/go v0.2103.8
+	github.com/oasisprotocol/oasis-core/go v0.2103.9
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1

--- a/tests/benchmark/go.sum
+++ b/tests/benchmark/go.sum
@@ -923,8 +923,8 @@ github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.9 h1:d2V2EaMCYcE1lksolS0CdP8mn8tWlcjd0sGaW9n6zkI=
+github.com/oasisprotocol/oasis-core/go v0.2103.9/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=

--- a/tests/consts.sh
+++ b/tests/consts.sh
@@ -6,7 +6,7 @@
 
 # Released version from GitHub Releases.
 # e.g. '21.1.2'
-OASIS_CORE_VERSION='21.3.8'
+OASIS_CORE_VERSION='21.3.9'
 
 # Development version from GitHub Actions.
 # e.g. '58512799'
@@ -16,4 +16,4 @@ GITHUB_ARTIFACT_VERSION=''
 
 # Version from Buildkite.
 # e.g. '4759'
-BUILD_NUMBER='6985' # v21.3.8
+BUILD_NUMBER='7069' # v21.3.9

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -22,7 +22,7 @@ replace (
 require (
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84
-	github.com/oasisprotocol/oasis-core/go v0.2103.8
+	github.com/oasisprotocol/oasis-core/go v0.2103.9
 	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.41.0
 )

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -930,8 +930,8 @@ github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2103.8 h1:4EvDfy18Qx/aDO9gDYjw8yPRaEgAMJmCtiFC2By8nJo=
-github.com/oasisprotocol/oasis-core/go v0.2103.8/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-core/go v0.2103.9 h1:d2V2EaMCYcE1lksolS0CdP8mn8tWlcjd0sGaW9n6zkI=
+github.com/oasisprotocol/oasis-core/go v0.2103.9/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661 h1:MB73kGMtuMGS+6VDoU/mitzff7Cu+aZo9ta5wabuxVA=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.9-oasis2 h1:wVFJjLnmen7QXpIAznbiGHOeVrX5oNtJMUk0rrpSmG8=

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -25,7 +25,6 @@ var (
 		KVMultisigTest,
 		KVRewardsTest,
 		KVTxGenTest,
-		ContractsTest,
 		ConfidentialTest,
 		TransactionsQueryTest,
 		BlockQueryTest,
@@ -42,6 +41,11 @@ var (
 		SimpleSolEVMTestCreateMulti,
 		SimpleERC20EVMTest,
 	})
+
+	// SimpleContractsRuntime is the simple-contracts runtime test.
+	SimpleContractsRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-contracts", []RunTestFunction{
+		ContractsTest,
+	})
 )
 
 // RegisterScenarios registers all oasis-sdk end-to-end runtime tests.
@@ -57,6 +61,7 @@ func RegisterScenarios() error {
 		SimpleKVRuntime,
 		SimpleConsensusRuntime,
 		SimpleEVMRuntime,
+		SimpleContractsRuntime,
 	} {
 		if err := cmd.Register(s); err != nil {
 			return err

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -296,7 +296,7 @@ func ConfidentialTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Clien
 		Key:   testKey,
 		Value: testValue,
 	})
-	tb.SetFeeGas(10 * defaultGasAmount)
+	tb.SetFeeGas(2 * defaultGasAmount)
 	if err = tb.SetCallFormat(ctx, types.CallFormatEncryptedX25519DeoxysII); err != nil {
 		return fmt.Errorf("failed to set call format: %w", err)
 	}
@@ -327,7 +327,7 @@ func TransactionsQueryTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.
 		Key:   testKey,
 		Value: testValue,
 	})
-	tb.SetFeeGas(10 * defaultGasAmount)
+	tb.SetFeeGas(2 * defaultGasAmount)
 	tb.AppendAuthSignature(sigspecForSigner(signer), nonce)
 	_ = tb.AppendSign(ctx, signer)
 	var meta *client.TransactionMeta
@@ -892,7 +892,7 @@ func KVTxGenTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn
 		"round_end", blk.Header.Round,
 	)
 	for round := initialRound; round <= blk.Header.Round; round++ {
-		txs, err := rtc.GetTransactions(ctx, round)
+		txs, err := rtc.GetTransactionsWithResults(ctx, round)
 		if err != nil {
 			return fmt.Errorf("failed to fetch transactions for round %d: %w", round, err)
 		}
@@ -901,11 +901,12 @@ func KVTxGenTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn
 		var (
 			gasPrices     []uint64
 			gasLimits     []uint64
+			results       []bool
 			totalGasLimit uint64
 		)
-		for _, utx := range txs {
+		for _, rtx := range txs {
 			var tx types.Transaction
-			if err = cbor.Unmarshal(utx.Body, &tx); err != nil {
+			if err = cbor.Unmarshal(rtx.Tx.Body, &tx); err != nil {
 				return fmt.Errorf("bad transaction in round %d: %w", round, err)
 			}
 
@@ -913,6 +914,7 @@ func KVTxGenTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn
 			gasPrices = append(gasPrices, gasPrice)
 			gasLimits = append(gasLimits, tx.AuthInfo.Fee.Gas)
 			totalGasLimit += tx.AuthInfo.Fee.Gas
+			results = append(results, rtx.Result.IsSuccess())
 		}
 
 		log.Info("got batch gas information",
@@ -920,6 +922,7 @@ func KVTxGenTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn
 			"prices", gasPrices,
 			"limits", gasLimits,
 			"total_limit", totalGasLimit,
+			"results", results,
 		)
 		// NOTE: The sum of gasLimits can be greater than the batch limit as the transaction could
 		//       have used less than the limit during actual execution.

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -57,6 +57,11 @@ cd "${TESTS_DIR}"/runtimes/simple-evm
 cargo build
 cp "${TESTS_DIR}"/../target/debug/test-runtime-simple-evm "${TEST_BASE_DIR}"/
 
+printf "${CYAN}### Building test simple-contracts runtime...${OFF}\n"
+cd "${TESTS_DIR}"/runtimes/simple-contracts
+cargo build
+cp "${TESTS_DIR}"/../target/debug/test-runtime-simple-contracts "${TEST_BASE_DIR}"/
+
 printf "${CYAN}### Building test hello contract...${OFF}\n"
 cd "${TESTS_DIR}"/contracts/hello
 cargo build --target wasm32-unknown-unknown --release

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -1,7 +1,7 @@
 //! Simple consensus runtime.
 use std::collections::BTreeMap;
 
-use oasis_runtime_sdk::{self as sdk, modules, types::token::Denomination, Version};
+use oasis_runtime_sdk::{self as sdk, config, modules, types::token::Denomination, Version};
 
 pub struct Config;
 
@@ -12,6 +12,14 @@ pub struct Runtime;
 
 impl sdk::Runtime for Runtime {
     const VERSION: Version = sdk::version_from_cargo!();
+
+    // Enable the runtime schedule control feature.
+    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+        initial_batch_size: 50,
+        batch_size: 50,
+        min_remaining_gas: 100,
+        max_tx_count: 1000,
+    });
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-contracts/Cargo.toml
+++ b/tests/runtimes/simple-contracts/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
-name = "test-runtime-simple-keyvalue"
+name = "test-runtime-simple-contracts"
 version = "0.1.0"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-oasis-runtime-sdk = { path = "../../../runtime-sdk" }
 cbor = { version = "0.2.1", package = "oasis-cbor" }
+oasis-runtime-sdk = { path = "../../../runtime-sdk" }
+oasis-runtime-sdk-contracts = { path = "../../../runtime-sdk/modules/contracts" }
 
 # Third party.
-anyhow = "1.0.50"
 thiserror = "1.0"
-futures = "0.3.18"

--- a/tests/runtimes/simple-contracts/src/lib.rs
+++ b/tests/runtimes/simple-contracts/src/lib.rs
@@ -1,0 +1,87 @@
+//! Simple WASM contracts runtime.
+use std::collections::BTreeMap;
+
+use oasis_runtime_sdk::{self as sdk, config, modules, types::token::Denomination, Version};
+use oasis_runtime_sdk_contracts as contracts;
+
+/// Simple EVM runtime.
+pub struct Runtime;
+
+/// Runtime configuration.
+pub struct Config;
+
+impl modules::core::Config for Config {}
+
+impl contracts::Config for Config {
+    type Accounts = modules::accounts::Module;
+}
+
+impl sdk::Runtime for Runtime {
+    const VERSION: Version = sdk::version_from_cargo!();
+
+    // Enable the runtime schedule control feature.
+    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+        initial_batch_size: 50,
+        batch_size: 50,
+        min_remaining_gas: 100,
+        max_tx_count: 1000,
+    });
+
+    type Core = modules::core::Module<Config>;
+
+    type Modules = (
+        modules::accounts::Module,
+        modules::core::Module<Config>,
+        contracts::Module<Config>,
+    );
+
+    fn genesis_state() -> <Self::Modules as sdk::module::MigrationHandler>::Genesis {
+        (
+            modules::accounts::Genesis {
+                parameters: Default::default(),
+                balances: {
+                    let mut b = BTreeMap::new();
+                    // Alice.
+                    b.insert(sdk::testing::keys::alice::address(), {
+                        let mut d = BTreeMap::new();
+                        d.insert(Denomination::NATIVE, 10_000_000);
+                        d
+                    });
+                    // Dave.
+                    b.insert(sdk::testing::keys::dave::address(), {
+                        let mut d = BTreeMap::new();
+                        d.insert(Denomination::NATIVE, 100_000_000);
+                        d
+                    });
+                    b
+                },
+                total_supplies: {
+                    let mut ts = BTreeMap::new();
+                    ts.insert(Denomination::NATIVE, 110_000_000);
+                    ts
+                },
+                ..Default::default()
+            },
+            modules::core::Genesis {
+                parameters: modules::core::Parameters {
+                    max_batch_gas: 10_000_000,
+                    max_tx_signers: 8,
+                    max_multisig_signers: 8,
+                    gas_costs: modules::core::GasCosts {
+                        auth_signature: 0,
+                        auth_multisig_signer: 0,
+                        ..Default::default()
+                    },
+                    min_gas_price: {
+                        let mut mgp = BTreeMap::new();
+                        mgp.insert(Denomination::NATIVE, 0);
+                        mgp
+                    },
+                },
+            },
+            contracts::Genesis {
+                parameters: Default::default(),
+            },
+        )
+    }
+}

--- a/tests/runtimes/simple-contracts/src/main.rs
+++ b/tests/runtimes/simple-contracts/src/main.rs
@@ -1,0 +1,5 @@
+use oasis_runtime_sdk::Runtime;
+
+fn main() {
+    test_runtime_simple_contracts::Runtime::start();
+}

--- a/tests/runtimes/simple-evm/src/lib.rs
+++ b/tests/runtimes/simple-evm/src/lib.rs
@@ -1,7 +1,7 @@
 //! Simple EVM runtime.
 use std::collections::BTreeMap;
 
-use oasis_runtime_sdk::{self as sdk, modules, types::token::Denomination, Version};
+use oasis_runtime_sdk::{self as sdk, config, modules, types::token::Denomination, Version};
 use oasis_runtime_sdk_evm as evm;
 
 /// Simple EVM runtime.
@@ -22,6 +22,14 @@ impl evm::Config for Config {
 
 impl sdk::Runtime for Runtime {
     const VERSION: Version = sdk::version_from_cargo!();
+
+    // Enable the runtime schedule control feature.
+    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+        initial_batch_size: 50,
+        batch_size: 50,
+        min_remaining_gas: 100,
+        max_tx_count: 1000,
+    });
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -2,7 +2,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use oasis_runtime_sdk::{
-    self as sdk,
+    self as sdk, config,
     core::common::crypto::signature::PrivateKey,
     keymanager::TrustedPolicySigners,
     modules,
@@ -34,6 +34,14 @@ impl sdk::Runtime for Runtime {
     // but only in a later version when you need to update some of the parameters. We do this here
     // to test the migration functionality.
     const STATE_VERSION: u32 = 1;
+
+    // Enable the runtime schedule control feature.
+    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+        initial_batch_size: 2,
+        batch_size: 50,
+        min_remaining_gas: 100,
+        max_tx_count: 1000,
+    });
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -9,7 +9,6 @@ use oasis_runtime_sdk::{
     types::token::{BaseUnits, Denomination},
     Module as _, Version,
 };
-use oasis_runtime_sdk_contracts as contracts;
 
 pub mod keyvalue;
 #[cfg(test)]
@@ -22,10 +21,6 @@ pub struct Runtime;
 pub struct Config;
 
 impl modules::core::Config for Config {}
-
-impl contracts::Config for Config {
-    type Accounts = modules::accounts::Module;
-}
 
 impl sdk::Runtime for Runtime {
     const VERSION: Version = sdk::version_from_cargo!();
@@ -50,7 +45,6 @@ impl sdk::Runtime for Runtime {
         modules::accounts::Module,
         modules::rewards::Module<modules::accounts::Module>,
         modules::core::Module<Config>,
-        contracts::Module<Config>,
     );
 
     fn trusted_policy_signers() -> Option<TrustedPolicySigners> {
@@ -161,9 +155,6 @@ impl sdk::Runtime for Runtime {
                         mgp
                     },
                 },
-            },
-            contracts::Genesis {
-                parameters: Default::default(),
             },
         )
     }

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -140,14 +140,14 @@ impl sdk::Runtime for Runtime {
             },
             modules::core::Genesis {
                 parameters: modules::core::Parameters {
-                    max_batch_gas: 10_000_000,
+                    max_batch_gas: 2_000,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     gas_costs: modules::core::GasCosts {
                         tx_byte: 1,
                         auth_signature: 10,
                         auth_multisig_signer: 10,
-                        callformat_x25519_deoxysii: 1000,
+                        callformat_x25519_deoxysii: 50,
                     },
                     min_gas_price: {
                         let mut mgp = BTreeMap::new();


### PR DESCRIPTION
Requires a new version of Oasis Core.

TODO
* [x] More tests.
* [x] Fetch more transactions from queue when space remains in batch.
* [x] Use released version of Oasis Core.