### PR TITLE
runtime-sdk-macros: automatically implement parameters query handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,18 +1757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oasis-contract-sdk-oas20"
-version = "0.1.0"
-dependencies = [
- "base64",
- "oasis-cbor",
- "oasis-contract-sdk",
- "oasis-contract-sdk-storage",
- "oasis-contract-sdk-types",
- "thiserror",
-]
-
-[[package]]
 name = "oasis-contract-sdk-storage"
 version = "0.1.0"
 dependencies = [

--- a/client-sdk/go/modules/accounts/accounts.go
+++ b/client-sdk/go/modules/accounts/accounts.go
@@ -15,6 +15,7 @@ const (
 	methodTransfer = "accounts.Transfer"
 
 	// Queries.
+	methodParameters       = "accounts.Parameters"
 	methodNonce            = "accounts.Nonce"
 	methodBalances         = "accounts.Balances"
 	methodAddresses        = "accounts.Addresses"
@@ -27,6 +28,9 @@ type V1 interface {
 
 	// Transfer generates an accounts.Transfer transaction.
 	Transfer(to types.Address, amount types.BaseUnits) *client.TransactionBuilder
+
+	// Parameters queries the accounts module parameters.
+	Parameters(ctx context.Context, round uint64) (*Parameters, error)
 
 	// Nonce queries the given account's nonce.
 	Nonce(ctx context.Context, round uint64, address types.Address) (uint64, error)
@@ -54,6 +58,16 @@ func (a *v1) Transfer(to types.Address, amount types.BaseUnits) *client.Transact
 		To:     to,
 		Amount: amount,
 	})
+}
+
+// Implements V1.
+func (a *v1) Parameters(ctx context.Context, round uint64) (*Parameters, error) {
+	var params Parameters
+	err := a.rc.Query(ctx, round, methodParameters, nil, &params)
+	if err != nil {
+		return nil, err
+	}
+	return &params, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/accounts/types.go
+++ b/client-sdk/go/modules/accounts/types.go
@@ -44,6 +44,19 @@ type DenominationInfo struct {
 // Addresses is the response of the accounts.Addresses query.
 type Addresses []types.Address
 
+// GasCosts are the accounts module gas costs.
+type GasCosts struct {
+	TxTransfer uint64 `json:"tx_transfer"`
+}
+
+// Parameters are the parameters for the accounts module.
+type Parameters struct {
+	TransfersDisabled      bool                                    `json:"transfers_disabled"`
+	GasCosts               GasCosts                                `json:"gas_costs"`
+	DebugDisableNonceCheck bool                                    `json:"debug_disable_nonce_check,omitempty"`
+	DenominationInfos      map[types.Denomination]DenominationInfo `json:"denomination_infos,omitempty"`
+}
+
 // ModuleName is the accounts module name.
 const ModuleName = "accounts"
 

--- a/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
+++ b/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
@@ -17,8 +17,9 @@ const (
 	methodWithdraw = "consensus.Withdraw"
 
 	// Queries.
-	methodBalance = "consensus.Balance"
-	methodAccount = "consensus.Account"
+	methodParameters = "consensus_accounts.Parameters"
+	methodBalance    = "consensus.Balance"
+	methodAccount    = "consensus.Account"
 )
 
 // V1 is the v1 consensus accounts module interface.
@@ -30,6 +31,9 @@ type V1 interface {
 
 	// Withdraw generates a consensus.Withdraw transaction.
 	Withdraw(to *types.Address, amount types.BaseUnits) *client.TransactionBuilder
+
+	// Parameters queries the consensus accounts module parameters.
+	Parameters(ctx context.Context, round uint64) (*Parameters, error)
 
 	// Balance queries the given account's balance of consensus denomination tokens.
 	Balance(ctx context.Context, round uint64, query *BalanceQuery) (*AccountBalance, error)
@@ -59,6 +63,16 @@ func (a *v1) Withdraw(to *types.Address, amount types.BaseUnits) *client.Transac
 		To:     to,
 		Amount: amount,
 	})
+}
+
+// Implements V1.
+func (a *v1) Parameters(ctx context.Context, round uint64) (*Parameters, error) {
+	var params Parameters
+	err := a.rc.Query(ctx, round, methodParameters, nil, &params)
+	if err != nil {
+		return nil, err
+	}
+	return &params, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/consensusaccounts/types.go
+++ b/client-sdk/go/modules/consensusaccounts/types.go
@@ -29,6 +29,17 @@ type AccountQuery struct {
 	Address types.Address `json:"address"`
 }
 
+// GasCosts are the consensus accounts module gas costs.
+type GasCosts struct {
+	TxDeposit  uint64 `json:"tx_deposit"`
+	TxWithdraw uint64 `json:"tx_withdraw"`
+}
+
+// Parameters are the parameters for the consensus accounts module.
+type Parameters struct {
+	GasCosts GasCosts `json:"gas_costs"`
+}
+
 // ConsensusError contains error details from the consensus layer.
 type ConsensusError struct {
 	Module string `json:"module,omitempty"`

--- a/client-sdk/go/modules/contracts/contracts.go
+++ b/client-sdk/go/modules/contracts/contracts.go
@@ -27,6 +27,7 @@ const (
 	methodInstanceStorage = "contracts.InstanceStorage"
 	methodPublicKey       = "contracts.PublicKey"
 	methodCustom          = "contracts.Custom"
+	methodParameters      = "contracts.Parameters"
 )
 
 // V1 is the v1 contracts module interface.
@@ -95,6 +96,9 @@ type V1 interface {
 	//
 	// This method will encode the specified data using CBOR as defined by the Oasis ABI.
 	Custom(ctx context.Context, round uint64, id InstanceID, data, rsp interface{}) error
+
+	// Parameters queries the EVM module parameters.
+	Parameters(ctx context.Context, round uint64) (*Parameters, error)
 
 	// GetEvents returns events emitted by the contract at the provided round.
 	GetEvents(ctx context.Context, instanceID InstanceID, round uint64) ([]*Event, error)
@@ -217,6 +221,16 @@ func (a *v1) Custom(ctx context.Context, round uint64, id InstanceID, data, rsp 
 		return fmt.Errorf("failed to unmarshal response from contract: %w", err)
 	}
 	return nil
+}
+
+// Implements V1.
+func (a *v1) Parameters(ctx context.Context, round uint64) (*Parameters, error) {
+	var params Parameters
+	err := a.rc.Query(ctx, round, methodParameters, nil, &params)
+	if err != nil {
+		return nil, err
+	}
+	return &params, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/contracts/types.go
+++ b/client-sdk/go/modules/contracts/types.go
@@ -194,6 +194,43 @@ type CustomQuery struct {
 // CustomQueryResult is the result of the contracts.Custom query.
 type CustomQueryResult []byte
 
+// GasCosts are the contracts module gas costs.
+type GasCosts struct {
+	TxUpload        uint64 `json:"tx_upload"`
+	TxUploadPerByte uint64 `json:"tx_upload_per_byte"`
+	TxInstantiate   uint64 `json:"tx_instantiate"`
+	TxCall          uint64 `json:"tx_call"`
+	TxUpgrade       uint64 `json:"tx_upgrade"`
+
+	SubcallDispatch uint64 `json:"subcall_dispatch"`
+
+	WASMStorageGetBase    uint64 `json:"wasm_storage_get_base"`
+	WASMStorageInsertBase uint64 `json:"wasm_storage_insert_base"`
+	WASMStorageRemoveBase uint64 `json:"wasm_storage_remove_base"`
+	WASMStorageKeyByte    uint64 `json:"wasm_storage_key_byte"`
+	WASMStorageValueByte  uint64 `json:"wasm_storage_value_byte"`
+	WASMEnvQueryBase      uint64 `json:"wasm_env_query_base"`
+
+	WASMCryptoECDSARecover uint64 `json:"wasm_crypto_ecdsa_recover"`
+}
+
+// Parameters are the parameters for the contracts module.
+type Parameters struct {
+	MaxCodeSize    uint32 `json:"max_code_size"`
+	MaxStackSize   uint32 `json:"max_stack_size"`
+	MaxMemoryPages uint32 `json:"max_memory_pages"`
+
+	MaxSubcallDepth uint16 `json:"max_subcall_depth"`
+	MaxSubcallCount uint16 `json:"max_subcall_count"`
+
+	MaxResultSizeBytes       uint32 `json:"max_result_size_bytes"`
+	MaxQuerySizeBytes        uint32 `json:"max_query_size_bytes"`
+	MaxStorageKeySizeBytes   uint32 `json:"max_storage_key_size_bytes"`
+	MaxStorageValueSizeBytes uint32 `json:"max_storage_value_size_bytes"`
+
+	GasCosts GasCosts `json:"gas_costs"`
+}
+
 // ModuleName is the contracts module name.
 const ModuleName = "contracts"
 

--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -12,12 +12,16 @@ import (
 
 const (
 	// Queries.
+	methodParameters  = "core.Parameters"
 	methodEstimateGas = "core.EstimateGas"
 	methodMinGasPrice = "core.MinGasPrice"
 )
 
 // V1 is the v1 core module interface.
 type V1 interface {
+	// Parameters queries the core module parameters.
+	Parameters(ctx context.Context, round uint64) (*Parameters, error)
+
 	// EstimateGas performs gas estimation for executing the given transaction.
 	EstimateGas(ctx context.Context, round uint64, tx *types.Transaction) (uint64, error)
 
@@ -34,6 +38,16 @@ type V1 interface {
 
 type v1 struct {
 	rc client.RuntimeClient
+}
+
+// Implements V1.
+func (a *v1) Parameters(ctx context.Context, round uint64) (*Parameters, error) {
+	var params Parameters
+	err := a.rc.Query(ctx, round, methodParameters, nil, &params)
+	if err != nil {
+		return nil, err
+	}
+	return &params, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/core/types.go
+++ b/client-sdk/go/modules/core/types.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
@@ -11,6 +13,23 @@ type EstimateGasQuery struct {
 	Caller *types.CallerAddress `json:"caller,omitempty"`
 	// Tx is the unsigned transaction to estimate.
 	Tx *types.Transaction `json:"tx"`
+}
+
+// GasCosts are the consensus accounts module gas costs.
+type GasCosts struct {
+	TxByte                   uint64 `json:"tx_byte"`
+	AuthSignature            uint64 `json:"auth_signature"`
+	AuthMultisigSigner       uint64 `json:"auth_multisig_signer"`
+	CallformatX25519Deoxysii uint64 `json:"callformat_x25519_deoxysii"`
+}
+
+// Parameters are the parameters for the consensus accounts module.
+type Parameters struct {
+	MaxBatchGas        uint64                                   `json:"max_batch_gas"`
+	MaxTxSigners       uint32                                   `json:"max_tx_signers"`
+	MaxMultisigSigners uint32                                   `json:"max_multisig_signers"`
+	GasCosts           GasCosts                                 `json:"gas_costs"`
+	MinGasPrice        map[types.Denomination]quantity.Quantity `json:"min_gas_price"`
 }
 
 // ModuleName is the core module name.

--- a/client-sdk/go/modules/evm/evm.go
+++ b/client-sdk/go/modules/evm/evm.go
@@ -20,6 +20,7 @@ const (
 	methodCode         = "evm.Code"
 	methodBalance      = "evm.Balance"
 	methodSimulateCall = "evm.SimulateCall"
+	methodParameters   = "evm.Parameters"
 )
 
 // V1 is the v1 EVM module interface.
@@ -50,6 +51,9 @@ type V1 interface {
 	// SimulateCall simulates an EVM CALL.
 	SimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
 
+	// Parameters queries the EVM module parameters.
+	Parameters(ctx context.Context, round uint64) (*Parameters, error)
+
 	// GetEvents returns events emitted by the EVM module.
 	GetEvents(ctx context.Context, round uint64) ([]*Event, error)
 }
@@ -73,6 +77,16 @@ func (a *v1) Call(address []byte, value []byte, data []byte) *client.Transaction
 		Value:   value,
 		Data:    data,
 	})
+}
+
+// Implements V1.
+func (a *v1) Parameters(ctx context.Context, round uint64) (*Parameters, error) {
+	var params Parameters
+	err := a.rtc.Query(ctx, round, methodParameters, nil, &params)
+	if err != nil {
+		return nil, err
+	}
+	return &params, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/evm/types.go
+++ b/client-sdk/go/modules/evm/types.go
@@ -42,6 +42,14 @@ type SimulateCallQuery struct {
 	Data     []byte `json:"data"`
 }
 
+// GasCosts are the EVM module gas costs.
+type GasCosts struct{}
+
+// Parameters are the parameters for the EVM module.
+type Parameters struct {
+	GasCosts GasCosts `json:"gas_costs"`
+}
+
 // ModuleName is the EVM module name.
 const ModuleName = "evm"
 

--- a/runtime-sdk/src/modules/consensus/mod.rs
+++ b/runtime-sdk/src/modules/consensus/mod.rs
@@ -17,7 +17,7 @@ use oasis_core_runtime::{
 
 use crate::{
     context::{Context, TxContext},
-    handler, module,
+    module,
     module::{Module as _, Parameters as _},
     modules, sdk_derive,
     types::{
@@ -180,12 +180,7 @@ impl Module {
 }
 
 #[sdk_derive(MethodHandler)]
-impl Module {
-    #[handler(query = "consensus.Parameters")]
-    fn query_parameters<C: Context>(ctx: &mut C, _args: ()) -> Result<Parameters, Error> {
-        Ok(Self::params(ctx.runtime_state()))
-    }
-}
+impl Module {}
 
 impl API for Module {
     fn transfer<C: TxContext>(

--- a/tests/e2e/contracts.go
+++ b/tests/e2e/contracts.go
@@ -411,3 +411,22 @@ OUTER:
 
 	return nil
 }
+
+// ContractsParametersTest tests the parameters methods.
+func ContractsParametersTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+	ctx := context.Background()
+	ct := contracts.NewV1(rtc)
+
+	params, err := ct.Parameters(ctx, client.RoundLatest)
+	if err != nil {
+		return fmt.Errorf("parameters: %w", err)
+	}
+	if cs := params.MaxCodeSize; cs != 524288 {
+		return fmt.Errorf("unexpected MaxCodeSize: expected: %v, got: %v", 10, cs)
+	}
+	if gc := params.GasCosts.TxUpload; gc != 0 {
+		return fmt.Errorf("unexpected GasCosts.TxUpload: expected: %v, got: %v", 0, gc)
+	}
+
+	return nil
+}

--- a/tests/e2e/scenarios.go
+++ b/tests/e2e/scenarios.go
@@ -28,10 +28,11 @@ var (
 		ConfidentialTest,
 		TransactionsQueryTest,
 		BlockQueryTest,
+		ParametersTest,
 	})
 
 	// SimpleConsensusRuntime is the simple-consensus runtime test.
-	SimpleConsensusRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-consensus", []RunTestFunction{SimpleConsensusTest})
+	SimpleConsensusRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-consensus", []RunTestFunction{SimpleConsensusTest, ConsensusAccountsParametersTest})
 
 	// SimpleEVMRuntime is the simple-evm runtime test.
 	SimpleEVMRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-evm", []RunTestFunction{
@@ -42,11 +43,13 @@ var (
 		SimpleERC20EVMTest,
 		SimpleEVMSuicideTest,
 		SimpleEVMCallSuicideTest,
+		EVMParametersTest,
 	})
 
 	// SimpleContractsRuntime is the simple-contracts runtime test.
 	SimpleContractsRuntime *RuntimeScenario = NewRuntimeScenario("test-runtime-simple-contracts", []RunTestFunction{
 		ContractsTest,
+		ContractsParametersTest,
 	})
 )
 

--- a/tests/e2e/simple_consensus.go
+++ b/tests/e2e/simple_consensus.go
@@ -325,3 +325,19 @@ func SimpleConsensusTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.Cl
 
 	return nil
 }
+
+// ConsensusAccountsParametersTest tests the parameters methods.
+func ConsensusAccountsParametersTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+	ctx := context.Background()
+	cac := consensusAccounts.NewV1(rtc)
+
+	params, err := cac.Parameters(ctx, client.RoundLatest)
+	if err != nil {
+		return fmt.Errorf("parameters: %w", err)
+	}
+	if gc := params.GasCosts.TxWithdraw; gc != 0 {
+		return fmt.Errorf("unexpected GasCosts.TxWithdraw: expected: %v, got: %v", 0, gc)
+	}
+
+	return nil
+}

--- a/tests/e2e/simpleevmtest.go
+++ b/tests/e2e/simpleevmtest.go
@@ -839,3 +839,16 @@ func SimpleEVMCallSuicideTest(sc *RuntimeScenario, log *logging.Logger, conn *gr
 
 	return nil
 }
+
+// EVMParametersTest tests parameters methods.
+func EVMParametersTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+	ctx := context.Background()
+	evm := evm.NewV1(rtc)
+
+	_, err := evm.Parameters(ctx, client.RoundLatest)
+	if err != nil {
+		return fmt.Errorf("parameters: %w", err)
+	}
+
+	return nil
+}

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -1088,3 +1088,34 @@ func KVTxGenTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn
 	log.Info("finished", "num_ok_submitted_txs", ok, "num_gen_errs", genErrs, "num_sub_errs", subErrs)
 	return nil
 }
+
+// ParametersTest tests parameters methods.
+func ParametersTest(sc *RuntimeScenario, log *logging.Logger, conn *grpc.ClientConn, rtc client.RuntimeClient) error {
+	ctx := context.Background()
+	ac := accounts.NewV1(rtc)
+	core := core.NewV1(rtc)
+
+	accParams, err := ac.Parameters(ctx, client.RoundLatest)
+	if err != nil {
+		return fmt.Errorf("accounts parameters: %w", err)
+	}
+	if accParams.DebugDisableNonceCheck {
+		return fmt.Errorf("accounts DebugDisableNonceChecks should be disabled")
+	}
+	if gc := accParams.GasCosts.TxTransfer; gc != 100 {
+		return fmt.Errorf("unexpected GasCosts.TxTransfer: expected: %v, got: %v", 100, gc)
+	}
+
+	coreParams, err := core.Parameters(ctx, client.RoundLatest)
+	if err != nil {
+		return fmt.Errorf("core parameters: %w", err)
+	}
+	if s := coreParams.MaxTxSigners; s != 8 {
+		return fmt.Errorf("unexpected core.MaxTxSigners: expected: %v, got: %v", 8, s)
+	}
+	if gc := coreParams.GasCosts.TxByte; gc != 1 {
+		return fmt.Errorf("unexpected GasCosts.TxByte: expected: %v, got: %v", 10, gc)
+	}
+
+	return nil
+}


### PR DESCRIPTION
TODO:
- [x] migrate rewards module to use the `sdk_derive(MethodHandler)`
- [x] implement go/ts bindings for parameters methods 
  - [x] will open a separate issue for implementing TS bindings after merging this (https://github.com/oasisprotocol/oasis-sdk/issues/812)
- [x] add tests