### PR TITLE
ts-web: reflect updates

### DIFF
--- a/client-sdk/ts-web/core/reflect-go/main.go
+++ b/client-sdk/ts-web/core/reflect-go/main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	_ "unsafe"
 
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
@@ -509,6 +510,7 @@ func write() {
 var registeredMethods sync.Map
 
 func main() {
+	visitClient(reflect.TypeOf((*beacon.Backend)(nil)).Elem())
 	visitClient(reflect.TypeOf((*scheduler.Backend)(nil)).Elem())
 	visitClient(reflect.TypeOf((*registry.Backend)(nil)).Elem())
 	visitClient(reflect.TypeOf((*staking.Backend)(nil)).Elem())

--- a/client-sdk/ts-web/core/reflect-go/main.go
+++ b/client-sdk/ts-web/core/reflect-go/main.go
@@ -226,11 +226,6 @@ func getStructName(t reflect.Type) string {
 	return prefix + t.Name()
 }
 
-var (
-	mapKeyNames          = map[reflect.Type]string{}
-	mapKeyNamesConsulted = map[reflect.Type]bool{}
-)
-
 func getMapKeyName(t reflect.Type) string {
 	switch t.Key() {
 	case reflect.TypeOf(transaction.Op("")):
@@ -545,11 +540,6 @@ func main() {
 	for prefix := range prefixByPackage {
 		if !prefixConsulted[prefix] {
 			panic(fmt.Sprintf("unused prefix %s", prefix))
-		}
-	}
-	for t := range mapKeyNames {
-		if !mapKeyNamesConsulted[t] {
-			panic(fmt.Sprintf("unused map key name %v", t))
 		}
 	}
 	if !encounteredVersionInfo {

--- a/client-sdk/ts-web/core/reflect-go/main.go
+++ b/client-sdk/ts-web/core/reflect-go/main.go
@@ -16,12 +16,12 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
+	_ "unsafe"
 
-	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-	"github.com/oasisprotocol/oasis-core/go/common/entity"
 	"github.com/oasisprotocol/oasis-core/go/common/node"
 	"github.com/oasisprotocol/oasis-core/go/common/pubsub"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
@@ -504,45 +504,30 @@ func write() {
 	}
 }
 
+// might be nicer to add a function to list these in oasis-core
+//go:linkname registeredMethods github.com/oasisprotocol/oasis-core/go/consensus/api/transaction.registeredMethods
+var registeredMethods sync.Map
+
 func main() {
-	visitType(reflect.TypeOf((*beacon.EpochTime)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*scheduler.Backend)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*registry.Backend)(nil)).Elem())
-	visitType(reflect.TypeOf((*entity.SignedEntity)(nil)).Elem())
-	visitType(reflect.TypeOf((*registry.DeregisterEntity)(nil)).Elem())
-	visitType(reflect.TypeOf((*node.MultiSignedNode)(nil)).Elem())
-	visitType(reflect.TypeOf((*registry.UnfreezeNode)(nil)).Elem())
-	visitType(reflect.TypeOf((*registry.Runtime)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*staking.Backend)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.Transfer)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.Burn)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.Escrow)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.ReclaimEscrow)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.AmendCommissionSchedule)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.Allow)(nil)).Elem())
-	visitType(reflect.TypeOf((*staking.Withdraw)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*keymanager.Backend)(nil)).Elem())
-	visitType(reflect.TypeOf((*keymanager.SignedPolicySGX)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*roothash.Backend)(nil)).Elem())
-	visitType(reflect.TypeOf((*roothash.ExecutorCommit)(nil)).Elem())
-	visitType(reflect.TypeOf((*roothash.ExecutorProposerTimeoutRequest)(nil)).Elem())
-	visitType(reflect.TypeOf((*roothash.Evidence)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*governance.Backend)(nil)).Elem())
-	visitType(reflect.TypeOf((*governance.ProposalContent)(nil)).Elem())
-	visitType(reflect.TypeOf((*governance.ProposalVote)(nil)).Elem())
-
 	visitClient(reflect.TypeOf((*runtimeClient.RuntimeClient)(nil)).Elem())
 	visitClient(reflect.TypeOf((*storage.Backend)(nil)).Elem())
 	visitClient(reflect.TypeOf((*workerStorage.StorageWorker)(nil)).Elem())
 	visitClient(reflect.TypeOf((*consensus.ClientBackend)(nil)).Elem())
 	visitClient(reflect.TypeOf((*control.NodeController)(nil)).Elem())
 	visitClient(reflect.TypeOf((*control.DebugController)(nil)).Elem())
+
+	_, _ = fmt.Fprintf(os.Stderr, "visiting transaction body types\n")
+	registeredMethods.Range(func(name, bodyType interface{}) bool {
+		_, _ = fmt.Fprintf(os.Stderr, "visiting method %v\n", name)
+		visitType(reflect.TypeOf(bodyType))
+		return true
+	})
 
 	write()
 	for p := range modulePaths {

--- a/client-sdk/ts-web/core/src/beacon.ts
+++ b/client-sdk/ts-web/core/src/beacon.ts
@@ -2,13 +2,9 @@ import * as consensus from './consensus';
 import * as types from './types';
 
 /**
- * MethodPVSSCommit is the method name for a PVSS commitment.
+ * MethodVRFProve is the method name for a VRF proof.
  */
-export const METHOD_PVSS_COMMIT = 'beacon.PVSSCommit';
-/**
- * MethodPVSSReveal is the method name for a PVSS reveal.
- */
-export const METHOD_PVSS_REVEAL = 'beacon.PVSSReveal';
+export const METHOD_VRF_PROVE = 'beacon.VRFProve';
 /**
  * MethodSetEpoch is the method name for setting epochs.
  */
@@ -19,9 +15,9 @@ export const METHOD_SET_EPOCH = '000_beacon.SetEpoch';
  */
 export const BACKEND_INSECURE = 'insecure';
 /**
- * BackendPVSS is the name of the PVSS backend.
+ * BackendVRF is the name of the VRF backend.
  */
-export const BACKEND_PVSS = 'pvss';
+export const BACKEND_VRF = 'vrf';
 
 /**
  * ModuleName is a unique module name for the beacon module.
@@ -34,12 +30,8 @@ export const MODULE_NAME = 'beacon';
  */
 export const ERR_BEACON_NOT_AVAILABLE_CODE = 1;
 
-export function pvssCommitWrapper() {
-    return new consensus.TransactionWrapper<types.BeaconPVSSCommit>(METHOD_PVSS_COMMIT);
-}
-
-export function pvssRevealWrapper() {
-    return new consensus.TransactionWrapper<types.BeaconPVSSReveal>(METHOD_PVSS_REVEAL);
+export function vrfProveWrapper() {
+    return new consensus.TransactionWrapper<types.BeaconVRFProve>(METHOD_VRF_PROVE);
 }
 
 export function setEpochWrapper() {

--- a/client-sdk/ts-web/core/src/common.ts
+++ b/client-sdk/ts-web/core/src/common.ts
@@ -7,10 +7,6 @@ import * as types from './types';
  */
 export const ROLE_COMPUTE_WORKER = 1 << 0;
 /**
- * RoleStorageWorker is the storage worker role.
- */
-export const ROLE_STORAGE_WORKER = 1 << 1;
-/**
  * RoleKeyManager is the the key manager role.
  */
 export const ROLE_KEY_MANAGER = 1 << 2;
@@ -22,6 +18,10 @@ export const ROLE_VALIDATOR = 1 << 3;
  * RoleConsensusRPC is the public consensus RPC services worker role.
  */
 export const ROLE_CONSENSUS_RPC = 1 << 4;
+/**
+ * RoleStorageRPC is the public storage RPC services worker role.
+ */
+export const ROLE_STORAGE_RPC = 1 << 5;
 
 /**
  * TEEHardwareInvalid is a non-TEE implementation.

--- a/client-sdk/ts-web/core/src/registry.ts
+++ b/client-sdk/ts-web/core/src/registry.ts
@@ -103,7 +103,7 @@ export const GOVERNANCE_MAX = GOVERNANCE_CONSENSUS;
  * LatestRuntimeDescriptorVersion is the latest entity descriptor version that should be used
  * for all new descriptors. Using earlier versions may be rejected.
  */
-export const LATEST_RUNTIME_DESCRIPTOR_VERSION = 2;
+export const LATEST_RUNTIME_DESCRIPTOR_VERSION = 3;
 
 /**
  * ModuleName is a unique module name for the registry module.

--- a/client-sdk/ts-web/core/src/roothash.ts
+++ b/client-sdk/ts-web/core/src/roothash.ts
@@ -15,10 +15,9 @@ export const EXECUTOR_SIGNATURE_CONTEXT = 'oasis-core/roothash: executor commitm
 export const COMPUTE_RESULTS_HEADER_SIGNATURE_CONTEXT =
     'oasis-core/roothash: compute results header';
 /**
- * ProposedBatchSignatureContext is the context used for signing propose batch
- * dispatch messages.
+ * ProposalSignatureContext is the context used for signing propose batch dispatch messages.
  */
-export const PROPOSED_BATCH_SIGNATURE_CONTEXT = 'oasis-core/roothash: proposed batch';
+export const PROPOSAL_SIGNATURE_CONTEXT = 'oasis-core/roothash: proposal';
 
 /**
  * MethodExecutorCommit is the method name for executor commit submission.
@@ -32,6 +31,10 @@ export const METHOD_EXECUTOR_PROPOSER_TIMEOUT = 'roothash.ExecutorProposerTimeou
  * MethodEvidence is the method name for submitting evidence of node misbehavior.
  */
 export const METHOD_EVIDENCE = 'roothash.Evidence';
+/**
+ * MethodSubmitMsg is the method name for queuing incoming runtime messages.
+ */
+export const METHOD_SUBMIT_MSG = 'roothash.SubmitMsg';
 
 /**
  * GasOpComputeCommit is the gas operation identifier for compute commits.
@@ -45,6 +48,10 @@ export const GAS_OP_PROPOSER_TIMEOUT = 'proposer_timeout';
  * GasOpEvidence is the gas operation identifier for evidence submission transaction cost.
  */
 export const GAS_OP_EVIDENCE = 'evidence';
+/**
+ * GasOpSubmitMsg is the gas operation identifier for message submission transaction cost.
+ */
+export const GAS_OP_SUBMIT_MSG = 'submit_msg';
 
 /**
  * Invalid is an invalid header type and should never be stored.
@@ -134,9 +141,23 @@ export const ERR_RUNTIME_DOES_NOT_SLASH_CODE = 8;
  */
 export const ERR_DUPLICATE_EVIDENCE_CODE = 9;
 /**
- * ErrInvalidEvidence is the error return when an invalid evidence is submitted.
+ * ErrInvalidEvidence is the error returned when an invalid evidence is submitted.
  */
 export const ERR_INVALID_EVIDENCE_CODE = 10;
+/**
+ * ErrIncomingMessageQueueFull is the error returned when the incoming message queue is full.
+ */
+export const ERR_INCOMING_MESSAGE_QUEUE_FULL_CODE = 11;
+/**
+ * ErrIncomingMessageInsufficientFee is the error returned when the provided fee is smaller than
+ * the configured minimum incoming message submission fee.
+ */
+export const ERR_INCOMING_MESSAGE_INSUFFICIENT_FEE_CODE = 12;
+/**
+ * ErrMaxInMessagesTooBig is the error returned when the MaxInMessages parameter is set to a
+ * value larger than the MaxInRuntimeMessages specified in consensus parameters.
+ */
+export const ERR_MAX_IN_MESSAGES_TOO_BIG_CODE = 13;
 
 /**
  * moduleName is the module name used for namespacing errors.
@@ -154,9 +175,7 @@ export const ERR_DISCREPANCY_DETECTED_CODE = 8;
 export const ERR_STILL_WAITING_CODE = 9;
 export const ERR_INSUFFICIENT_VOTES_CODE = 10;
 export const ERR_BAD_EXECUTOR_COMMITMENT_CODE = 11;
-export const ERR_TXN_SCHED_SIG_INVALID_CODE = 12;
 export const ERR_INVALID_MESSAGES_CODE = 13;
-export const ERR_BAD_STORAGE_RECEIPTS_CODE = 14;
 export const ERR_TIMEOUT_NOT_CORRECT_ROUND_CODE = 15;
 export const ERR_NODE_IS_SCHEDULER_CODE = 16;
 export const ERR_MAJORITY_FAILURE_CODE = 17;
@@ -248,4 +267,8 @@ export function executorProposerTimeoutWrapper() {
 
 export function evidenceWrapper() {
     return new consensus.TransactionWrapper<types.RootHashEvidence>(METHOD_EVIDENCE);
+}
+
+export function submitMsgWrapper() {
+    return new consensus.TransactionWrapper<types.RootHashSubmitMsg>(METHOD_SUBMIT_MSG);
 }

--- a/client-sdk/ts-web/core/src/roothash.ts
+++ b/client-sdk/ts-web/core/src/roothash.ts
@@ -183,29 +183,34 @@ export const ERR_INVALID_ROUND_CODE = 18;
 export const ERR_NO_PROPOSER_COMMITMENT_CODE = 19;
 export const ERR_BAD_PROPOSER_COMMITMENT_CODE = 20;
 
-export async function openExecutorCommitment(
+export async function verifyExecutorCommitment(
     chainContext: string,
     runtimeID: Uint8Array,
-    signed: types.SignatureSigned,
+    commitment: types.RootHashExecutorCommitment,
 ) {
     const context = `${signature.combineChainContext(
         EXECUTOR_SIGNATURE_CONTEXT,
         chainContext,
     )} for runtime ${misc.toHex(runtimeID)}`;
-    return misc.fromCBOR(await signature.openSigned(context, signed)) as types.RootHashComputeBody;
+    return await signature.verify(
+        commitment.node_id,
+        context,
+        misc.toCBOR(commitment.header),
+        commitment.sig,
+    );
 }
 
 export async function signExecutorCommitment(
     signer: signature.ContextSigner,
     chainContext: string,
     runtimeID: Uint8Array,
-    computeBody: types.RootHashComputeBody,
+    header: types.RootHashExecutorCommitmentHeader,
 ) {
     const context = `${signature.combineChainContext(
         EXECUTOR_SIGNATURE_CONTEXT,
         chainContext,
     )} for runtime ${misc.toHex(runtimeID)}`;
-    return await signature.signSigned(signer, context, misc.toCBOR(computeBody));
+    return await signer.sign(context, misc.toCBOR(header));
 }
 
 export async function verifyComputeResultsHeader(
@@ -228,31 +233,34 @@ export async function signComputeResultsHeader(
     return await rakSigner.sign(COMPUTE_RESULTS_HEADER_SIGNATURE_CONTEXT, misc.toCBOR(header));
 }
 
-export async function openProposedBatch(
+export async function verifyProposal(
     chainContext: string,
     runtimeID: Uint8Array,
-    signed: types.SignatureSigned,
+    proposal: types.RootHashProposal,
 ) {
     const context = `${signature.combineChainContext(
-        PROPOSED_BATCH_SIGNATURE_CONTEXT,
+        PROPOSAL_SIGNATURE_CONTEXT,
         chainContext,
     )} for runtime ${misc.toHex(runtimeID)}`;
-    return misc.fromCBOR(
-        await signature.openSigned(context, signed),
-    ) as types.RootHashProposedBatch;
+    return await signature.verify(
+        proposal.node_id,
+        context,
+        misc.toCBOR(proposal.header),
+        proposal.sig,
+    );
 }
 
-export async function signProposedBatch(
+export async function signProposal(
     signer: signature.ContextSigner,
     chainContext: string,
     runtimeID: Uint8Array,
-    proposedBatch: types.RootHashProposedBatch,
+    header: types.RootHashProposalHeader,
 ) {
     const context = `${signature.combineChainContext(
-        PROPOSED_BATCH_SIGNATURE_CONTEXT,
+        PROPOSAL_SIGNATURE_CONTEXT,
         chainContext,
     )} for runtime ${misc.toHex(runtimeID)}`;
-    return await signature.signSigned(signer, context, misc.toCBOR(proposedBatch));
+    return await signer.sign(context, misc.toCBOR(header));
 }
 
 export function executorCommitWrapper() {

--- a/client-sdk/ts-web/core/src/scheduler.ts
+++ b/client-sdk/ts-web/core/src/scheduler.ts
@@ -20,15 +20,6 @@ export const KIND_INVALID = 0;
  */
 export const KIND_COMPUTE_EXECUTOR = 1;
 /**
- * KindStorage is a storage committee.
- */
-export const KIND_STORAGE = 2;
-/**
  * MaxCommitteeKind is a dummy value used for iterating all committee kinds.
  */
-export const MAX_COMMITTEE_KIND = 3;
-
-/**
- * TxnSchedulerSimple is the name of the simple batching algorithm.
- */
-export const TXN_SCHEDULER_SIMPLE = 'simple';
+export const MAX_COMMITTEE_KIND = 2;

--- a/client-sdk/ts-web/core/src/staking.ts
+++ b/client-sdk/ts-web/core/src/staking.ts
@@ -94,6 +94,10 @@ export const SLASH_RUNTIME_INCORRECT_RESULTS = 0x80;
  * executor commits or proposed batches for the same round.
  */
 export const SLASH_RUNTIME_EQUIVOCATION = 0x81;
+/**
+ * SlashRuntimeLiveness is slashing due to not doing the required work.
+ */
+export const SLASH_RUNTIME_LIVENESS = 0x82;
 
 /**
  * GasOpTransfer is the gas operation identifier for transfer.
@@ -168,6 +172,17 @@ export const ERR_TOO_MANY_ALLOWANCES_CODE = 7;
  * consensus parameters.
  */
 export const ERR_UNDER_MIN_DELEGATION_AMOUNT_CODE = 8;
+/**
+ * ErrUnderMinTransferAmount is the error returned when the given transfer
+ * or burn or withdrawal amount is lower than the minimum transfer amount
+ * specified in the consensus parameters.
+ */
+export const ERR_UNDER_MIN_TRANSFER_AMOUNT_CODE = 9;
+/**
+ * ErrBalanceTooLow is the error returned when an account's balance is
+ * below the minimum allowed amount.
+ */
+export const ERR_BALANCE_TOO_LOW_CODE = 10;
 
 /**
  * ModuleName is a unique module name for the staking/token module.

--- a/client-sdk/ts-web/core/src/storage.ts
+++ b/client-sdk/ts-web/core/src/storage.ts
@@ -1,12 +1,3 @@
-import * as misc from './misc';
-import * as signature from './signature';
-import * as types from './types';
-
-/**
- * ReceiptSignatureContext is the signature context used for verifying MKVS receipts.
- */
-export const RECEIPT_SIGNATURE_CONTEXT = 'oasis-core/storage: receipt';
-
 export const CHECKPOINT_VERSION = 1;
 
 /**
@@ -161,17 +152,3 @@ export const MKVS_DB_ERR_INVALID_MULTIPART_VERSION_CODE = 14;
  * database is therefore unusable. Run the upgrade tool to finish upgrading.
  */
 export const MKVS_DB_ERR_UPGRADE_IN_PROGRESS_CODE = 15;
-
-export async function openReceipt(chainContext: string, receipt: types.SignatureSigned) {
-    const context = signature.combineChainContext(RECEIPT_SIGNATURE_CONTEXT, chainContext);
-    return misc.fromCBOR(await signature.openSigned(context, receipt)) as types.StorageReceiptBody;
-}
-
-export async function signReceipt(
-    signer: signature.ContextSigner,
-    chainContext: string,
-    receiptBody: types.StorageReceiptBody,
-) {
-    const context = signature.combineChainContext(RECEIPT_SIGNATURE_CONTEXT, chainContext);
-    return await signature.signSigned(signer, context, misc.toCBOR(receiptBody));
-}


### PR DESCRIPTION
fixes #822 #922 

- maintaining the list of types from transaction method bodies is too much work, so let's read from the registered methods list. but unfortunately it's unexported, so it's some kind of ugly `go:linkname` thing that I found out the idea of online

up to 22.1.5