### PR TITLE
client-sdk/go: add package DecodeEvent methods

### DIFF
--- a/client-sdk/go/modules/accounts/accounts.go
+++ b/client-sdk/go/modules/accounts/accounts.go
@@ -119,6 +119,11 @@ func (a *v1) GetEvents(ctx context.Context, round uint64) ([]*Event, error) {
 
 // Implements client.EventDecoder.
 func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
+	return DecodeEvent(event)
+}
+
+// DecodeEvent decodes an accounts event.
+func DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	if event.Module != ModuleName {
 		return nil, nil
 	}

--- a/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
+++ b/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
@@ -107,6 +107,10 @@ func (a *v1) GetEvents(ctx context.Context, round uint64) ([]*Event, error) {
 
 // Implements client.EventDecoder.
 func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
+	return DecodeEvent(event)
+}
+
+func DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	if event.Module != ModuleName {
 		return nil, nil
 	}

--- a/client-sdk/go/modules/contracts/contracts.go
+++ b/client-sdk/go/modules/contracts/contracts.go
@@ -245,6 +245,11 @@ func (a *v1) GetEvents(ctx context.Context, instanceID InstanceID, round uint64)
 
 // Implements client.EventDecoder.
 func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
+	return DecodeEvent(event)
+}
+
+// DecodeEvent decodes a contract event.
+func DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	// "contracts" or "contracts.<...>".
 	if event.Module != ModuleName && !strings.HasPrefix(event.Module, ModuleName+".") {
 		return nil, nil

--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -96,6 +96,11 @@ func (a *v1) GetEvents(ctx context.Context, round uint64) ([]*Event, error) {
 
 // Implements client.EventDecoder.
 func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
+	return DecodeEvent(event)
+}
+
+// DecodeEvent decodes a core event.
+func DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	if event.Module != ModuleName {
 		return nil, nil
 	}

--- a/client-sdk/go/modules/evm/evm.go
+++ b/client-sdk/go/modules/evm/evm.go
@@ -152,6 +152,11 @@ func (a *v1) GetEvents(ctx context.Context, round uint64) ([]*Event, error) {
 
 // Implements client.EventDecoder.
 func (a *v1) DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
+	return DecodeEvent(event)
+}
+
+// DecodeEvent decodes an evm event.
+func DecodeEvent(event *types.Event) ([]client.DecodedEvent, error) {
 	if event.Module != ModuleName || event.Code != 1 {
 		return nil, nil
 	}


### PR DESCRIPTION
This is useful when you already have raw events that you want to decode (e.g. obtained via `TransactionWithResults`) and no runtime client.