### PR TITLE
ts-web: docs updates

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -4,7 +4,8 @@
 
 New features:
 
-- We've tighted up some TypeScript declarations to work better in strict mode.
+- We've tightened up some TypeScript declarations to work better in strict
+  mode.
 
 ## v0.1.0-alpha9
 

--- a/client-sdk/ts-web/ext-utils/docs/changelog.md
+++ b/client-sdk/ts-web/ext-utils/docs/changelog.md
@@ -4,7 +4,8 @@
 
 New features:
 
-- We've tighted up some TypeScript declarations to work better in strict mode.
+- We've tightened up some TypeScript declarations to work better in strict
+  mode.
 
 ## v0.1.0-alpha3
 

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -6,7 +6,8 @@ New features:
 
 - We added bindings for several new SDK features, notably including the
   contracts module, the gas used event, and runtime introspection.
-- We've tighted up some TypeScript declarations to work better in strict mode.
+- We've tightened up some TypeScript declarations to work better in strict
+  mode.
 
 ## v0.2.0-alpha10
 


### PR DESCRIPTION
that getting-started doc was way out of date

- client class has moved
- public node urls changed
- our sample now uses the cors way
