### PR TITLE
cli: Default to legacy derivation on ledger

### DIFF
--- a/cli/wallet/ledger/ledger.go
+++ b/cli/wallet/ledger/ledger.go
@@ -182,7 +182,7 @@ func (w *ledgerWallet) UnsafeExport() string {
 
 func init() {
 	flags := flag.NewFlagSet("", flag.ContinueOnError)
-	flags.String(cfgDerivation, derivationAdr8, "Derivation scheme to use [adr8, legacy]")
+	flags.String(cfgDerivation, derivationLegacy, "Derivation scheme to use [adr8, legacy]")
 	flags.Uint32(cfgNumber, 0, "Key number to use for ADR 0008 key derivation scheme")
 
 	wallet.Register(&ledgerWalletFactory{


### PR DESCRIPTION
Default oasis cli derivation path on ledger is currently ADR8 and is inconsistent with Oasis web/ext wallets. This PR defaults to legacy, so we avoid issues when users don't see correct accounts and balances using defaults.