### PR TITLE
ts-web: fix consensusGetSignerNonce return type (can be undefined)

### DIFF
--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -440,7 +440,9 @@ const methodDescriptorConsensusEstimateGas = createMethodDescriptorUnary<
 >('Consensus', 'EstimateGas');
 const methodDescriptorConsensusGetSignerNonce = createMethodDescriptorUnary<
     types.ConsensusGetSignerNonceRequest,
-    types.longnum
+    // TODO: remove `undefined` after https://github.com/grpc/grpc-web/pull/1230
+    //       and see TODO in callUnary.
+    types.longnum | undefined
 >('Consensus', 'GetSignerNonce');
 const methodDescriptorConsensusGetBlock = createMethodDescriptorUnary<
     types.longnum,
@@ -581,6 +583,8 @@ export class GRPCWrapper {
                 // This seems to be normal. Void methods don't send back anything, which makes
                 // grpc-web freak out. I don't know why we don't send a CBOR undefined or
                 // something.
+                // TODO: remove after https://github.com/grpc/grpc-web/pull/1230
+                //       and see TODO in methodDescriptorConsensusGetSignerNonce
                 return undefined;
             }
             if (e.metadata && 'grpc-status-details-bin' in e.metadata) {


### PR DESCRIPTION
Example that returns undefined
```ts
await oasisClient.consensusGetSignerNonce({
  account_address: oasis.staking.addressFromBech32('oasis1qqqnpm9l8khrj9zaqzmt537gvnx6y38ntsc8jdrh'),
  height: 0,
})
```

(And playground already handles undefined return: https://github.com/oasisprotocol/oasis-sdk/blob/037546906fa06cae3983fb6b9b6ebadeaf63ac4e/client-sdk/ts-web/core/playground/src/index.js#L53-L56
)