### PR TITLE
runtime-sdk/migrations: allow migrating from empty state

### DIFF
--- a/runtime-sdk/src/runtime.rs
+++ b/runtime-sdk/src/runtime.rs
@@ -90,7 +90,8 @@ pub trait Runtime {
             .unwrap_or_default();
         if global_version != Self::STATE_VERSION {
             assert!(
-                global_version == Self::STATE_VERSION - 1,
+                // There should either be no state, or it should be the pervious version.
+                global_version == 0 || global_version == Self::STATE_VERSION - 1,
                 "inconsistent existing state version (expected: {} got: {})",
                 Self::STATE_VERSION - 1,
                 global_version


### PR DESCRIPTION
This is useful so that one is able to run a paratime with migrations on fresh state (e.g. local test network).