### PR TITLE
evm: handle empty revert reason

### DIFF
--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -198,6 +198,10 @@ fn process_evm_result(exit_reason: evm::ExitReason, data: Vec<u8>) -> Result<Vec
     match exit_reason {
         evm::ExitReason::Succeed(_) => Ok(data),
         evm::ExitReason::Revert(_) => {
+            if data.is_empty() {
+                return Err(Error::Reverted("no revert reason".to_string()));
+            }
+
             // Decode revert reason, format is as follows:
             //
             // 08c379a0                                                         <- Function selector

--- a/runtime-sdk/modules/evm/src/test.rs
+++ b/runtime-sdk/modules/evm/src/test.rs
@@ -547,8 +547,8 @@ fn test_revert_reason_decoding() {
         ),
         // Valid value, reason too long and should be truncated.
         (long_reason_hex, &long_reason_str[..1024]),
-        // Malformed output.
-        ("", "invalid reason prefix: ''"),
+        // No revert reason.
+        ("", "no revert reason"),
         // Malformed output, incorrect selector and bad length.
         (
             "BADBADBADBADBADBAD",


### PR DESCRIPTION
Special case empty revert reason, so that instead of: `invalid reason prefix: ''` we return `no revert reason`