### PR TITLE
Add debugging niceties

### DIFF
--- a/contract-sdk/Cargo.toml
+++ b/contract-sdk/Cargo.toml
@@ -22,3 +22,4 @@ wee_alloc = "0.4.5"
 
 [features]
 default = ["oasis-contract-sdk-macros"]
+debug-utils = []

--- a/contract-sdk/src/abi/env.rs
+++ b/contract-sdk/src/abi/env.rs
@@ -20,6 +20,9 @@ extern "C" {
 
     #[link_name = "address_for_instance"]
     fn env_address_for_instance(instance_id: u64, dst_ptr: u32, dst_len: u32);
+
+    #[link_name = "debug_print"]
+    fn env_debug_print(msg_ptr: u32, msg_len: u32);
 }
 
 /// Performs an environment query.
@@ -53,6 +56,17 @@ impl Env for HostEnv {
         // Parse the returned address.
         Address::try_from(dst.as_ref()).unwrap()
     }
+
+    #[cfg(feature = "debug-utils")]
+    fn debug_print(&self, msg: &str) {
+        debug_print(msg)
+    }
+}
+
+#[cfg(feature = "debug-utils")]
+pub(crate) fn debug_print(msg: &str) {
+    let msg_region = HostRegionRef::from_slice(msg.as_bytes());
+    unsafe { env_debug_print(msg_region.offset, msg_region.length) };
 }
 
 impl Crypto for HostEnv {

--- a/contract-sdk/src/env.rs
+++ b/contract-sdk/src/env.rs
@@ -13,6 +13,10 @@ pub trait Env {
 
     /// Returns an address for the contract instance id.
     fn address_for_instance(&self, instance_id: InstanceId) -> Address;
+
+    /// Prints a message to the console. Useful when debugging.
+    #[cfg(feature = "debug-utils")]
+    fn debug_print(&self, msg: &str);
 }
 
 /// Crypto helpers trait.

--- a/contract-sdk/src/testing.rs
+++ b/contract-sdk/src/testing.rs
@@ -77,6 +77,11 @@ impl Env for MockEnv {
         .concat();
         Address::from_bytes(&b).unwrap()
     }
+
+    #[cfg(feature = "debug-utils")]
+    fn debug_print(&self, msg: &str) {
+        eprintln!("{}", msg);
+    }
 }
 
 impl Crypto for MockEnv {

--- a/runtime-sdk/modules/contracts/Cargo.toml
+++ b/runtime-sdk/modules/contracts/Cargo.toml
@@ -27,3 +27,6 @@ walrus = "0.19.0"
 
 [dev-dependencies]
 wat = "1.0"
+
+[features]
+debug-utils = []

--- a/runtime-sdk/modules/contracts/src/abi/oasis/env.rs
+++ b/runtime-sdk/modules/contracts/src/abi/oasis/env.rs
@@ -82,6 +82,24 @@ impl<Cfg: Config> OasisV1<Cfg> {
             },
         );
 
+        // env.debug_print(messsage, len)
+        #[cfg(feature = "debug-utils")]
+        let _ = instance.link_function(
+            "env",
+            "debug_print",
+            |ctx, request: (u32, u32)| -> Result<(), wasm3::Trap> {
+                ctx.instance
+                    .runtime()
+                    .try_with_memory(|memory| -> Result<_, wasm3::Trap> {
+                        let msg_bytes = Region::from_arg(request).as_slice(&memory)?;
+                        if let Ok(msg) = std::str::from_utf8(msg_bytes) {
+                            eprintln!("{}", msg);
+                        }
+                        Ok(())
+                    })?
+            },
+        );
+
         Ok(())
     }
 }

--- a/runtime-sdk/modules/contracts/src/lib.rs
+++ b/runtime-sdk/modules/contracts/src/lib.rs
@@ -329,7 +329,7 @@ impl<Cfg: Config> Module<Cfg> {
 #[sdk_derive(MethodHandler)]
 impl<Cfg: Config> Module<Cfg> {
     #[handler(call = "contracts.Upload")]
-    fn tx_upload<C: TxContext>(
+    pub fn tx_upload<C: TxContext>(
         ctx: &mut C,
         body: types::Upload,
     ) -> Result<types::UploadResult, Error> {
@@ -425,7 +425,7 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(call = "contracts.Instantiate")]
-    fn tx_instantiate<C: TxContext>(
+    pub fn tx_instantiate<C: TxContext>(
         ctx: &mut C,
         body: types::Instantiate,
     ) -> Result<types::InstantiateResult, Error> {
@@ -496,7 +496,10 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(call = "contracts.Call")]
-    fn tx_call<C: TxContext>(ctx: &mut C, body: types::Call) -> Result<types::CallResult, Error> {
+    pub fn tx_call<C: TxContext>(
+        ctx: &mut C,
+        body: types::Call,
+    ) -> Result<types::CallResult, Error> {
         let params = Self::params(ctx.runtime_state());
         let caller = ctx.tx_caller_address();
 
@@ -548,7 +551,7 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(call = "contracts.Upgrade")]
-    fn tx_upgrade<C: TxContext>(ctx: &mut C, body: types::Upgrade) -> Result<(), Error> {
+    pub fn tx_upgrade<C: TxContext>(ctx: &mut C, body: types::Upgrade) -> Result<(), Error> {
         let params = Self::params(ctx.runtime_state());
         let caller = ctx.tx_caller_address();
 
@@ -626,12 +629,15 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(query = "contracts.Code")]
-    fn query_code<C: Context>(ctx: &mut C, args: types::CodeQuery) -> Result<types::Code, Error> {
+    pub fn query_code<C: Context>(
+        ctx: &mut C,
+        args: types::CodeQuery,
+    ) -> Result<types::Code, Error> {
         Self::load_code_info(ctx, args.id)
     }
 
     #[handler(query = "contracts.Instance")]
-    fn query_instance<C: Context>(
+    pub fn query_instance<C: Context>(
         ctx: &mut C,
         args: types::InstanceQuery,
     ) -> Result<types::Instance, Error> {
@@ -639,7 +645,7 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(query = "contracts.InstanceStorage")]
-    fn query_instance_storage<C: Context>(
+    pub fn query_instance_storage<C: Context>(
         ctx: &mut C,
         args: types::InstanceStorageQuery,
     ) -> Result<types::InstanceStorageQueryResult, Error> {
@@ -653,7 +659,7 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(query = "contracts.PublicKey")]
-    fn query_public_key<C: Context>(
+    pub fn query_public_key<C: Context>(
         _ctx: &mut C,
         _args: types::PublicKeyQuery,
     ) -> Result<types::PublicKeyQueryResult, Error> {
@@ -661,7 +667,7 @@ impl<Cfg: Config> Module<Cfg> {
     }
 
     #[handler(query = "contracts.Custom")]
-    fn query_custom<C: Context>(
+    pub fn query_custom<C: Context>(
         ctx: &mut C,
         args: types::CustomQuery,
     ) -> Result<types::CustomQueryResult, Error> {
@@ -707,13 +713,13 @@ impl<Cfg: Config> module::Module for Module<Cfg> {
 
 impl<Cfg: Config> Module<Cfg> {
     /// Initialize state from genesis.
-    fn init<C: Context>(ctx: &mut C, genesis: Genesis) {
+    pub fn init<C: Context>(ctx: &mut C, genesis: Genesis) {
         // Set genesis parameters.
         Self::set_params(ctx.runtime_state(), genesis.parameters);
     }
 
     /// Migrate state from a previous version.
-    fn migrate<C: Context>(_ctx: &mut C, _from: u32) -> bool {
+    pub fn migrate<C: Context>(_ctx: &mut C, _from: u32) -> bool {
         // No migrations currently supported.
         false
     }


### PR DESCRIPTION
This PR:
* adds a `debug_print` method for inspecting the state of the contract
* makes methods on `Module` public so that third parties can programmatically invoke the environment (I copied over the e2e tests from this repo to my own crate, with good results)