### PR TITLE
contract-sdk: Add marker traits for confidential/public stores

### DIFF
--- a/contract-sdk/specs/oas20/src/helpers.rs
+++ b/contract-sdk/specs/oas20/src/helpers.rs
@@ -6,7 +6,7 @@ use oasis_contract_sdk::{
         InstanceId,
     },
 };
-use oasis_contract_sdk_storage::{cell::Cell, map::Map};
+use oasis_contract_sdk_storage::{cell::PublicCell, map::PublicMap};
 use oasis_contract_sdk_types::address::Address;
 
 use crate::types::{
@@ -17,9 +17,9 @@ use crate::types::{
 /// Handles an OAS20 request call.
 pub fn handle_call<C: sdk::Context>(
     ctx: &mut C,
-    token_info: Cell<TokenInformation>,
-    balances: Map<Address, u128>,
-    allowances: Map<(Address, Address), u128>,
+    token_info: PublicCell<TokenInformation>,
+    balances: PublicMap<Address, u128>,
+    allowances: PublicMap<(Address, Address), u128>,
     request: Request,
 ) -> Result<Response, Error> {
     match request {
@@ -89,9 +89,9 @@ pub fn handle_call<C: sdk::Context>(
 /// Handles an OAS20 request query.
 pub fn handle_query<C: sdk::Context>(
     ctx: &mut C,
-    token_info: Cell<TokenInformation>,
-    balances: Map<Address, u128>,
-    allowances: Map<(Address, Address), u128>,
+    token_info: PublicCell<TokenInformation>,
+    balances: PublicMap<Address, u128>,
+    allowances: PublicMap<(Address, Address), u128>,
     request: Request,
 ) -> Result<Response, Error> {
     match request {
@@ -123,8 +123,8 @@ pub fn handle_query<C: sdk::Context>(
 /// Instantiates the contract state.
 pub fn instantiate<C: sdk::Context>(
     ctx: &mut C,
-    balances: Map<Address, u128>,
-    token_info: Cell<TokenInformation>,
+    balances: PublicMap<Address, u128>,
+    token_info: PublicCell<TokenInformation>,
     instantiation: TokenInstantiation,
 ) -> Result<TokenInformation, Error> {
     // Setup initial balances and compute the total supply.
@@ -151,7 +151,7 @@ pub fn instantiate<C: sdk::Context>(
 /// Transfer the `amount` of funds from `from` to `to` address.
 pub fn transfer<C: sdk::Context>(
     ctx: &mut C,
-    balances: Map<Address, u128>,
+    balances: PublicMap<Address, u128>,
     from: Address,
     to: Address,
     amount: u128,
@@ -177,8 +177,8 @@ pub fn transfer<C: sdk::Context>(
 /// Burns the `amount` of funds from `from`.
 pub fn burn<C: sdk::Context>(
     ctx: &mut C,
-    balances: Map<Address, u128>,
-    token_info: Cell<TokenInformation>,
+    balances: PublicMap<Address, u128>,
+    token_info: PublicCell<TokenInformation>,
     from: Address,
     amount: u128,
 ) -> Result<(), Error> {
@@ -207,8 +207,8 @@ pub fn burn<C: sdk::Context>(
 /// Mints the `amount` of tokens to `to`.
 pub fn mint<C: sdk::Context>(
     ctx: &mut C,
-    balances: Map<Address, u128>,
-    token_info_cell: Cell<TokenInformation>,
+    balances: PublicMap<Address, u128>,
+    token_info_cell: PublicCell<TokenInformation>,
     to: Address,
     amount: u128,
 ) -> Result<(), Error> {
@@ -256,7 +256,7 @@ pub fn mint<C: sdk::Context>(
 #[allow(clippy::too_many_arguments)]
 pub fn send<C: sdk::Context>(
     ctx: &mut C,
-    balances: Map<Address, u128>,
+    balances: PublicMap<Address, u128>,
     from: Address,
     to: InstanceId,
     amount: u128,
@@ -294,7 +294,7 @@ pub fn send<C: sdk::Context>(
 /// Update the `beneficiary` allowance by the `amount`.
 pub fn allow<C: sdk::Context>(
     ctx: &mut C,
-    allowances: Map<(Address, Address), u128>,
+    allowances: PublicMap<(Address, Address), u128>,
     allower: Address,
     beneficiary: Address,
     negative: bool,
@@ -331,8 +331,8 @@ pub fn allow<C: sdk::Context>(
 /// Withdraw the `amount` of funds from `from` to `to`.
 pub fn withdraw<C: sdk::Context>(
     ctx: &mut C,
-    balances: Map<Address, u128>,
-    allowances: Map<(Address, Address), u128>,
+    balances: PublicMap<Address, u128>,
+    allowances: PublicMap<(Address, Address), u128>,
     from: Address,
     to: Address,
     amount: u128,

--- a/contract-sdk/specs/oas20/src/lib.rs
+++ b/contract-sdk/specs/oas20/src/lib.rs
@@ -5,7 +5,7 @@ pub mod helpers;
 pub mod types;
 
 use oasis_contract_sdk::{self as sdk};
-use oasis_contract_sdk_storage::{cell::Cell, map::Map};
+use oasis_contract_sdk_storage::{cell::PublicCell, map::PublicMap};
 use oasis_contract_sdk_types::address::Address;
 
 use types::{Error, Event, Request, Response};
@@ -14,11 +14,11 @@ use types::{Error, Event, Request, Response};
 pub struct Oas20Token;
 
 /// Storage cell for the token information.
-const TOKEN_INFO: Cell<types::TokenInformation> = Cell::new(b"token_info");
+const TOKEN_INFO: PublicCell<types::TokenInformation> = PublicCell::new(b"token_info");
 /// Storage map for account balances.
-const BALANCES: Map<Address, u128> = Map::new(b"balances");
+const BALANCES: PublicMap<Address, u128> = PublicMap::new(b"balances");
 /// Storage map for allowances.
-const ALLOWANCES: Map<(Address, Address), u128> = Map::new(b"allowances");
+const ALLOWANCES: PublicMap<(Address, Address), u128> = PublicMap::new(b"allowances");
 
 // Implementation of the sdk::Contract trait is required in order for the type to be a contract.
 impl sdk::Contract for Oas20Token {

--- a/contract-sdk/src/abi/dispatch.rs
+++ b/contract-sdk/src/abi/dispatch.rs
@@ -6,8 +6,8 @@ use crate::{
     event::Event,
     memory::HostRegion,
     types::{
-        address::Address, event::Event as RawEvent, message::Message, storage::StoreKind, token,
-        ExecutionContext, ExecutionOk, ExecutionResult, InstanceId,
+        address::Address, event::Event as RawEvent, message::Message, token, ExecutionContext,
+        ExecutionOk, ExecutionResult, InstanceId,
     },
 };
 
@@ -16,8 +16,8 @@ use super::{env, storage};
 struct Context {
     ec: ExecutionContext,
 
-    public_store: storage::HostStore,
-    confidential_store: storage::HostStore,
+    public_store: storage::PublicHostStore,
+    confidential_store: storage::ConfidentialHostStore,
     env: env::HostEnv,
 
     messages: Vec<Message>,
@@ -29,8 +29,8 @@ impl From<ExecutionContext> for Context {
         Self {
             ec,
 
-            public_store: storage::HostStore::new(StoreKind::Public),
-            confidential_store: storage::HostStore::new(StoreKind::Confidential),
+            public_store: storage::PublicHostStore,
+            confidential_store: storage::ConfidentialHostStore,
             env: env::HostEnv,
 
             messages: vec![],
@@ -40,8 +40,8 @@ impl From<ExecutionContext> for Context {
 }
 
 impl context::Context for Context {
-    type PublicStore = storage::HostStore;
-    type ConfidentialStore = storage::HostStore;
+    type PublicStore = storage::PublicHostStore;
+    type ConfidentialStore = storage::ConfidentialHostStore;
     type Env = env::HostEnv;
 
     fn instance_id(&self) -> InstanceId {

--- a/contract-sdk/src/abi/storage.rs
+++ b/contract-sdk/src/abi/storage.rs
@@ -1,7 +1,7 @@
 //! Storage ABI.
 use crate::{
     memory::{HostRegion, HostRegionRef},
-    storage::Store,
+    storage::{ConfidentialStore, PublicStore, Store},
     types::storage::StoreKind,
 };
 
@@ -55,28 +55,40 @@ pub fn remove(store: StoreKind, key: &[u8]) {
     }
 }
 
-/// Store backed by the host through the Oasis WASM ABI.
-pub struct HostStore {
-    kind: StoreKind,
-}
+/// Public store backed by the host through the Oasis WASM ABI.
+pub struct PublicHostStore;
 
-impl HostStore {
-    /// Create a new host-backed storage.
-    pub fn new(kind: StoreKind) -> Self {
-        Self { kind }
-    }
-}
-
-impl Store for HostStore {
+impl Store for PublicHostStore {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        get(self.kind, key)
+        get(StoreKind::Public, key)
     }
 
     fn insert(&mut self, key: &[u8], value: &[u8]) {
-        insert(self.kind, key, value)
+        insert(StoreKind::Public, key, value)
     }
 
     fn remove(&mut self, key: &[u8]) {
-        remove(self.kind, key)
+        remove(StoreKind::Public, key)
     }
 }
+
+impl PublicStore for PublicHostStore {}
+
+/// Confidential store backed by the host through the Oasis WASM ABI.
+pub struct ConfidentialHostStore;
+
+impl Store for ConfidentialHostStore {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        get(StoreKind::Confidential, key)
+    }
+
+    fn insert(&mut self, key: &[u8], value: &[u8]) {
+        insert(StoreKind::Confidential, key, value)
+    }
+
+    fn remove(&mut self, key: &[u8]) {
+        remove(StoreKind::Confidential, key)
+    }
+}
+
+impl ConfidentialStore for ConfidentialHostStore {}

--- a/contract-sdk/src/context.rs
+++ b/contract-sdk/src/context.rs
@@ -2,16 +2,16 @@
 use crate::{
     env::{Crypto, Env},
     event::Event,
-    storage::Store,
+    storage::{ConfidentialStore, PublicStore},
     types::{address::Address, message::Message, token, InstanceId},
 };
 
 /// Execution context.
 pub trait Context {
     /// The public store.
-    type PublicStore: Store;
+    type PublicStore: PublicStore;
     /// The confidential store.
-    type ConfidentialStore: Store;
+    type ConfidentialStore: ConfidentialStore;
     /// The environment.
     type Env: Env + Crypto;
 

--- a/contract-sdk/src/storage.rs
+++ b/contract-sdk/src/storage.rs
@@ -11,3 +11,9 @@ pub trait Store {
     /// Remove a given key from contract storage.
     fn remove(&mut self, key: &[u8]);
 }
+
+/// Marker trait for stores backed by public storage.
+pub trait PublicStore: Store {}
+
+/// Marker trait for stores backed by confidential storage.
+pub trait ConfidentialStore: Store {}

--- a/contract-sdk/src/testing.rs
+++ b/contract-sdk/src/testing.rs
@@ -8,7 +8,7 @@ use crate::{
     context::Context,
     env::{Crypto, Env},
     event::Event,
-    storage::Store,
+    storage::{ConfidentialStore, PublicStore, Store},
     types::{
         address::Address,
         env::{QueryRequest, QueryResponse},
@@ -46,6 +46,9 @@ impl Store for MockStore {
         self.inner.remove(key);
     }
 }
+
+impl PublicStore for MockStore {}
+impl ConfidentialStore for MockStore {}
 
 /// Mock environment.
 #[derive(Clone, Default)]

--- a/contract-sdk/storage/src/cell.rs
+++ b/contract-sdk/storage/src/cell.rs
@@ -1,52 +1,59 @@
 //! Low-level storage primitive that holds one value.
 use std::marker::PhantomData;
 
-use oasis_contract_sdk::storage::Store;
+use oasis_contract_sdk::storage::{ConfidentialStore, PublicStore};
 
-/// A storage cell identifies a storage key of a specific type.
-pub struct Cell<'key, T> {
-    key: &'key [u8],
-    _type: PhantomData<T>,
-}
-
-impl<'key, T> Cell<'key, T> {
-    /// Create a new storage cell with the specified key and type.
-    pub const fn new(key: &'key [u8]) -> Self {
-        Self {
-            key,
-            _type: PhantomData,
+macro_rules! declare_cell {
+    ($name:ident, $store:ident) => {
+        /// A storage cell identifies a storage key of a specific type.
+        pub struct $name<'key, T> {
+            key: &'key [u8],
+            _type: PhantomData<T>,
         }
-    }
 
-    /// Clear the value in the storage cell.
-    pub fn clear(&self, store: &mut dyn Store) {
-        store.remove(self.key);
-    }
+        impl<'key, T> $name<'key, T> {
+            /// Create a new storage cell with the specified key and type.
+            pub const fn new(key: &'key [u8]) -> Self {
+                Self {
+                    key,
+                    _type: PhantomData,
+                }
+            }
+
+            /// Clear the value in the storage cell.
+            pub fn clear(&self, store: &mut dyn $store) {
+                store.remove(self.key);
+            }
+        }
+
+        impl<'key, T> $name<'key, T>
+        where
+            T: cbor::Decode,
+        {
+            /// Return the current value of the storage cell.
+            ///
+            /// # Panics
+            ///
+            /// The method will panic in case the raw cell value cannot be deserialized.
+            ///
+            pub fn get(&self, store: &dyn $store) -> Option<T> {
+                store
+                    .get(self.key)
+                    .map(|raw| cbor::from_slice(&raw).unwrap())
+            }
+        }
+
+        impl<'key, T> $name<'key, T>
+        where
+            T: cbor::Encode,
+        {
+            /// Set the value of the storage cell.
+            pub fn set(&self, store: &mut dyn $store, value: T) {
+                store.insert(self.key, &cbor::to_vec(value));
+            }
+        }
+    };
 }
 
-impl<'key, T> Cell<'key, T>
-where
-    T: cbor::Decode,
-{
-    /// Return the current value of the storage cell.
-    ///
-    /// # Panics
-    ///
-    /// The method will panic in case the raw cell value cannot be deserialized.
-    ///
-    pub fn get(&self, store: &dyn Store) -> Option<T> {
-        store
-            .get(self.key)
-            .map(|raw| cbor::from_slice(&raw).unwrap())
-    }
-}
-
-impl<'key, T> Cell<'key, T>
-where
-    T: cbor::Encode,
-{
-    /// Set the value of the storage cell.
-    pub fn set(&self, store: &mut dyn Store, value: T) {
-        store.insert(self.key, &cbor::to_vec(value));
-    }
-}
+declare_cell!(PublicCell, PublicStore);
+declare_cell!(ConfidentialCell, ConfidentialStore);

--- a/docs/contract/hello-world.md
+++ b/docs/contract/hello-world.md
@@ -95,7 +95,7 @@ content:
 extern crate alloc;
 
 use oasis_contract_sdk as sdk;
-use oasis_contract_sdk_storage::cell::Cell;
+use oasis_contract_sdk_storage::cell::PublicCell;
 
 /// All possible errors that can be returned by the contract.
 ///
@@ -136,7 +136,7 @@ pub enum Response {
 pub struct HelloWorld;
 
 /// Storage cell for the counter.
-const COUNTER: Cell<u64> = Cell::new(b"counter");
+const COUNTER: PublicCell<u64> = PublicCell::new(b"counter");
 
 impl HelloWorld {
     /// Increment the counter and return the previous value.
@@ -160,7 +160,7 @@ impl sdk::Contract for HelloWorld {
         match request {
             // We require the caller to always pass the Instantiate request.
             Request::Instantiate { initial_counter } => {
-                // Initialize counter to 1.
+                // Initialize counter to specified value.
                 COUNTER.set(ctx.public_store(), initial_counter);
 
                 Ok(())

--- a/tests/contracts/hello/src/lib.rs
+++ b/tests/contracts/hello/src/lib.rs
@@ -17,7 +17,7 @@ use oasis_contract_sdk::{
         token, CodeId, InstanceId,
     },
 };
-use oasis_contract_sdk_storage::cell::Cell;
+use oasis_contract_sdk_storage::cell::{ConfidentialCell, PublicCell};
 
 /// All possible errors that can be returned by the contract.
 ///
@@ -141,11 +141,11 @@ pub enum Response {
 /// The contract type.
 pub struct HelloWorld;
 
-/// Storage cell for the counter.
-const COUNTER: Cell<u64> = Cell::new(b"counter");
+/// Storage cell for the public counter.
+const COUNTER: PublicCell<u64> = PublicCell::new(b"counter");
 
 /// Storage cell for the confidential counter.
-const CONFIDENTIAL_COUNTER: Cell<u64> = Cell::new(b"confidential_counter");
+const CONFIDENTIAL_COUNTER: ConfidentialCell<u64> = ConfidentialCell::new(b"confidential_counter");
 
 impl HelloWorld {
     /// Increment the counter and return the previous value.
@@ -177,7 +177,7 @@ impl sdk::Contract for HelloWorld {
         match request {
             // We require the caller to always pass the Instantiate request.
             Request::Instantiate { initial_counter } => {
-                // Initialize counter to 1.
+                // Initialize counter to specified value.
                 COUNTER.set(ctx.public_store(), initial_counter);
                 CONFIDENTIAL_COUNTER.set(ctx.confidential_store(), initial_counter);
 


### PR DESCRIPTION
This makes it possible to ensure the correct kind of store is used in various places.