### PR TITLE
ts-web/core: version 0.1.0-alpha9

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.1.0-alpha8:
+## v0.1.0-alpha8
 
 Spotlight change:
 
@@ -14,14 +14,14 @@ New features:
 - Errors from `client` are now wrapped to show what method you were calling.
   Use the `.cause` property in newer browsers to get the original error.
 
-## v0.1.0-alpha7:
+## v0.1.0-alpha7
 
 Spotlight change:
 
 - We changed the protobuf scripts to be commonjs for better compatibility with
   various tools.
 
-## v0.1.0-alpha6:
+## v0.1.0-alpha6
 
 Spotlight change:
 

--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.1.0-alpha9
+
+Spotlight change:
+
+- Compatibility with oasis-core is updated to 22.1.5.
+
+New features:
+
+- The typing for `consensusGetSignerNonce` is corrected to indicate that it
+  return `undefined` instead of `0`.
+
 ## v0.1.0-alpha8
 
 Spotlight change:

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client",
-    "version": "0.1.0-alpha8",
+    "version": "0.1.0-alpha9",
     "license": "Apache-2.0",
     "files": [
         "dist",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -13,7 +13,7 @@
         },
         "core": {
             "name": "@oasisprotocol/client",
-            "version": "0.1.0-alpha8",
+            "version": "0.1.0-alpha9",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^2.0.0",


### PR DESCRIPTION
for compatibility with oasis-core 22.1.x

the API changes are to parts not known to be in widespread use.

there's also a nice typing change for the typescript users