### PR TITLE
ci: cancel concurrent in-progress workflows on same branch

### DIFF
--- a/.github/workflows/benchmarking-image.yml
+++ b/.github/workflows/benchmarking-image.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-benchmarking-image:

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -9,6 +9,11 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   audit:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
 
   publish-docs:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -15,6 +15,11 @@ on:
       - main
       - stable/*
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint-rust:

--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   check-reproducible-build:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -15,6 +15,11 @@ on:
       - main
       - stable/*
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test-rust:

--- a/.github/workflows/runtime-builder-image.yml
+++ b/.github/workflows/runtime-builder-image.yml
@@ -26,6 +26,11 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
+# Cancel in-progress jobs on same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-runtime-builder:


### PR DESCRIPTION
Default behavior is that in-progress runs are not canceled (e.g. when pushing new changes to a branch).