### PR TITLE
ts-web: update core dependency

### DIFF
--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -17,7 +17,7 @@
         "prepare": "tsc"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.0-alpha8"
+        "@oasisprotocol/client": "^0.1.0-alpha9"
     },
     "devDependencies": {
         "@oasisprotocol/client-rt": "^0.2.0-alpha10",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -1107,7 +1107,7 @@
             "version": "0.1.0-alpha3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.0-alpha8"
+                "@oasisprotocol/client": "^0.1.0-alpha9"
             },
             "devDependencies": {
                 "@oasisprotocol/client-rt": "^0.2.0-alpha10",
@@ -8824,7 +8824,7 @@
             "name": "@oasisprotocol/client-rt",
             "version": "0.2.0-alpha10",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.0-alpha8",
+                "@oasisprotocol/client": "^0.1.0-alpha9",
                 "elliptic": "^6.5.3",
                 "sha3": "^2.1.4"
             },
@@ -9913,7 +9913,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^6.27.1",
-                "@oasisprotocol/client": "^0.1.0-alpha8",
+                "@oasisprotocol/client": "^0.1.0-alpha9",
                 "@oasisprotocol/ledger": "^0.2.3"
             },
             "devDependencies": {
@@ -11706,7 +11706,7 @@
         "@oasisprotocol/client-ext-utils": {
             "version": "file:ext-utils",
             "requires": {
-                "@oasisprotocol/client": "^0.1.0-alpha8",
+                "@oasisprotocol/client": "^0.1.0-alpha9",
                 "@oasisprotocol/client-rt": "^0.2.0-alpha10",
                 "buffer": "^6.0.3",
                 "cypress": "^9.6.1",
@@ -11722,7 +11722,7 @@
         "@oasisprotocol/client-rt": {
             "version": "file:rt",
             "requires": {
-                "@oasisprotocol/client": "^0.1.0-alpha8",
+                "@oasisprotocol/client": "^0.1.0-alpha9",
                 "@types/elliptic": "^6.4.14",
                 "@types/jest": "^27.5.1",
                 "buffer": "^6.0.3",
@@ -12552,7 +12552,7 @@
             "version": "file:signer-ledger",
             "requires": {
                 "@ledgerhq/hw-transport-webusb": "^6.27.1",
-                "@oasisprotocol/client": "^0.1.0-alpha8",
+                "@oasisprotocol/client": "^0.1.0-alpha9",
                 "@oasisprotocol/ledger": "^0.2.3",
                 "@types/w3c-web-usb": "^1.0.6",
                 "buffer": "^6.0.3",

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -14,7 +14,7 @@
         "test": "jest"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.0-alpha8",
+        "@oasisprotocol/client": "^0.1.0-alpha9",
         "elliptic": "^6.5.3",
         "sha3": "^2.1.4"
     },

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.1",
-        "@oasisprotocol/client": "^0.1.0-alpha8",
+        "@oasisprotocol/client": "^0.1.0-alpha9",
         "@oasisprotocol/ledger": "^0.2.3"
     },
     "devDependencies": {


### PR DESCRIPTION
0.1.0-alpha9 is out

during development, these are linked in a workspace, so they always use the version in the repo. bumping the version in the released one ensures that external projects using these libraries have consistent versions