### PR TITLE
runtime-sdk: Fix handling of expensive queries option

### DIFF
--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -330,12 +330,12 @@ impl<Cfg: Config> API for Module<Cfg> {
     ) -> Result<Vec<u8>, Error> {
         let caller = Self::derive_caller(ctx)?;
 
-        if ctx.is_check_only() && !ctx.are_expensive_queries_allowed() {
+        if ctx.is_check_only() || (ctx.is_simulation() && !ctx.are_expensive_queries_allowed()) {
             // Only fast checks are allowed.
             return Ok(vec![]);
         }
 
-        let rsp = Self::do_evm(
+        Self::do_evm(
             caller,
             ctx,
             |exec, gas_limit| {
@@ -349,14 +349,7 @@ impl<Cfg: Config> API for Module<Cfg> {
             },
             // If in simulation, this must be EstimateGas query.
             ctx.is_simulation(),
-        );
-
-        // Always return success in CheckTx, as we might not have up-to-date state.
-        if ctx.is_check_only() {
-            rsp.or_else(|_| Ok(vec![]))
-        } else {
-            rsp
-        }
+        )
     }
 
     fn call<C: TxContext>(
@@ -367,12 +360,12 @@ impl<Cfg: Config> API for Module<Cfg> {
     ) -> Result<Vec<u8>, Error> {
         let caller = Self::derive_caller(ctx)?;
 
-        if ctx.is_check_only() && !ctx.are_expensive_queries_allowed() {
+        if ctx.is_check_only() || (ctx.is_simulation() && !ctx.are_expensive_queries_allowed()) {
             // Only fast checks are allowed.
             return Ok(vec![]);
         }
 
-        let rsp = Self::do_evm(
+        Self::do_evm(
             caller,
             ctx,
             |exec, gas_limit| {
@@ -387,14 +380,7 @@ impl<Cfg: Config> API for Module<Cfg> {
             },
             // If in simulation, this must be EstimateGas query.
             ctx.is_simulation(),
-        );
-
-        // Always return success in CheckTx, as we might not have up-to-date state.
-        if ctx.is_check_only() {
-            rsp.or_else(|_| Ok(vec![]))
-        } else {
-            rsp
-        }
+        )
     }
 
     fn get_storage<C: Context>(ctx: &mut C, address: H160, index: H256) -> Result<Vec<u8>, Error> {

--- a/runtime-sdk/src/context.rs
+++ b/runtime-sdk/src/context.rs
@@ -85,10 +85,9 @@ pub trait Context {
 
     /// Whether expensive queries are allowed based on local configuration.
     ///
-    /// This method will always return `true` if `is_check_only` returns `false` to avoid any bugs
-    /// that would cause non-determinism in non-check-tx contexts.
+    /// This method will always return `true` in `Mode::ExecuteTx` contexts.
     fn are_expensive_queries_allowed(&self) -> bool {
-        if !self.is_check_only() {
+        if self.mode() == Mode::ExecuteTx {
             return true;
         }
 
@@ -98,13 +97,12 @@ pub trait Context {
 
     /// Returns node operator-provided local configuration.
     ///
-    /// This method will always return `None` if `is_check_only` returns `false` to avoid any bugs
-    /// that would cause non-determinism in non-check-tx contexts.
+    /// This method will always return `None` in `Mode::ExecuteTx` contexts.
     fn local_config<T>(&self, key: &str) -> Option<T>
     where
         T: cbor::Decode,
     {
-        if !self.is_check_only() {
+        if self.mode() == Mode::ExecuteTx {
             return None;
         }
 


### PR DESCRIPTION
It should only be taken into account during simulation mode and not
during transaction checks.