### PR TITLE
i18n: Fix usage of term "wallet" instead of "account"

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -43,22 +43,22 @@ oasis network set-default testnet
 oasis paratime set-default testnet emerald
 ```
 
-To be able to sign transactions you will need to first create or import a
-wallet. Currently only a local file-based backend is supported. To create a new
-wallet run:
+To be able to sign transactions you will need to first create or import an
+account into your wallet. Currently, only a local file-based backend is
+supported. To create a new account run:
 
 ```bash
-oasis wallet create mywallet
+oasis wallet create myaccount
 ```
 
-It will ask you to choose and confirm a passphrase to encrypt your wallet with.
-You can see a list of all wallets by running:
+It will ask you to choose and confirm a passphrase to encrypt your account with.
+You can see a list of all accounts by running:
 
 ```bash
 oasis wallet list
 ```
 
-To show the wallet's balance on the default network/paratime, run:
+To show the account's balance on the default network/paratime, run:
 
 ```bash
 oasis accounts show

--- a/cli/cmd/common/selector.go
+++ b/cli/cmd/common/selector.go
@@ -13,7 +13,7 @@ import (
 var (
 	selectedNetwork  string
 	selectedParaTime string
-	selectedWallet   string
+	selectedAccount  string
 
 	noParaTime bool
 )
@@ -21,21 +21,21 @@ var (
 // SelectorFlags contains the common selector flags for network/paratime/wallet.
 var SelectorFlags *flag.FlagSet
 
-// NPWSelection contains the network/paratime/wallet selection.
-type NPWSelection struct {
+// NPASelection contains the network/paratime/account selection.
+type NPASelection struct {
 	NetworkName string
 	Network     *config.Network
 
 	ParaTimeName string
 	ParaTime     *config.ParaTime
 
-	WalletName string
-	Wallet     *cliConfig.Wallet
+	AccountName string
+	Account     *cliConfig.Account
 }
 
-// GetNPWSelection returns the user-selected network/paratime/wallet combination.
-func GetNPWSelection(cfg *cliConfig.Config) *NPWSelection {
-	var s NPWSelection
+// GetNPASelection returns the user-selected network/paratime/account combination.
+func GetNPASelection(cfg *cliConfig.Config) *NPASelection {
+	var s NPASelection
 	s.NetworkName = cfg.Networks.Default
 	if selectedNetwork != "" {
 		s.NetworkName = selectedNetwork
@@ -61,14 +61,14 @@ func GetNPWSelection(cfg *cliConfig.Config) *NPWSelection {
 		}
 	}
 
-	s.WalletName = cfg.Wallets.Default
-	if selectedWallet != "" {
-		s.WalletName = selectedWallet
+	s.AccountName = cfg.Wallet.Default
+	if selectedAccount != "" {
+		s.AccountName = selectedAccount
 	}
-	if s.WalletName != "" {
-		s.Wallet = cfg.Wallets.All[s.WalletName]
-		if s.Wallet == nil {
-			cobra.CheckErr(fmt.Errorf("wallet '%s' does not exist", s.WalletName))
+	if s.AccountName != "" {
+		s.Account = cfg.Wallet.All[s.AccountName]
+		if s.Account == nil {
+			cobra.CheckErr(fmt.Errorf("account '%s' does not exist in the wallet", s.AccountName))
 		}
 	}
 
@@ -80,5 +80,5 @@ func init() {
 	SelectorFlags.StringVar(&selectedNetwork, "network", "", "explicitly set network to use")
 	SelectorFlags.StringVar(&selectedParaTime, "paratime", "", "explicitly set paratime to use")
 	SelectorFlags.BoolVar(&noParaTime, "no-paratime", false, "explicitly set that no paratime should be used")
-	SelectorFlags.StringVar(&selectedWallet, "wallet", "", "explicitly set wallet to use")
+	SelectorFlags.StringVar(&selectedAccount, "wallet", "", "explicitly set account to use")
 }

--- a/cli/cmd/common/selector.go
+++ b/cli/cmd/common/selector.go
@@ -80,5 +80,10 @@ func init() {
 	SelectorFlags.StringVar(&selectedNetwork, "network", "", "explicitly set network to use")
 	SelectorFlags.StringVar(&selectedParaTime, "paratime", "", "explicitly set paratime to use")
 	SelectorFlags.BoolVar(&noParaTime, "no-paratime", false, "explicitly set that no paratime should be used")
-	SelectorFlags.StringVar(&selectedAccount, "wallet", "", "explicitly set account to use")
+	SelectorFlags.StringVar(&selectedAccount, "account", "", "explicitly set account to use")
+
+	// Backward compatibility.
+	SelectorFlags.StringVar(&selectedAccount, "wallet", "", "explicitly set account to use. OBSOLETE, USE --account INSTEAD!")
+	err := SelectorFlags.MarkHidden("wallet")
+	cobra.CheckErr(err)
 }

--- a/cli/cmd/common/transaction.go
+++ b/cli/cmd/common/transaction.go
@@ -239,6 +239,11 @@ func PrintTransactionBeforeSigning(npa *NPASelection, tx interface{}) {
 	}
 	fmt.Println()
 
+	fmt.Printf("Account:  %s", npa.AccountName)
+	if len(npa.Account.Description) > 0 {
+		fmt.Printf(" (%s)", npa.Account.Description)
+	}
+	fmt.Println()
 	fmt.Printf("Network:  %s", npa.NetworkName)
 	if len(npa.Network.Description) > 0 {
 		fmt.Printf(" (%s)", npa.Network.Description)

--- a/cli/cmd/common/transaction.go
+++ b/cli/cmd/common/transaction.go
@@ -57,15 +57,15 @@ func GetTransactionConfig() *TransactionConfig {
 // SignConsensusTransaction signs a consensus transaction.
 func SignConsensusTransaction(
 	ctx context.Context,
-	npw *NPWSelection,
-	wallet wallet.Wallet,
+	npa *NPASelection,
+	wallet wallet.Account,
 	conn connection.Connection,
 	tx *consensusTx.Transaction,
 ) (*consensusTx.SignedTransaction, error) {
 	// Require consensus signer.
 	signer := wallet.ConsensusSigner()
 	if signer == nil {
-		return nil, fmt.Errorf("wallet does not support signing consensus transactions")
+		return nil, fmt.Errorf("account does not support signing consensus transactions")
 	}
 
 	// Default to passed values and do online estimation when possible.
@@ -78,7 +78,7 @@ func SignConsensusTransaction(
 	gasPrice := quantity.NewQuantity()
 	if txGasPrice != "" {
 		var err error
-		gasPrice, err = helpers.ParseConsensusDenomination(npw.Network, txGasPrice)
+		gasPrice, err = helpers.ParseConsensusDenomination(npa.Network, txGasPrice)
 		if err != nil {
 			return nil, fmt.Errorf("bad gas price: %w", err)
 		}
@@ -121,12 +121,12 @@ func SignConsensusTransaction(
 	}
 	tx.Fee.Amount = *gasPrice
 
-	PrintTransactionBeforeSigning(npw, tx)
+	PrintTransactionBeforeSigning(npa, tx)
 
 	// Sign the transaction.
 	// NOTE: We build our own domain separation context here as we need to support multiple chain
 	//       contexts at the same time. Would be great if chainContextSeparator was exposed in core.
-	sigCtx := coreSignature.Context([]byte(fmt.Sprintf("%s for chain %s", consensusTx.SignatureContext, npw.Network.ChainContext)))
+	sigCtx := coreSignature.Context([]byte(fmt.Sprintf("%s for chain %s", consensusTx.SignatureContext, npa.Network.ChainContext)))
 	signed, err := coreSignature.SignSigned(signer, sigCtx, tx)
 	if err != nil {
 		return nil, err
@@ -138,8 +138,8 @@ func SignConsensusTransaction(
 // SignParaTimeTransaction signs a ParaTime transaction.
 func SignParaTimeTransaction(
 	ctx context.Context,
-	npw *NPWSelection,
-	wallet wallet.Wallet,
+	npa *NPASelection,
+	wallet wallet.Account,
 	conn connection.Connection,
 	tx *types.Transaction,
 ) (*types.UnverifiedTransaction, error) {
@@ -151,7 +151,7 @@ func SignParaTimeTransaction(
 	if txGasPrice != "" {
 		// TODO: Support different denominations for gas fees.
 		var err error
-		gasPrice, err = helpers.ParseParaTimeDenomination(npw.ParaTime, txGasPrice, types.NativeDenomination)
+		gasPrice, err = helpers.ParseParaTimeDenomination(npa.ParaTime, txGasPrice, types.NativeDenomination)
 		if err != nil {
 			return nil, fmt.Errorf("bad gas price: %w", err)
 		}
@@ -161,7 +161,7 @@ func SignParaTimeTransaction(
 		// Query nonce if not specified.
 		if nonce == invalidNonce {
 			var err error
-			nonce, err = conn.Runtime(npw.ParaTime).Accounts.Nonce(ctx, client.RoundLatest, wallet.Address())
+			nonce, err = conn.Runtime(npa.ParaTime).Accounts.Nonce(ctx, client.RoundLatest, wallet.Address())
 			if err != nil {
 				return nil, fmt.Errorf("failed to query nonce: %w", err)
 			}
@@ -175,7 +175,7 @@ func SignParaTimeTransaction(
 		// Gas estimation if not specified.
 		if tx.AuthInfo.Fee.Gas == invalidGasLimit {
 			var err error
-			tx.AuthInfo.Fee.Gas, err = conn.Runtime(npw.ParaTime).Core.EstimateGas(ctx, client.RoundLatest, tx)
+			tx.AuthInfo.Fee.Gas, err = conn.Runtime(npa.ParaTime).Core.EstimateGas(ctx, client.RoundLatest, tx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to estimate gas: %w", err)
 			}
@@ -183,7 +183,7 @@ func SignParaTimeTransaction(
 
 		// Gas price determination if not specified.
 		if txGasPrice == "" {
-			mgp, err := conn.Runtime(npw.ParaTime).Core.MinGasPrice(ctx)
+			mgp, err := conn.Runtime(npa.ParaTime).Core.MinGasPrice(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query minimum gas price: %w", err)
 			}
@@ -208,10 +208,10 @@ func SignParaTimeTransaction(
 
 	// TODO: Support confidential transactions (only in online mode).
 
-	PrintTransactionBeforeSigning(npw, tx)
+	PrintTransactionBeforeSigning(npa, tx)
 
 	// Sign the transaction.
-	sigCtx := signature.DeriveChainContext(npw.ParaTime.Namespace(), npw.Network.ChainContext)
+	sigCtx := signature.DeriveChainContext(npa.ParaTime.Namespace(), npa.Network.ChainContext)
 	ts := tx.PrepareForSigning()
 	if err := ts.AppendSign(sigCtx, wallet.Signer()); err != nil {
 		return nil, fmt.Errorf("failed to sign transaction: %w", err)
@@ -221,15 +221,15 @@ func SignParaTimeTransaction(
 }
 
 // PrintTransactionBeforeSigning prints the transaction and asks the user for confirmation.
-func PrintTransactionBeforeSigning(npw *NPWSelection, tx interface{}) {
+func PrintTransactionBeforeSigning(npa *NPASelection, tx interface{}) {
 	fmt.Printf("You are about to sign the following transaction:\n")
 
 	switch rtx := tx.(type) {
 	case *consensusTx.Transaction:
 		// Consensus transaction.
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, consensusPretty.ContextKeyTokenSymbol, npw.Network.Denomination.Symbol)
-		ctx = context.WithValue(ctx, consensusPretty.ContextKeyTokenValueExponent, npw.Network.Denomination.Decimals)
+		ctx = context.WithValue(ctx, consensusPretty.ContextKeyTokenSymbol, npa.Network.Denomination.Symbol)
+		ctx = context.WithValue(ctx, consensusPretty.ContextKeyTokenValueExponent, npa.Network.Denomination.Decimals)
 		rtx.PrettyPrint(ctx, "", os.Stdout)
 	default:
 		// TODO: Add pretty variant for paratime transactions.
@@ -239,15 +239,15 @@ func PrintTransactionBeforeSigning(npw *NPWSelection, tx interface{}) {
 	}
 	fmt.Println()
 
-	fmt.Printf("Network:  %s", npw.NetworkName)
-	if len(npw.Network.Description) > 0 {
-		fmt.Printf(" (%s)", npw.Network.Description)
+	fmt.Printf("Network:  %s", npa.NetworkName)
+	if len(npa.Network.Description) > 0 {
+		fmt.Printf(" (%s)", npa.Network.Description)
 	}
 	fmt.Println()
-	if _, isParaTimeTx := tx.(*types.Transaction); isParaTimeTx && npw.ParaTime != nil {
-		fmt.Printf("Paratime: %s", npw.ParaTimeName)
-		if len(npw.ParaTime.Description) > 0 {
-			fmt.Printf(" (%s)", npw.ParaTime.Description)
+	if _, isParaTimeTx := tx.(*types.Transaction); isParaTimeTx && npa.ParaTime != nil {
+		fmt.Printf("Paratime: %s", npa.ParaTimeName)
+		if len(npa.ParaTime.Description) > 0 {
+			fmt.Printf(" (%s)", npa.ParaTime.Description)
 		}
 		fmt.Println()
 	} else {

--- a/cli/cmd/common/wallet.go
+++ b/cli/cmd/common/wallet.go
@@ -10,31 +10,31 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/cli/wallet"
 )
 
-// LoadWallet loads the given named wallet.
-func LoadWallet(cfg *config.Config, name string) wallet.Wallet {
-	// Early check for whether the wallet exists so that we don't ask for passphrase first.
+// LoadAccount loads the given named account.
+func LoadAccount(cfg *config.Config, name string) wallet.Account {
+	// Early check for whether the account exists so that we don't ask for passphrase first.
 	var (
-		wcfg   *config.Wallet
+		acfg   *config.Account
 		exists bool
 	)
-	if wcfg, exists = cfg.Wallets.All[name]; !exists {
-		cobra.CheckErr(fmt.Errorf("wallet '%s' does not exist", name))
+	if acfg, exists = cfg.Wallet.All[name]; !exists {
+		cobra.CheckErr(fmt.Errorf("account '%s' does not exist in the wallet", name))
 	}
 
-	wf, err := wcfg.LoadFactory()
+	af, err := acfg.LoadFactory()
 	cobra.CheckErr(err)
 
 	var passphrase string
-	if wf.RequiresPassphrase() {
-		// Ask for passphrase to decrypt the wallet.
-		fmt.Printf("Unlock your wallet.\n")
+	if af.RequiresPassphrase() {
+		// Ask for passphrase to decrypt the account.
+		fmt.Printf("Unlock your account.\n")
 
 		err = survey.AskOne(PromptPassphrase, &passphrase)
 		cobra.CheckErr(err)
 	}
 
-	wallet, err := cfg.Wallets.Load(name, passphrase)
+	acc, err := cfg.Wallet.Load(name, passphrase)
 	cobra.CheckErr(err)
 
-	return wallet
+	return acc
 }

--- a/cli/cmd/inspect/governance_proposal.go
+++ b/cli/cmd/inspect/governance_proposal.go
@@ -28,7 +28,7 @@ var governanceProposalCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := cliConfig.Global()
-		npw := common.GetNPWSelection(cfg)
+		npa := common.GetNPASelection(cfg)
 
 		// Determine the proposal ID to query.
 		proposalID, err := strconv.ParseUint(args[0], 10, 64)
@@ -36,7 +36,7 @@ var governanceProposalCmd = &cobra.Command{
 
 		// Establish connection with the target network.
 		ctx := context.Background()
-		conn, err := connection.Connect(ctx, npw.Network)
+		conn, err := connection.Connect(ctx, npa.Network)
 		cobra.CheckErr(err)
 
 		consensusConn := conn.Consensus()

--- a/cli/cmd/inspect/native_token.go
+++ b/cli/cmd/inspect/native_token.go
@@ -22,11 +22,11 @@ var nativeTokenCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := cliConfig.Global()
-		npw := common.GetNPWSelection(cfg)
+		npa := common.GetNPASelection(cfg)
 
 		// Establish connection with the target network.
 		ctx := context.Background()
-		conn, err := connection.Connect(ctx, npw.Network)
+		conn, err := connection.Connect(ctx, npa.Network)
 		cobra.CheckErr(err)
 
 		consensusConn := conn.Consensus()

--- a/cli/cmd/inspect/node_status.go
+++ b/cli/cmd/inspect/node_status.go
@@ -17,11 +17,11 @@ var nodeStatusCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := cliConfig.Global()
-		npw := common.GetNPWSelection(cfg)
+		npa := common.GetNPASelection(cfg)
 
 		// Establish connection with the target network.
 		ctx := context.Background()
-		conn, err := connection.Connect(ctx, npw.Network)
+		conn, err := connection.Connect(ctx, npa.Network)
 		cobra.CheckErr(err)
 
 		ctrlConn := conn.Control()

--- a/cli/cmd/inspect/runtime_stats.go
+++ b/cli/cmd/inspect/runtime_stats.go
@@ -172,8 +172,8 @@ var runtimeStatsCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := cliConfig.Global()
-		npw := common.GetNPWSelection(cfg)
-		runtimeID := npw.ParaTime.Namespace()
+		npa := common.GetNPASelection(cfg)
+		runtimeID := npa.ParaTime.Namespace()
 
 		// Parse command line arguments
 		var startHeight, endHeight uint64
@@ -192,7 +192,7 @@ var runtimeStatsCmd = &cobra.Command{
 
 		// Establish connection with the target network.
 		ctx := context.Background()
-		conn, err := connection.Connect(ctx, npw.Network)
+		conn, err := connection.Connect(ctx, npa.Network)
 		cobra.CheckErr(err)
 
 		consensusConn := conn.Consensus()

--- a/cli/cmd/network.go
+++ b/cli/cmd/network.go
@@ -35,7 +35,7 @@ var (
 			for name, net := range cfg.Networks.All {
 				displayName := name
 				if cfg.Networks.Default == name {
-					displayName += " (*)"
+					displayName += defaultMarker
 				}
 
 				output = append(output, []string{

--- a/cli/cmd/paratime.go
+++ b/cli/cmd/paratime.go
@@ -33,7 +33,7 @@ var (
 				for ptName, pt := range net.ParaTimes.All {
 					displayPtName := ptName
 					if net.ParaTimes.Default == ptName {
-						displayPtName += " (*)"
+						displayPtName += defaultMarker
 					}
 
 					output = append(output, []string{

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,6 +16,10 @@ import (
 	_ "github.com/oasisprotocol/oasis-sdk/cli/wallet/ledger" // Register ledger wallet backend.
 )
 
+const (
+	defaultMarker = " (*)"
+)
+
 var (
 	cfgFile string
 

--- a/cli/cmd/wallet.go
+++ b/cli/cmd/wallet.go
@@ -37,6 +37,9 @@ var (
 
 			var output [][]string
 			for name, acc := range cfg.Wallet.All {
+				if cfg.Wallet.Default == name {
+					name += defaultMarker
+				}
 				output = append(output, []string{
 					name,
 					acc.PrettyKind(),

--- a/cli/cmd/wallet.go
+++ b/cli/cmd/wallet.go
@@ -18,17 +18,17 @@ import (
 )
 
 var (
-	walletKind string
+	accKind string
 
 	walletCmd = &cobra.Command{
 		Use:   "wallet",
-		Short: "Manage wallets",
+		Short: "Manage accounts in the local wallet",
 	}
 
 	walletListCmd = &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List configured wallets",
+		Short:   "List configured accounts",
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
@@ -36,11 +36,11 @@ var (
 			table.SetHeader([]string{"Name", "Kind", "Address"})
 
 			var output [][]string
-			for name, wallet := range cfg.Wallets.All {
+			for name, acc := range cfg.Wallet.All {
 				output = append(output, []string{
 					name,
-					wallet.PrettyKind(),
-					wallet.Address,
+					acc.PrettyKind(),
+					acc.Address,
 				})
 			}
 
@@ -56,28 +56,28 @@ var (
 
 	walletCreateCmd = &cobra.Command{
 		Use:   "create <name>",
-		Short: "Create a new wallet",
+		Short: "Create a new account",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			name := args[0]
 
-			wf, err := wallet.Load(walletKind)
+			af, err := wallet.Load(accKind)
 			cobra.CheckErr(err)
 
 			// Ask for passphrase to encrypt the wallet with.
 			var passphrase string
-			if wf.RequiresPassphrase() {
+			if af.RequiresPassphrase() {
 				passphrase = common.AskNewPassphrase()
 			}
 
-			walletCfg := &config.Wallet{
-				Kind: walletKind,
+			accCfg := &config.Account{
+				Kind: accKind,
 			}
-			err = walletCfg.SetConfigFromFlags()
+			err = accCfg.SetConfigFromFlags()
 			cobra.CheckErr(err)
 
-			err = cfg.Wallets.Create(name, passphrase, walletCfg)
+			err = cfg.Wallet.Create(name, passphrase, accCfg)
 			cobra.CheckErr(err)
 
 			err = cfg.Save()
@@ -87,35 +87,35 @@ var (
 
 	walletShowCmd = &cobra.Command{
 		Use:   "show <name>",
-		Short: "Show public wallet information",
+		Short: "Show public account information",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 
-			wallet := common.LoadWallet(config.Global(), name)
-			showPublicWalletInfo(wallet)
+			acc := common.LoadAccount(config.Global(), name)
+			showPublicWalletInfo(acc)
 		},
 	}
 
 	walletRmCmd = &cobra.Command{
 		Use:     "rm <name>",
 		Aliases: []string{"remove"},
-		Short:   "Remove an existing wallet",
+		Short:   "Remove an existing account",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			name := args[0]
 
 			// Early check for whether the wallet exists so that we don't ask for confirmation first.
-			if _, exists := cfg.Wallets.All[name]; !exists {
-				cobra.CheckErr(fmt.Errorf("wallet '%s' does not exist", name))
+			if _, exists := cfg.Wallet.All[name]; !exists {
+				cobra.CheckErr(fmt.Errorf("account '%s' does not exist", name))
 			}
 
-			fmt.Printf("WARNING: Removing the wallet will ERASE secret key material!\n")
+			fmt.Printf("WARNING: Removing the account will ERASE secret key material!\n")
 			fmt.Printf("WARNING: THIS ACTION IS IRREVERSIBLE!\n")
 
 			var result string
-			confirmText := fmt.Sprintf("I really want to remove wallet %s", name)
+			confirmText := fmt.Sprintf("I really want to remove account %s", name)
 			prompt := &survey.Input{
 				Message: fmt.Sprintf("Enter '%s' (without quotes) to confirm removal:", confirmText),
 			}
@@ -126,7 +126,7 @@ var (
 				cobra.CheckErr("Aborted.")
 			}
 
-			err = cfg.Wallets.Remove(name)
+			err = cfg.Wallet.Remove(name)
 			cobra.CheckErr(err)
 
 			err = cfg.Save()
@@ -136,13 +136,13 @@ var (
 
 	walletRenameCmd = &cobra.Command{
 		Use:   "rename <old> <new>",
-		Short: "Rename an existing wallet",
+		Short: "Rename an existing account",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			oldName, newName := args[0], args[1]
 
-			err := cfg.Wallets.Rename(oldName, newName)
+			err := cfg.Wallet.Rename(oldName, newName)
 			cobra.CheckErr(err)
 
 			err = cfg.Save()
@@ -152,13 +152,13 @@ var (
 
 	walletSetDefaultCmd = &cobra.Command{
 		Use:   "set-default <name>",
-		Short: "Sets the given wallet as the default wallet",
+		Short: "Sets the given account as the default account",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			name := args[0]
 
-			err := cfg.Wallets.SetDefault(name)
+			err := cfg.Wallet.SetDefault(name)
 			cobra.CheckErr(err)
 
 			err = cfg.Save()
@@ -168,23 +168,23 @@ var (
 
 	walletImportCmd = &cobra.Command{
 		Use:   "import <name>",
-		Short: "Import an existing wallet",
+		Short: "Import an existing account",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			name := args[0]
 
-			if _, exists := cfg.Wallets.All[name]; exists {
-				cobra.CheckErr(fmt.Errorf("wallet '%s' already exists", name))
+			if _, exists := cfg.Wallet.All[name]; exists {
+				cobra.CheckErr(fmt.Errorf("account '%s' already exists", name))
 			}
 
 			// NOTE: We only support importing into the file-based wallet for now.
-			wf, err := wallet.Load(walletFile.Kind)
+			af, err := wallet.Load(walletFile.Kind)
 			cobra.CheckErr(err)
 
 			// Ask for import kind.
 			var supportedKinds []string
-			for _, kind := range wf.SupportedImportKinds() {
+			for _, kind := range af.SupportedImportKinds() {
 				supportedKinds = append(supportedKinds, string(kind))
 			}
 
@@ -200,7 +200,7 @@ var (
 			cobra.CheckErr(err)
 
 			// Ask for wallet configuration.
-			wfCfg, err := wf.GetConfigFromSurvey(&kind)
+			afCfg, err := af.GetConfigFromSurvey(&kind)
 			cobra.CheckErr(err)
 
 			// Ask for import data.
@@ -210,8 +210,8 @@ var (
 			questions := []*survey.Question{
 				{
 					Name:     "data",
-					Prompt:   wf.DataPrompt(kind, wfCfg),
-					Validate: wf.DataValidator(kind, wfCfg),
+					Prompt:   af.DataPrompt(kind, afCfg),
+					Validate: af.DataValidator(kind, afCfg),
 				},
 			}
 			err = survey.Ask(questions, &answers)
@@ -220,16 +220,16 @@ var (
 			// Ask for passphrase.
 			passphrase := common.AskNewPassphrase()
 
-			walletCfg := &config.Wallet{
-				Kind:   wf.Kind(),
-				Config: wfCfg,
+			accCfg := &config.Account{
+				Kind:   af.Kind(),
+				Config: afCfg,
 			}
 			src := &wallet.ImportSource{
 				Kind: kind,
 				Data: answers.Data,
 			}
 
-			err = cfg.Wallets.Import(name, passphrase, walletCfg, src)
+			err = cfg.Wallet.Import(name, passphrase, accCfg, src)
 			cobra.CheckErr(err)
 
 			err = cfg.Save()
@@ -239,23 +239,23 @@ var (
 
 	walletExportCmd = &cobra.Command{
 		Use:   "export <name>",
-		Short: "Export secret wallet information",
+		Short: "Export secret account information",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 
-			fmt.Printf("WARNING: Exporting the wallet will expose secret key material!\n")
-			wallet := common.LoadWallet(config.Global(), name)
+			fmt.Printf("WARNING: Exporting the account will expose secret key material!\n")
+			acc := common.LoadAccount(config.Global(), name)
 
-			showPublicWalletInfo(wallet)
+			showPublicWalletInfo(acc)
 
 			fmt.Printf("Export:\n")
-			fmt.Println(wallet.UnsafeExport())
+			fmt.Println(acc.UnsafeExport())
 		},
 	}
 )
 
-func showPublicWalletInfo(wallet wallet.Wallet) {
+func showPublicWalletInfo(wallet wallet.Account) {
 	fmt.Printf("Public Key:       %s\n", wallet.Signer().Public())
 	fmt.Printf("Address:          %s\n", wallet.Address())
 	if wallet.SignatureAddressSpec().Secp256k1Eth != nil {
@@ -271,11 +271,11 @@ func init() {
 	for _, w := range wallet.AvailableKinds() {
 		kinds = append(kinds, w.Kind())
 	}
-	walletFlags.StringVar(&walletKind, "kind", "file", fmt.Sprintf("Wallet kind [%s]", strings.Join(kinds, ", ")))
+	walletFlags.StringVar(&accKind, "kind", "file", fmt.Sprintf("Account kind [%s]", strings.Join(kinds, ", ")))
 
 	// TODO: Group flags in usage by tweaking the usage template/function.
-	for _, wf := range wallet.AvailableKinds() {
-		walletFlags.AddFlagSet(wf.Flags())
+	for _, af := range wallet.AvailableKinds() {
+		walletFlags.AddFlagSet(af.Flags())
 	}
 
 	walletCreateCmd.Flags().AddFlagSet(walletFlags)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	viper *viper.Viper
 
 	Networks config.Networks `mapstructure:"networks"`
-	Wallets  Wallets         `mapstructure:"wallets"`
+	Wallet   Wallet          `mapstructure:"wallets"`
 }
 
 // Load loads the configuration structure from viper.
@@ -165,7 +165,7 @@ func (cfg *Config) Validate() error {
 	if err := cfg.Networks.Validate(); err != nil {
 		return fmt.Errorf("failed to validate network configuration: %w", err)
 	}
-	if err := cfg.Wallets.Validate(); err != nil {
+	if err := cfg.Wallet.Validate(); err != nil {
 		return fmt.Errorf("failed to validate wallet configuration: %w", err)
 	}
 	return nil

--- a/cli/config/wallet.go
+++ b/cli/config/wallet.go
@@ -8,64 +8,64 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-// Wallets contains the configuration of wallets.
-type Wallets struct {
-	// Default is the name of the default wallet.
+// Wallet contains the configuration of the wallet.
+type Wallet struct {
+	// Default is the name of the default account.
 	Default string `mapstructure:"default"`
 
-	// All is a map of all configured wallets.
-	All map[string]*Wallet `mapstructure:",remain"`
+	// All is a map of all configured accounts in the wallet.
+	All map[string]*Account `mapstructure:",remain"`
 }
 
 // Validate performs config validation.
-func (w *Wallets) Validate() error {
-	// Make sure the default wallet actually exists.
+func (w *Wallet) Validate() error {
+	// Make sure the default account actually exists.
 	if _, exists := w.All[w.Default]; w.Default != "" && !exists {
-		return fmt.Errorf("default wallet '%s' does not exist", w.Default)
+		return fmt.Errorf("default account '%s' does not exist in the wallet", w.Default)
 	}
 
-	// Make sure all wallets are valid.
-	for name, wallet := range w.All {
+	// Make sure all accounts are valid.
+	for name, acc := range w.All {
 		if err := config.ValidateIdentifier(name); err != nil {
-			return fmt.Errorf("malformed wallet name '%s': %w", name, err)
+			return fmt.Errorf("malformed account name '%s': %w", name, err)
 		}
 
-		if err := wallet.Validate(); err != nil {
-			return fmt.Errorf("wallet '%s': %w", name, err)
+		if err := acc.Validate(); err != nil {
+			return fmt.Errorf("account '%s': %w", name, err)
 		}
 	}
 
 	return nil
 }
 
-// Create creates a new wallet.
-func (w *Wallets) Create(name string, passphrase string, nw *Wallet) error {
+// Create creates a new account.
+func (w *Wallet) Create(name string, passphrase string, nw *Account) error {
 	if _, exists := w.All[name]; exists {
-		return fmt.Errorf("wallet '%s' already exists", name)
+		return fmt.Errorf("account '%s' already exists", name)
 	}
 
 	if err := config.ValidateIdentifier(name); err != nil {
-		return fmt.Errorf("malformed wallet name '%s': %w", name, err)
+		return fmt.Errorf("malformed account name '%s': %w", name, err)
 	}
 
-	wf, err := wallet.Load(nw.Kind)
+	af, err := wallet.Load(nw.Kind)
 	if err != nil {
 		return err
 	}
-	wl, err := wf.Create(name, passphrase, nw.Config)
+	acc, err := af.Create(name, passphrase, nw.Config)
 	if err != nil {
 		return err
 	}
 
-	// Store address so we don't need to load the wallet to see the address.
-	address, err := wl.Address().MarshalText()
+	// Store address so we don't need to load the account to see the address.
+	address, err := acc.Address().MarshalText()
 	if err != nil {
-		return fmt.Errorf("failed to marshal wallet address: %w", err)
+		return fmt.Errorf("failed to marshal account address: %w", err)
 	}
 	nw.Address = string(address)
 
 	if w.All == nil {
-		w.All = make(map[string]*Wallet)
+		w.All = make(map[string]*Account)
 	}
 	w.All[name] = nw
 
@@ -77,55 +77,55 @@ func (w *Wallets) Create(name string, passphrase string, nw *Wallet) error {
 	return nil
 }
 
-// Load loads the given wallet.
-func (w *Wallets) Load(name string, passphrase string) (wallet.Wallet, error) {
+// Load loads the given account.
+func (w *Wallet) Load(name string, passphrase string) (wallet.Account, error) {
 	cfg, exists := w.All[name]
 	if !exists {
-		return nil, fmt.Errorf("wallet '%s' does not exist", name)
+		return nil, fmt.Errorf("account '%s' does not exist in the wallet", name)
 	}
 
 	if err := config.ValidateIdentifier(name); err != nil {
-		return nil, fmt.Errorf("malformed wallet name '%s': %w", name, err)
+		return nil, fmt.Errorf("malformed account name '%s': %w", name, err)
 	}
 
-	wf, err := wallet.Load(cfg.Kind)
+	af, err := wallet.Load(cfg.Kind)
 	if err != nil {
 		return nil, err
 	}
 
-	wl, err := wf.Load(name, passphrase, cfg.Config)
+	acc, err := af.Load(name, passphrase, cfg.Config)
 	if err != nil {
 		return nil, err
 	}
 
 	// Make sure the address matches what we have in the config.
-	if expected, actual := cfg.GetAddress(), wl.Address(); !actual.Equal(expected) {
-		return nil, fmt.Errorf("address mismatch after loading wallet (expected: %s got: %s)",
+	if expected, actual := cfg.GetAddress(), acc.Address(); !actual.Equal(expected) {
+		return nil, fmt.Errorf("address mismatch after loading account (expected: %s got: %s)",
 			expected,
 			actual,
 		)
 	}
 
-	return wl, nil
+	return acc, nil
 }
 
-// Remove removes the given wallet.
-func (w *Wallets) Remove(name string) error {
+// Remove removes the given account.
+func (w *Wallet) Remove(name string) error {
 	cfg, exists := w.All[name]
 	if !exists {
-		return fmt.Errorf("wallet '%s' does not exist", name)
+		return fmt.Errorf("account '%s' does not exist in the wallet", name)
 	}
 
 	if err := config.ValidateIdentifier(name); err != nil {
-		return fmt.Errorf("malformed wallet name '%s': %w", name, err)
+		return fmt.Errorf("malformed account name '%s': %w", name, err)
 	}
 
-	wf, err := wallet.Load(cfg.Kind)
+	af, err := wallet.Load(cfg.Kind)
 	if err != nil {
 		return err
 	}
 
-	if err := wf.Remove(name, cfg.Config); err != nil {
+	if err := af.Remove(name, cfg.Config); err != nil {
 		return err
 	}
 
@@ -139,30 +139,30 @@ func (w *Wallets) Remove(name string) error {
 	return nil
 }
 
-// Rename renames an existing wallet.
-func (w *Wallets) Rename(old, new string) error {
+// Rename renames an existing account.
+func (w *Wallet) Rename(old, new string) error {
 	cfg, exists := w.All[old]
 	if !exists {
-		return fmt.Errorf("wallet '%s' does not exist", old)
+		return fmt.Errorf("account '%s' does not exist", old)
 	}
 
 	if _, exists = w.All[new]; exists {
-		return fmt.Errorf("wallet '%s' already exists", new)
+		return fmt.Errorf("account '%s' already exists", new)
 	}
 
 	if err := config.ValidateIdentifier(old); err != nil {
-		return fmt.Errorf("malformed old wallet name '%s': %w", old, err)
+		return fmt.Errorf("malformed old account name '%s': %w", old, err)
 	}
 	if err := config.ValidateIdentifier(new); err != nil {
-		return fmt.Errorf("malformed new wallet name '%s': %w", new, err)
+		return fmt.Errorf("malformed new account name '%s': %w", new, err)
 	}
 
-	wf, err := wallet.Load(cfg.Kind)
+	af, err := wallet.Load(cfg.Kind)
 	if err != nil {
 		return err
 	}
 
-	if err := wf.Rename(old, new, cfg.Config); err != nil {
+	if err := af.Rename(old, new, cfg.Config); err != nil {
 		return err
 	}
 
@@ -177,34 +177,34 @@ func (w *Wallets) Rename(old, new string) error {
 	return nil
 }
 
-// Import imports an existing wallet.
-func (w *Wallets) Import(name string, passphrase string, nw *Wallet, src *wallet.ImportSource) error {
+// Import imports an existing account.
+func (w *Wallet) Import(name string, passphrase string, nw *Account, src *wallet.ImportSource) error {
 	if _, exists := w.All[name]; exists {
-		return fmt.Errorf("wallet '%s' already exists", name)
+		return fmt.Errorf("account '%s' already exists in the wallet", name)
 	}
 
 	if err := config.ValidateIdentifier(name); err != nil {
-		return fmt.Errorf("malformed wallet name '%s': %w", name, err)
+		return fmt.Errorf("malformed account name '%s': %w", name, err)
 	}
 
-	wf, err := wallet.Load(nw.Kind)
+	af, err := wallet.Load(nw.Kind)
 	if err != nil {
 		return err
 	}
-	wl, err := wf.Import(name, passphrase, nw.Config, src)
+	acc, err := af.Import(name, passphrase, nw.Config, src)
 	if err != nil {
 		return err
 	}
 
 	// Store address so we don't need to load the wallet to see the address.
-	address, err := wl.Address().MarshalText()
+	address, err := acc.Address().MarshalText()
 	if err != nil {
-		return fmt.Errorf("failed to marshal wallet address: %w", err)
+		return fmt.Errorf("failed to marshal account address: %w", err)
 	}
 	nw.Address = string(address)
 
 	if w.All == nil {
-		w.All = make(map[string]*Wallet)
+		w.All = make(map[string]*Account)
 	}
 	w.All[name] = nw
 
@@ -216,14 +216,14 @@ func (w *Wallets) Import(name string, passphrase string, nw *Wallet, src *wallet
 	return nil
 }
 
-// SetDefault sets the given wallet as the default wallet.
-func (w *Wallets) SetDefault(name string) error {
+// SetDefault marks the given account as default.
+func (w *Wallet) SetDefault(name string) error {
 	if _, exists := w.All[name]; !exists {
-		return fmt.Errorf("wallet '%s' does not exist", name)
+		return fmt.Errorf("account '%s' does not exist in the wallet", name)
 	}
 
 	if err := config.ValidateIdentifier(name); err != nil {
-		return fmt.Errorf("malformed wallet name '%s': %w", name, err)
+		return fmt.Errorf("malformed account name '%s': %w", name, err)
 	}
 
 	w.Default = name
@@ -231,8 +231,8 @@ func (w *Wallets) SetDefault(name string) error {
 	return nil
 }
 
-// Wallet is a wallet configuration object.
-type Wallet struct {
+// Account is an account configuration object.
+type Account struct {
 	Description string `mapstructure:"description"`
 	Kind        string `mapstructure:"kind"`
 	Address     string `mapstructure:"address"`
@@ -242,65 +242,65 @@ type Wallet struct {
 }
 
 // Validate performs config validation.
-func (w *Wallet) Validate() error {
-	// Check if given wallet kind is supported.
-	if _, err := wallet.Load(w.Kind); err != nil {
-		return fmt.Errorf("kind '%s' is not supported", w.Kind)
+func (a *Account) Validate() error {
+	// Check if given account kind is supported.
+	if _, err := wallet.Load(a.Kind); err != nil {
+		return fmt.Errorf("kind '%s' is not supported", a.Kind)
 	}
 
 	// Check that address is valid.
 	var address types.Address
-	if err := address.UnmarshalText([]byte(w.Address)); err != nil {
-		return fmt.Errorf("malformed address '%s': %w", w.Address, err)
+	if err := address.UnmarshalText([]byte(a.Address)); err != nil {
+		return fmt.Errorf("malformed address '%s': %a", a.Address, err)
 	}
 
 	return nil
 }
 
-// GetAddress returns the parsed wallet address.
-func (w *Wallet) GetAddress() types.Address {
+// GetAddress returns the parsed account address.
+func (a *Account) GetAddress() types.Address {
 	var address types.Address
-	if err := address.UnmarshalText([]byte(w.Address)); err != nil {
+	if err := address.UnmarshalText([]byte(a.Address)); err != nil {
 		panic(err)
 	}
 	return address
 }
 
 // SetConfigFromFlags populates the kind-specific configuration from CLI flags.
-func (w *Wallet) SetConfigFromFlags() error {
-	wf, err := wallet.Load(w.Kind)
+func (a *Account) SetConfigFromFlags() error {
+	af, err := wallet.Load(a.Kind)
 	if err != nil {
-		return fmt.Errorf("kind '%s' is not supported", w.Kind)
+		return fmt.Errorf("kind '%s' is not supported", a.Kind)
 	}
 
-	cfg, err := wf.GetConfigFromFlags()
+	cfg, err := af.GetConfigFromFlags()
 	if err != nil {
 		return err
 	}
 
-	w.Config = cfg
+	a.Config = cfg
 	return nil
 }
 
-// LoadFactory loads the wallet factory corresponding to this wallet's kind.
-func (w *Wallet) LoadFactory() (wallet.Factory, error) {
-	return wallet.Load(w.Kind)
+// LoadFactory loads the account factory corresponding to this account's kind.
+func (a *Account) LoadFactory() (wallet.Factory, error) {
+	return wallet.Load(a.Kind)
 }
 
-// PrettyKind returns a human-friendly wallet kind.
-func (w *Wallet) PrettyKind() string {
-	wf, err := wallet.Load(w.Kind)
+// PrettyKind returns a human-friendly account kind.
+func (a *Account) PrettyKind() string {
+	af, err := wallet.Load(a.Kind)
 	if err != nil {
 		return ""
 	}
-	return wf.PrettyKind(w.Config)
+	return af.PrettyKind(a.Config)
 }
 
-// HasConsensusSigner returns true, iff there is a consensus layer signer associated with this wallet.
-func (w *Wallet) HasConsensusSigner() bool {
-	wf, err := wallet.Load(w.Kind)
+// HasConsensusSigner returns true, iff there is a consensus layer signer associated with this account.
+func (a *Account) HasConsensusSigner() bool {
+	af, err := wallet.Load(a.Kind)
 	if err != nil {
 		return false
 	}
-	return wf.HasConsensusSigner(w.Config)
+	return af.HasConsensusSigner(a.Config)
 }

--- a/cli/wallet/file/ed25519.go
+++ b/cli/wallet/file/ed25519.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ed25519rawSigner is an in-memory signer that allows deserialization of raw ed25519 keys for use
-// in imported wallets that don't use ADR 0008.
+// in imported accounts that don't use ADR 0008.
 type ed25519rawSigner struct {
 	privateKey ed25519.PrivateKey
 }

--- a/cli/wallet/ledger/ledger.go
+++ b/cli/wallet/ledger/ledger.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// Kind is the wallet kind for the ledger-backed wallet.
+	// Kind is the account kind for the ledger-backed accounts.
 	Kind = "ledger"
 
 	derivationAdr8   = "adr8"
@@ -26,21 +26,21 @@ const (
 	cfgNumber     = "ledger.number"
 )
 
-type walletConfig struct {
+type accountConfig struct {
 	Derivation string `mapstructure:"derivation,omitempty"`
 	Number     uint32 `mapstructure:"number,omitempty"`
 }
 
-type ledgerWalletFactory struct {
+type ledgerAccountFactory struct {
 	flags *flag.FlagSet
 }
 
-func (wf *ledgerWalletFactory) Kind() string {
+func (af *ledgerAccountFactory) Kind() string {
 	return Kind
 }
 
-func (wf *ledgerWalletFactory) PrettyKind(rawCfg map[string]interface{}) string {
-	cfg, err := wf.unmarshalConfig(rawCfg)
+func (af *ledgerAccountFactory) PrettyKind(rawCfg map[string]interface{}) string {
+	cfg, err := af.unmarshalConfig(rawCfg)
 	if err != nil {
 		return ""
 	}
@@ -50,93 +50,93 @@ func (wf *ledgerWalletFactory) PrettyKind(rawCfg map[string]interface{}) string 
 	if derivation == "" {
 		derivation = derivationAdr8
 	}
-	return fmt.Sprintf("%s (%s:%d)", wf.Kind(), derivation, cfg.Number)
+	return fmt.Sprintf("%s (%s:%d)", af.Kind(), derivation, cfg.Number)
 }
 
-func (wf *ledgerWalletFactory) Flags() *flag.FlagSet {
-	return wf.flags
+func (af *ledgerAccountFactory) Flags() *flag.FlagSet {
+	return af.flags
 }
 
-func (wf *ledgerWalletFactory) GetConfigFromFlags() (map[string]interface{}, error) {
+func (af *ledgerAccountFactory) GetConfigFromFlags() (map[string]interface{}, error) {
 	cfg := make(map[string]interface{})
-	cfg["derivation"], _ = wf.flags.GetString(cfgDerivation)
-	cfg["number"], _ = wf.flags.GetUint32(cfgNumber)
+	cfg["derivation"], _ = af.flags.GetString(cfgDerivation)
+	cfg["number"], _ = af.flags.GetUint32(cfgNumber)
 	return cfg, nil
 }
 
-func (wf *ledgerWalletFactory) GetConfigFromSurvey(kind *wallet.ImportKind) (map[string]interface{}, error) {
+func (af *ledgerAccountFactory) GetConfigFromSurvey(kind *wallet.ImportKind) (map[string]interface{}, error) {
 	return nil, fmt.Errorf("ledger: import not supported")
 }
 
-func (wf *ledgerWalletFactory) DataPrompt(kind wallet.ImportKind, rawCfg map[string]interface{}) survey.Prompt {
+func (af *ledgerAccountFactory) DataPrompt(kind wallet.ImportKind, rawCfg map[string]interface{}) survey.Prompt {
 	return nil
 }
 
-func (wf *ledgerWalletFactory) DataValidator(kind wallet.ImportKind, rawCfg map[string]interface{}) survey.Validator {
+func (af *ledgerAccountFactory) DataValidator(kind wallet.ImportKind, rawCfg map[string]interface{}) survey.Validator {
 	return nil
 }
 
-func (wf *ledgerWalletFactory) RequiresPassphrase() bool {
+func (af *ledgerAccountFactory) RequiresPassphrase() bool {
 	return false
 }
 
-func (wf *ledgerWalletFactory) SupportedImportKinds() []wallet.ImportKind {
+func (af *ledgerAccountFactory) SupportedImportKinds() []wallet.ImportKind {
 	return []wallet.ImportKind{}
 }
 
-func (wf *ledgerWalletFactory) HasConsensusSigner(rawCfg map[string]interface{}) bool {
+func (af *ledgerAccountFactory) HasConsensusSigner(rawCfg map[string]interface{}) bool {
 	return true
 }
 
-func (wf *ledgerWalletFactory) unmarshalConfig(raw map[string]interface{}) (*walletConfig, error) {
+func (af *ledgerAccountFactory) unmarshalConfig(raw map[string]interface{}) (*accountConfig, error) {
 	if raw == nil {
 		return nil, fmt.Errorf("missing configuration")
 	}
 
-	var cfg walletConfig
+	var cfg accountConfig
 	if err := mapstructure.Decode(raw, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
 }
 
-func (wf *ledgerWalletFactory) Create(name string, passphrase string, rawCfg map[string]interface{}) (wallet.Wallet, error) {
-	cfg, err := wf.unmarshalConfig(rawCfg)
+func (af *ledgerAccountFactory) Create(name string, passphrase string, rawCfg map[string]interface{}) (wallet.Account, error) {
+	cfg, err := af.unmarshalConfig(rawCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return newWallet(cfg)
+	return newAccount(cfg)
 }
 
-func (wf *ledgerWalletFactory) Load(name string, passphrase string, rawCfg map[string]interface{}) (wallet.Wallet, error) {
-	cfg, err := wf.unmarshalConfig(rawCfg)
+func (af *ledgerAccountFactory) Load(name string, passphrase string, rawCfg map[string]interface{}) (wallet.Account, error) {
+	cfg, err := af.unmarshalConfig(rawCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return newWallet(cfg)
+	return newAccount(cfg)
 }
 
-func (wf *ledgerWalletFactory) Remove(name string, rawCfg map[string]interface{}) error {
+func (af *ledgerAccountFactory) Remove(name string, rawCfg map[string]interface{}) error {
 	return nil
 }
 
-func (wf *ledgerWalletFactory) Rename(old, new string, rawCfg map[string]interface{}) error {
+func (af *ledgerAccountFactory) Rename(old, new string, rawCfg map[string]interface{}) error {
 	return nil
 }
 
-func (wf *ledgerWalletFactory) Import(name string, passphrase string, rawCfg map[string]interface{}, src *wallet.ImportSource) (wallet.Wallet, error) {
+func (af *ledgerAccountFactory) Import(name string, passphrase string, rawCfg map[string]interface{}, src *wallet.ImportSource) (wallet.Account, error) {
 	return nil, fmt.Errorf("ledger: import not supported")
 }
 
-type ledgerWallet struct {
-	cfg        *walletConfig
+type ledgerAccount struct {
+	cfg        *accountConfig
 	signer     *ledgerSigner
 	coreSigner *ledgerCoreSigner
 }
 
-func newWallet(cfg *walletConfig) (wallet.Wallet, error) {
+func newAccount(cfg *accountConfig) (wallet.Account, error) {
 	// Connect to device.
 	dev, err := connectToDevice()
 	if err != nil {
@@ -180,30 +180,30 @@ func newWallet(cfg *walletConfig) (wallet.Wallet, error) {
 		return nil, fmt.Errorf("ledger: got malformed public key: %w", err)
 	}
 
-	return &ledgerWallet{
+	return &ledgerAccount{
 		cfg:        cfg,
 		signer:     signer,
 		coreSigner: coreSigner,
 	}, nil
 }
 
-func (w *ledgerWallet) ConsensusSigner() coreSignature.Signer {
-	return w.coreSigner
+func (a *ledgerAccount) ConsensusSigner() coreSignature.Signer {
+	return a.coreSigner
 }
 
-func (w *ledgerWallet) Signer() signature.Signer {
-	return w.signer
+func (a *ledgerAccount) Signer() signature.Signer {
+	return a.signer
 }
 
-func (w *ledgerWallet) Address() types.Address {
-	return types.NewAddress(w.SignatureAddressSpec())
+func (a *ledgerAccount) Address() types.Address {
+	return types.NewAddress(a.SignatureAddressSpec())
 }
 
-func (w *ledgerWallet) SignatureAddressSpec() types.SignatureAddressSpec {
-	return types.NewSignatureAddressSpecEd25519(w.signer.Public().(ed25519.PublicKey))
+func (a *ledgerAccount) SignatureAddressSpec() types.SignatureAddressSpec {
+	return types.NewSignatureAddressSpecEd25519(a.signer.Public().(ed25519.PublicKey))
 }
 
-func (w *ledgerWallet) UnsafeExport() string {
+func (a *ledgerAccount) UnsafeExport() string {
 	return ""
 }
 
@@ -212,7 +212,7 @@ func init() {
 	flags.String(cfgDerivation, derivationLegacy, "Derivation scheme to use [adr8, legacy]")
 	flags.Uint32(cfgNumber, 0, "Key number to use in the derivation scheme")
 
-	wallet.Register(&ledgerWalletFactory{
+	wallet.Register(&ledgerAccountFactory{
 		flags: flags,
 	})
 }

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -25,55 +25,55 @@ const (
 	AlgorithmSecp256k1Raw = "secp256k1-raw"
 )
 
-// Factory is a factory that supports wallets of a specific kind.
+// Factory is a factory that supports accounts of a specific kind.
 type Factory interface {
-	// Kind returns the kind of wallets this factory will produce.
+	// Kind returns the kind of accounts this factory will produce.
 	Kind() string
 
-	// PrettyKind returns human-friendly kind of wallets this factory will produce.
+	// PrettyKind returns human-friendly kind of accounts this factory will produce.
 	PrettyKind(cfg map[string]interface{}) string
 
-	// Flags returns the CLI flags that can be used for configuring this wallet factory.
+	// Flags returns the CLI flags that can be used for configuring this account factory.
 	Flags() *flag.FlagSet
 
-	// GetConfigFromFlags generates wallet configuration from flags.
+	// GetConfigFromFlags generates account configuration from flags.
 	GetConfigFromFlags() (map[string]interface{}, error)
 
-	// GetConfigFromSurvey generates wallet configuration from survey answers.
+	// GetConfigFromSurvey generates account configuration from survey answers.
 	GetConfigFromSurvey(kind *ImportKind) (map[string]interface{}, error)
 
-	// DataPrompt returns a survey prompt for entering data when importing the wallet.
+	// DataPrompt returns a survey prompt for entering data when importing the account.
 	DataPrompt(kind ImportKind, cfg map[string]interface{}) survey.Prompt
 
-	// DataValidator returns a survey data input validator used when importing the wallet.
+	// DataValidator returns a survey data input validator used when importing the account.
 	DataValidator(kind ImportKind, cfg map[string]interface{}) survey.Validator
 
-	// RequiresPassphrase returns true if the wallet requires a passphrase.
+	// RequiresPassphrase returns true if the account requires a passphrase.
 	RequiresPassphrase() bool
 
-	// SupportedImportKinds returns the import kinds supported by this wallet.
+	// SupportedImportKinds returns the import kinds supported by this account.
 	SupportedImportKinds() []ImportKind
 
-	// HasConsensusSigner returns true, iff there is a consensus layer signer associated with this wallet.
+	// HasConsensusSigner returns true, iff there is a consensus layer signer associated with this account.
 	HasConsensusSigner(cfg map[string]interface{}) bool
 
-	// Create creates a new wallet.
-	Create(name string, passphrase string, cfg map[string]interface{}) (Wallet, error)
+	// Create creates a new account.
+	Create(name string, passphrase string, cfg map[string]interface{}) (Account, error)
 
-	// Load loads an existing wallet.
-	Load(name string, passphrase string, cfg map[string]interface{}) (Wallet, error)
+	// Load loads an existing account.
+	Load(name string, passphrase string, cfg map[string]interface{}) (Account, error)
 
-	// Remove removes an existing wallet.
+	// Remove removes an existing account.
 	Remove(name string, cfg map[string]interface{}) error
 
-	// Rename renames an existing wallet.
+	// Rename renames an existing account.
 	Rename(old, new string, cfg map[string]interface{}) error
 
-	// Import creates a new wallet from imported key material.
-	Import(name string, passphrase string, cfg map[string]interface{}, src *ImportSource) (Wallet, error)
+	// Import creates a new account from imported key material.
+	Import(name string, passphrase string, cfg map[string]interface{}, src *ImportSource) (Account, error)
 }
 
-// ImportKind is a wallet import kind.
+// ImportKind is an account import kind.
 type ImportKind string
 
 // Supported import kinds.
@@ -95,49 +95,49 @@ func (k *ImportKind) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// ImportSource is a source of imported wallet key material.
+// ImportSource is a source of imported account key material.
 type ImportSource struct {
 	Kind ImportKind
 	Data string
 }
 
-// Wallet is the wallet interface.
-type Wallet interface {
-	// ConsensusSigner returns the consensus layer signer associated with the wallet.
+// Account is an interface of a single account in the wallet.
+type Account interface {
+	// ConsensusSigner returns the consensus layer signer associated with the account.
 	//
-	// It may return nil in case this wallet cannot be used with the consensus layer.
+	// It may return nil in case this account cannot be used with the consensus layer.
 	ConsensusSigner() coreSignature.Signer
 
-	// Signer returns the signer associated with the wallet.
+	// Signer returns the signer associated with the account.
 	Signer() signature.Signer
 
-	// Address returns the address associated with the wallet.
+	// Address returns the address associated with the account.
 	Address() types.Address
 
-	// SignatureAddressSpec returns the signature address specification associated with the wallet.
+	// SignatureAddressSpec returns the signature address specification associated with the account.
 	SignatureAddressSpec() types.SignatureAddressSpec
 
-	// UnsafeExport exports the wallet's secret state.
+	// UnsafeExport exports the account's secret state.
 	UnsafeExport() string
 }
 
-// Register registers a new wallet type.
-func Register(wf Factory) {
-	if _, loaded := registeredFactories.LoadOrStore(wf.Kind(), wf); loaded {
-		panic(fmt.Sprintf("wallet: kind '%s' is already registered", wf.Kind()))
+// Register registers a new account type.
+func Register(af Factory) {
+	if _, loaded := registeredFactories.LoadOrStore(af.Kind(), af); loaded {
+		panic(fmt.Sprintf("wallet: kind '%s' is already registered", af.Kind()))
 	}
 }
 
-// Load loads a previously registered wallet factory.
+// Load loads a previously registered account factory.
 func Load(kind string) (Factory, error) {
-	wf, loaded := registeredFactories.Load(kind)
+	af, loaded := registeredFactories.Load(kind)
 	if !loaded {
 		return nil, fmt.Errorf("wallet: kind '%s' not available", kind)
 	}
-	return wf.(Factory), nil
+	return af.(Factory), nil
 }
 
-// AvailableKinds returns all of the available wallet factories.
+// AvailableKinds returns all of the available account factories.
 func AvailableKinds() []Factory {
 	var kinds []Factory
 	registeredFactories.Range(func(key, value interface{}) bool {
@@ -147,7 +147,7 @@ func AvailableKinds() []Factory {
 	return kinds
 }
 
-// ImportKinds returns all of the available wallet import kinds.
+// ImportKinds returns all of the available account import kinds.
 func ImportKinds() []string {
 	return []string{
 		string(ImportKindMnemonic),


### PR DESCRIPTION
Porting "wallet"-"account" term fixes from [oasis-wallet-web#814 ](https://github.com/oasisprotocol/oasis-wallet-web/pull/814) for consistency:
- Replaces term "wallet" with "account" in command descriptions where applicable
- Renames internal `Wallet` structs with `Account` and `Wallets` with `Wallet`.
- Renamed `--wallet` to `--account`, `--wallet` remains there for backward compatibility
- Shows account name before signing transactions
- Shows `(*)` for default account in `wallet list` output

Some leftovers which this PR doesn't cover, because it affects end users flow too much:
- `wallets.<some_account_name>` field in the config file is intact (should be `accounts.<some_account_name>`, but would break loading the existing wallet)