### PR TITLE
runtime-sdk: Permanently enable schedule control

### DIFF
--- a/client-sdk/go/modules/core/types.go
+++ b/client-sdk/go/modules/core/types.go
@@ -31,6 +31,11 @@ type Parameters struct {
 	MaxMultisigSigners uint32                                   `json:"max_multisig_signers"`
 	GasCosts           GasCosts                                 `json:"gas_costs"`
 	MinGasPrice        map[types.Denomination]quantity.Quantity `json:"min_gas_price"`
+
+	// Fields below have omitempty set for backwards compatibility. Once there are no deployed
+	// runtimes using an old version of the SDK, this should be removed.
+
+	MaxTxSize uint32 `json:"max_tx_size,omitempty"`
 }
 
 // ModuleName is the core module name.

--- a/runtime-sdk/src/config.rs
+++ b/runtime-sdk/src/config.rs
@@ -14,3 +14,15 @@ pub struct ScheduleControl {
     /// This is only used as a last resort to avoid the batch going over the runtime's limit.
     pub max_tx_count: usize,
 }
+
+impl ScheduleControl {
+    /// Construct a default schedule control configuration.
+    pub const fn default() -> Self {
+        Self {
+            initial_batch_size: 50,
+            batch_size: 50,
+            min_remaining_gas: 1_000,
+            max_tx_count: 1_000,
+        }
+    }
+}

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -536,7 +536,7 @@ impl<R: Runtime + Send + Sync> transaction::dispatcher::Dispatcher for Dispatche
         batch: &mut TxnBatch,
         _in_msgs: &[roothash::IncomingMessage],
     ) -> Result<ExecuteBatchResult, RuntimeError> {
-        let cfg = R::SCHEDULE_CONTROL.unwrap(); // Must succeed otherwise we wouldn't be here.
+        let cfg = R::SCHEDULE_CONTROL;
         let mut tx_reject_hashes = Vec::new();
 
         let mut result = self.execute_batch_common(

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -138,7 +138,8 @@ impl<R: Runtime> Dispatcher<R> {
         ctx: &mut C,
         tx: &[u8],
     ) -> Result<types::transaction::Transaction, modules::core::Error> {
-        // TODO: Check against transaction size limit.
+        // Perform any checks before decoding.
+        R::Modules::approve_raw_tx(ctx, tx)?;
 
         // Deserialize transaction.
         let utx: types::transaction::UnverifiedTransaction = cbor::from_slice(tx)

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -282,6 +282,13 @@ impl MethodHandler for Tuple {
 
 /// Transaction handler.
 pub trait TransactionHandler {
+    /// Judge if a raw transaction is good enough to undergo decoding.
+    /// This takes place before even decoding the transaction.
+    fn approve_raw_tx<C: Context>(_ctx: &mut C, _tx: &[u8]) -> Result<(), modules::core::Error> {
+        // Default implementation doesn't do any checks.
+        Ok(())
+    }
+
     /// Judge if an unverified transaction is good enough to undergo verification.
     /// This takes place before even verifying signatures.
     fn approve_unverified_tx<C: Context>(
@@ -344,6 +351,11 @@ pub trait TransactionHandler {
 
 #[impl_for_tuples(30)]
 impl TransactionHandler for Tuple {
+    fn approve_raw_tx<C: Context>(ctx: &mut C, tx: &[u8]) -> Result<(), modules::core::Error> {
+        for_tuples!( #( Tuple::approve_raw_tx(ctx, tx)?; )* );
+        Ok(())
+    }
+
     fn approve_unverified_tx<C: Context>(
         ctx: &mut C,
         utx: &UnverifiedTransaction,

--- a/runtime-sdk/src/module.rs
+++ b/runtime-sdk/src/module.rs
@@ -17,9 +17,7 @@ use crate::{
     storage::{Prefix, Store},
     types::{
         message::MessageResult,
-        transaction::{
-            self, AuthInfo, Call, Transaction, TransactionWeight, UnverifiedTransaction,
-        },
+        transaction::{self, AuthInfo, Call, Transaction, UnverifiedTransaction},
     },
 };
 
@@ -454,11 +452,6 @@ pub trait BlockHandler {
     fn end_block<C: Context>(_ctx: &mut C) {
         // Default implementation doesn't do anything.
     }
-
-    /// Returns module per-batch weight limits.
-    fn get_block_weight_limits<C: Context>(_ctx: &mut C) -> BTreeMap<TransactionWeight, u64> {
-        BTreeMap::new()
-    }
 }
 
 #[impl_for_tuples(30)]
@@ -469,18 +462,6 @@ impl BlockHandler for Tuple {
 
     fn end_block<C: Context>(ctx: &mut C) {
         for_tuples!( #( Tuple::end_block(ctx); )* );
-    }
-
-    // Ignore let and return for the empty tuple case.
-    #[allow(clippy::let_and_return)]
-    fn get_block_weight_limits<C: Context>(ctx: &mut C) -> BTreeMap<TransactionWeight, u64> {
-        let mut result = BTreeMap::new();
-
-        for_tuples!( #(
-            result.extend( Tuple::get_block_weight_limits(ctx) );
-        )* );
-
-        result
     }
 }
 

--- a/runtime-sdk/src/modules/core/mod.rs
+++ b/runtime-sdk/src/modules/core/mod.rs
@@ -17,10 +17,7 @@ use crate::{
     module::{self, InvariantHandler as _, Module as _, ModuleInfoHandler as _},
     types::{
         token,
-        transaction::{
-            self, AddressSpec, AuthProof, Call, CallFormat, TransactionWeight,
-            UnverifiedTransaction,
-        },
+        transaction::{self, AddressSpec, AuthProof, Call, CallFormat, UnverifiedTransaction},
     },
     Runtime,
 };
@@ -179,16 +176,6 @@ pub trait API {
     /// Increase transaction priority for the provided amount.
     fn add_priority<C: Context>(ctx: &mut C, priority: u64) -> Result<(), Error>;
 
-    /// Increase the specific transaction weight for the provided amount.
-    fn add_weight<C: TxContext>(
-        ctx: &mut C,
-        weight: TransactionWeight,
-        val: u64,
-    ) -> Result<(), Error>;
-
-    /// Takes the stored transaction weight.
-    fn take_weights<C: Context>(ctx: &mut C) -> BTreeMap<TransactionWeight, u64>;
-
     /// Takes and returns the stored transaction priority.
     fn take_priority<C: Context>(ctx: &mut C) -> u64;
 }
@@ -242,9 +229,6 @@ pub struct Module<Cfg: Config> {
 
 const CONTEXT_KEY_GAS_USED: &str = "core.GasUsed";
 const CONTEXT_KEY_PRIORITY: &str = "core.Priority";
-const CONTEXT_KEY_WEIGHTS: &str = "core.Weights";
-
-const GAS_WEIGHT_NAME: &str = "gas";
 
 impl<Cfg: Config> Module<Cfg> {
     /// Initialize state from genesis.
@@ -330,30 +314,8 @@ impl<Cfg: Config> API for Module<Cfg> {
         Ok(())
     }
 
-    fn add_weight<C: TxContext>(
-        ctx: &mut C,
-        weight: TransactionWeight,
-        val: u64,
-    ) -> Result<(), Error> {
-        let weights = ctx
-            .value::<BTreeMap<TransactionWeight, u64>>(CONTEXT_KEY_WEIGHTS)
-            .or_default();
-
-        let w = weights.remove(&weight).unwrap_or_default();
-        let added_w = w.checked_add(val).unwrap_or(u64::MAX);
-        weights.insert(weight, added_w);
-
-        Ok(())
-    }
-
     fn take_priority<C: Context>(ctx: &mut C) -> u64 {
         ctx.value::<u64>(CONTEXT_KEY_PRIORITY)
-            .take()
-            .unwrap_or_default()
-    }
-
-    fn take_weights<C: Context>(ctx: &mut C) -> BTreeMap<TransactionWeight, u64> {
-        ctx.value::<BTreeMap<TransactionWeight, u64>>(CONTEXT_KEY_WEIGHTS)
             .take()
             .unwrap_or_default()
     }
@@ -647,17 +609,9 @@ impl<Cfg: Config> module::TransactionHandler for Module<Cfg> {
             }
         }
 
-        // Set weight based on configured gas limit.
-        Self::add_weight(ctx, GAS_WEIGHT_NAME.into(), gas)?;
-
-        // Attempt to limit the maximum number of consensus messages and add appropriate weights.
+        // Attempt to limit the maximum number of consensus messages.
         let consensus_messages = ctx.tx_auth_info().fee.consensus_messages;
         ctx.limit_max_messages(consensus_messages)?;
-        Self::add_weight(
-            ctx,
-            TransactionWeight::ConsensusMessages,
-            consensus_messages as u64,
-        )?;
 
         Ok(())
     }
@@ -692,15 +646,5 @@ impl<Cfg: Config> module::MigrationHandler for Module<Cfg> {
     }
 }
 
-impl<Cfg: Config> module::BlockHandler for Module<Cfg> {
-    fn get_block_weight_limits<C: Context>(ctx: &mut C) -> BTreeMap<TransactionWeight, u64> {
-        let batch_gas_limit = Self::params(ctx.runtime_state()).max_batch_gas;
-
-        let mut res = BTreeMap::new();
-        res.insert(GAS_WEIGHT_NAME.into(), batch_gas_limit);
-
-        res
-    }
-}
-
+impl<Cfg: Config> module::BlockHandler for Module<Cfg> {}
 impl<Cfg: Config> module::InvariantHandler for Module<Cfg> {}

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -1,25 +1,19 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use oasis_core_runtime::types::BATCH_WEIGHT_LIMIT_QUERY_METHOD;
-
 use crate::{
     context::{BatchContext, Context, Mode, TxContext},
     core::common::version::Version,
     crypto::multisig,
-    dispatcher,
     event::IntoTags,
     handler,
     module::{self, BlockHandler, Module as _, TransactionHandler as _},
     runtime::Runtime,
     sdk_derive,
     testing::{configmap, keys, mock},
-    types::{
-        token, transaction,
-        transaction::{CallerAddress, TransactionWeight},
-    },
+    types::{token, transaction, transaction::CallerAddress},
 };
 
-use super::{types, Event, Parameters, API as _, GAS_WEIGHT_NAME};
+use super::{types, Event, Parameters, API as _};
 
 type Core = super::Module<Config>;
 
@@ -479,186 +473,6 @@ fn test_add_priority_overflow() {
         Core::take_priority(&mut ctx),
         "adding priority should work"
     );
-}
-
-#[test]
-fn test_add_weights() {
-    let mut mock = mock::Mock::default();
-    let mut ctx = mock.create_ctx();
-
-    assert!(
-        Core::take_weights(&mut ctx).is_empty(),
-        "default weights should be empty"
-    );
-
-    let tx = mock::transaction();
-    ctx.with_tx(0, tx.clone(), |mut tx_ctx, _call| {
-        Core::add_weight(&mut tx_ctx, "test_weight".into(), 1)
-            .expect("adding weight should succeed");
-        Core::add_weight(&mut tx_ctx, "test_weight2".into(), 10)
-            .expect("adding weight should succeed");
-        Core::add_weight(&mut tx_ctx, "test_weight".into(), 15)
-            .expect("adding weight should succeed");
-        Core::add_weight(&mut tx_ctx, "test_weight3".into(), 20)
-            .expect("adding weight should succeed");
-        Core::add_weight(&mut tx_ctx, "test_weight4".into(), u64::MAX)
-            .expect("adding weight should succeed");
-        Core::add_weight(&mut tx_ctx, "test_weight4".into(), 5)
-            .expect("adding weight should succeed");
-    });
-
-    let mut expected = BTreeMap::new();
-    expected.insert("test_weight".into(), 1 + 15);
-    expected.insert("test_weight2".into(), 10);
-    expected.insert("test_weight3".into(), 20);
-    expected.insert("test_weight4".into(), u64::MAX);
-
-    assert_eq!(
-        expected,
-        Core::take_weights(&mut ctx),
-        "adding weights should work"
-    );
-}
-
-#[test]
-fn test_get_batch_weight_limits() {
-    let mut mock = mock::Mock::default();
-    let mut ctx = mock.create_ctx_for_runtime::<GasWasterRuntime>(Mode::CheckTx);
-
-    GasWasterRuntime::migrate(&mut ctx);
-
-    // Max batch gas as in runtime genesis (u64::MAX).
-    let mut expected = BTreeMap::new();
-    expected.insert(GAS_WEIGHT_NAME.into(), u64::MAX);
-
-    assert_eq!(
-        expected,
-        Core::get_block_weight_limits(&mut ctx),
-        "querying empty weights limits should work"
-    );
-
-    // Update max_batch_gas.
-    Core::set_params(
-        ctx.runtime_state(),
-        Parameters {
-            max_batch_gas: 100,
-            ..Default::default()
-        },
-    );
-    expected.insert(GAS_WEIGHT_NAME.into(), 100);
-    assert_eq!(
-        expected,
-        Core::get_block_weight_limits(&mut ctx),
-        "querying weights limits should work"
-    );
-}
-
-#[test]
-fn test_get_batch_weight_limits_query() {
-    let mut mock = mock::Mock::default();
-    let mut ctx = mock.create_ctx_for_runtime::<GasWasterRuntime>(Mode::CheckTx);
-
-    // Max batch gas as in runtime genesis (u64::MAX).
-    let mut expected: BTreeMap<TransactionWeight, u64> = BTreeMap::new();
-    expected.insert(GAS_WEIGHT_NAME.into(), u64::MAX);
-
-    let res = dispatcher::Dispatcher::<GasWasterRuntime>::dispatch_query(
-        &mut ctx,
-        BATCH_WEIGHT_LIMIT_QUERY_METHOD,
-        cbor::to_vec(cbor::Value::Simple(cbor::SimpleValue::NullValue)),
-    )
-    .expect("batch weight limit query should work");
-    assert_eq!(
-        expected,
-        cbor::from_slice(&res).unwrap(),
-        "querying empty weights should return correct limits"
-    );
-
-    // Update max_batch_gas.
-    Core::set_params(
-        ctx.runtime_state(),
-        Parameters {
-            max_batch_gas: 100,
-            ..Default::default()
-        },
-    );
-    expected.insert(GAS_WEIGHT_NAME.into(), 100);
-
-    let res = dispatcher::Dispatcher::<GasWasterRuntime>::dispatch_query(
-        &mut ctx,
-        BATCH_WEIGHT_LIMIT_QUERY_METHOD,
-        cbor::to_vec(cbor::Value::Simple(cbor::SimpleValue::NullValue)),
-    )
-    .expect("batch weight limit query should work");
-    assert_eq!(
-        expected,
-        cbor::from_slice(&res).unwrap(),
-        "querying weights should return correct limits"
-    );
-}
-
-#[test]
-fn test_check_weights() {
-    let mut mock = mock::Mock::default();
-    let mut ctx = mock.create_ctx_for_runtime::<GasWasterRuntime>(Mode::CheckTx);
-
-    Core::set_params(
-        ctx.runtime_state(),
-        Parameters {
-            max_batch_gas: u64::MAX,
-            max_tx_size: 32 * 1024,
-            max_tx_signers: 8,
-            max_multisig_signers: 8,
-            gas_costs: super::GasCosts {
-                tx_byte: 0,
-                auth_signature: GasWasterRuntime::AUTH_SIGNATURE_GAS,
-                auth_multisig_signer: GasWasterRuntime::AUTH_MULTISIG_GAS,
-                callformat_x25519_deoxysii: 0,
-            },
-            min_gas_price: {
-                let mut mgp = BTreeMap::new();
-                mgp.insert(token::Denomination::NATIVE, 0);
-                mgp
-            },
-        },
-    );
-
-    let tx = transaction::Transaction {
-        version: 1,
-        call: transaction::Call {
-            format: transaction::CallFormat::Plain,
-            method: GasWasterModule::METHOD_WASTE_GAS.to_owned(),
-            body: cbor::Value::Simple(cbor::SimpleValue::NullValue),
-        },
-        auth_info: transaction::AuthInfo {
-            signer_info: vec![transaction::SignerInfo::new_sigspec(
-                keys::alice::sigspec(),
-                0,
-            )],
-            fee: transaction::Fee {
-                amount: token::BaseUnits::new(10_000, token::Denomination::NATIVE),
-                gas: 1_000,
-                consensus_messages: 1,
-            },
-        },
-    };
-
-    ctx.with_tx(0, tx.clone(), |mut tx_ctx, call| {
-        Core::before_handle_call(&mut tx_ctx, &call).unwrap();
-
-        let weights = Core::take_weights(&mut tx_ctx);
-
-        assert_eq!(
-            weights.get(&GAS_WEIGHT_NAME.into()),
-            Some(&1_000),
-            "gas weight should be correct"
-        );
-        assert_eq!(
-            weights.get(&TransactionWeight::ConsensusMessages),
-            Some(&1),
-            "consensus messages weight should be correct"
-        );
-    });
 }
 
 #[test]

--- a/runtime-sdk/src/modules/core/test.rs
+++ b/runtime-sdk/src/modules/core/test.rs
@@ -33,6 +33,7 @@ fn test_use_gas() {
         ctx.runtime_state(),
         Parameters {
             max_batch_gas: BLOCK_MAX_GAS,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 8,
             max_multisig_signers: 8,
             gas_costs: Default::default(),
@@ -128,6 +129,7 @@ fn test_query_min_gas_price() {
         ctx.runtime_state(),
         Parameters {
             max_batch_gas: 10000,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 8,
             max_multisig_signers: 8,
             gas_costs: Default::default(),
@@ -230,6 +232,7 @@ impl Runtime for GasWasterRuntime {
             super::Genesis {
                 parameters: Parameters {
                     max_batch_gas: u64::MAX,
+                    max_tx_size: 32 * 1024,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     gas_costs: super::GasCosts {
@@ -388,6 +391,7 @@ fn test_approve_unverified_tx() {
         ctx.runtime_state(),
         Parameters {
             max_batch_gas: u64::MAX,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 2,
             max_multisig_signers: 2,
             gas_costs: Default::default(),
@@ -602,6 +606,7 @@ fn test_check_weights() {
         ctx.runtime_state(),
         Parameters {
             max_batch_gas: u64::MAX,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 8,
             max_multisig_signers: 8,
             gas_costs: super::GasCosts {
@@ -665,6 +670,7 @@ fn test_min_gas_price() {
         ctx.runtime_state(),
         Parameters {
             max_batch_gas: u64::MAX,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 8,
             max_multisig_signers: 8,
             gas_costs: super::GasCosts {
@@ -845,6 +851,7 @@ fn test_gas_used_events() {
         ctx.runtime_state(),
         Parameters {
             max_batch_gas: 1_000_000,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 8,
             max_multisig_signers: 8,
             gas_costs: Default::default(),

--- a/runtime-sdk/src/runtime.rs
+++ b/runtime-sdk/src/runtime.rs
@@ -33,8 +33,8 @@ pub trait Runtime {
     /// Prefetch limit. To enable prefetch set it to a non-zero value.
     const PREFETCH_LIMIT: u16 = 0;
 
-    /// Whether the runtime should take control of transaction scheduling.
-    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = None;
+    /// Runtime schedule control configuration.
+    const SCHEDULE_CONTROL: config::ScheduleControl = config::ScheduleControl::default();
 
     /// Module that provides the core API.
     type Core: modules::core::API;
@@ -153,12 +153,11 @@ pub trait Runtime {
         };
 
         // Configure the runtime features.
-        let mut features = Features::default();
-        if let Some(cfg) = Self::SCHEDULE_CONTROL {
-            features.schedule_control = Some(FeatureScheduleControl {
-                initial_batch_size: cfg.initial_batch_size,
-            });
-        }
+        let features = Features {
+            schedule_control: Some(FeatureScheduleControl {
+                initial_batch_size: Self::SCHEDULE_CONTROL.initial_batch_size,
+            }),
+        };
 
         // Start the runtime.
         start_runtime(

--- a/tests/runtimes/benchmarking/src/lib.rs
+++ b/tests/runtimes/benchmarking/src/lib.rs
@@ -47,6 +47,7 @@ impl sdk::Runtime for Runtime {
             modules::core::Genesis {
                 parameters: modules::core::Parameters {
                     max_batch_gas: 10_000_000,
+                    max_tx_size: 32 * 1024,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     // These are free, in order to simplify benchmarking.

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -13,13 +13,12 @@ pub struct Runtime;
 impl sdk::Runtime for Runtime {
     const VERSION: Version = sdk::version_from_cargo!();
 
-    // Enable the runtime schedule control feature.
-    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+    const SCHEDULE_CONTROL: config::ScheduleControl = config::ScheduleControl {
         initial_batch_size: 50,
         batch_size: 50,
         min_remaining_gas: 100,
         max_tx_count: 1000,
-    });
+    };
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -65,6 +65,7 @@ impl sdk::Runtime for Runtime {
             modules::core::Genesis {
                 parameters: modules::core::Parameters {
                     max_batch_gas: 10_000,
+                    max_tx_size: 32 * 1024,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     // These are free, in order to simplify testing.

--- a/tests/runtimes/simple-contracts/src/lib.rs
+++ b/tests/runtimes/simple-contracts/src/lib.rs
@@ -89,6 +89,7 @@ impl sdk::Runtime for Runtime {
             modules::core::Genesis {
                 parameters: modules::core::Parameters {
                     max_batch_gas: 10_000_000,
+                    max_tx_size: 512 * 1024,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     gas_costs: modules::core::GasCosts {

--- a/tests/runtimes/simple-contracts/src/lib.rs
+++ b/tests/runtimes/simple-contracts/src/lib.rs
@@ -22,13 +22,12 @@ impl contracts::Config for Config {
 impl sdk::Runtime for Runtime {
     const VERSION: Version = sdk::version_from_cargo!();
 
-    // Enable the runtime schedule control feature.
-    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+    const SCHEDULE_CONTROL: config::ScheduleControl = config::ScheduleControl {
         initial_batch_size: 50,
         batch_size: 50,
         min_remaining_gas: 100,
         max_tx_count: 1000,
-    });
+    };
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-evm/src/lib.rs
+++ b/tests/runtimes/simple-evm/src/lib.rs
@@ -23,13 +23,12 @@ impl evm::Config for Config {
 impl sdk::Runtime for Runtime {
     const VERSION: Version = sdk::version_from_cargo!();
 
-    // Enable the runtime schedule control feature.
-    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+    const SCHEDULE_CONTROL: config::ScheduleControl = config::ScheduleControl {
         initial_batch_size: 50,
         batch_size: 50,
         min_remaining_gas: 100,
         max_tx_count: 1000,
-    });
+    };
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-evm/src/lib.rs
+++ b/tests/runtimes/simple-evm/src/lib.rs
@@ -69,6 +69,7 @@ impl sdk::Runtime for Runtime {
             modules::core::Genesis {
                 parameters: modules::core::Parameters {
                     max_batch_gas: 1_000_000,
+                    max_tx_size: 32 * 1024,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     gas_costs: modules::core::GasCosts {

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -30,13 +30,12 @@ impl sdk::Runtime for Runtime {
     // to test the migration functionality.
     const STATE_VERSION: u32 = 1;
 
-    // Enable the runtime schedule control feature.
-    const SCHEDULE_CONTROL: Option<config::ScheduleControl> = Some(config::ScheduleControl {
+    const SCHEDULE_CONTROL: config::ScheduleControl = config::ScheduleControl {
         initial_batch_size: 2,
         batch_size: 50,
         min_remaining_gas: 100,
         max_tx_count: 1000,
-    });
+    };
 
     type Core = modules::core::Module<Config>;
 

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -145,6 +145,7 @@ impl sdk::Runtime for Runtime {
             modules::core::Genesis {
                 parameters: modules::core::Parameters {
                     max_batch_gas: 2_000,
+                    max_tx_size: 32 * 1024,
                     max_tx_signers: 8,
                     max_multisig_signers: 8,
                     gas_costs: modules::core::GasCosts {

--- a/tests/runtimes/simple-keyvalue/src/test.rs
+++ b/tests/runtimes/simple-keyvalue/src/test.rs
@@ -16,6 +16,7 @@ fn test_impl_for_tuple() {
         ctx.runtime_state(),
         core::Parameters {
             max_batch_gas: u64::MAX,
+            max_tx_size: 32 * 1024,
             max_tx_signers: 1,
             max_multisig_signers: 1,
             gas_costs: Default::default(),


### PR DESCRIPTION
Given upcoming oasisprotocol/oasis-core#4665 which will mandate runtime schedule control, this makes schedule control always enabled.