### PR TITLE
ts-web/core: v0.1.1-alpha.1

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased changes
+## v0.1.1-alpha.1
 
-New features:
+Spotlight change:
 
 - We've tightened up some TypeScript declarations to work better in strict
   mode.

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client",
-    "version": "0.1.0-alpha9",
+    "version": "0.1.1-alpha.1",
     "license": "Apache-2.0",
     "files": [
         "dist",

--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -17,7 +17,7 @@
         "prepare": "tsc"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.0-alpha9"
+        "@oasisprotocol/client": "^0.1.1-alpha.1"
     },
     "devDependencies": {
         "@oasisprotocol/client-rt": "^0.2.0-alpha10",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -13,7 +13,7 @@
         },
         "core": {
             "name": "@oasisprotocol/client",
-            "version": "0.1.0-alpha9",
+            "version": "0.1.1-alpha.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^2.0.0",
@@ -1107,7 +1107,7 @@
             "version": "0.1.0-alpha3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.0-alpha9"
+                "@oasisprotocol/client": "^0.1.1-alpha.1"
             },
             "devDependencies": {
                 "@oasisprotocol/client-rt": "^0.2.0-alpha10",
@@ -8824,7 +8824,7 @@
             "name": "@oasisprotocol/client-rt",
             "version": "0.2.0-alpha10",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.0-alpha9",
+                "@oasisprotocol/client": "^0.1.1-alpha.1",
                 "elliptic": "^6.5.3",
                 "sha3": "^2.1.4"
             },
@@ -9913,7 +9913,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^6.27.1",
-                "@oasisprotocol/client": "^0.1.0-alpha9",
+                "@oasisprotocol/client": "^0.1.1-alpha.1",
                 "@oasisprotocol/ledger": "^0.2.3"
             },
             "devDependencies": {
@@ -11706,7 +11706,7 @@
         "@oasisprotocol/client-ext-utils": {
             "version": "file:ext-utils",
             "requires": {
-                "@oasisprotocol/client": "^0.1.0-alpha9",
+                "@oasisprotocol/client": "^0.1.1-alpha.1",
                 "@oasisprotocol/client-rt": "^0.2.0-alpha10",
                 "buffer": "^6.0.3",
                 "cypress": "^9.6.1",
@@ -11722,7 +11722,7 @@
         "@oasisprotocol/client-rt": {
             "version": "file:rt",
             "requires": {
-                "@oasisprotocol/client": "^0.1.0-alpha9",
+                "@oasisprotocol/client": "^0.1.1-alpha.1",
                 "@types/elliptic": "^6.4.14",
                 "@types/jest": "^27.5.1",
                 "buffer": "^6.0.3",
@@ -12552,7 +12552,7 @@
             "version": "file:signer-ledger",
             "requires": {
                 "@ledgerhq/hw-transport-webusb": "^6.27.1",
-                "@oasisprotocol/client": "^0.1.0-alpha9",
+                "@oasisprotocol/client": "^0.1.1-alpha.1",
                 "@oasisprotocol/ledger": "^0.2.3",
                 "@types/w3c-web-usb": "^1.0.6",
                 "buffer": "^6.0.3",

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -14,7 +14,7 @@
         "test": "jest"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.0-alpha9",
+        "@oasisprotocol/client": "^0.1.1-alpha.1",
         "elliptic": "^6.5.3",
         "sha3": "^2.1.4"
     },

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.1",
-        "@oasisprotocol/client": "^0.1.0-alpha9",
+        "@oasisprotocol/client": "^0.1.1-alpha.1",
         "@oasisprotocol/ledger": "^0.2.3"
     },
     "devDependencies": {


### PR DESCRIPTION
typescript changes from #790 

turns out the `-alpha9` thing was not the prerelease format that npm's semver supports. moving on to 0.1.0-alpha10 would be treated as a lower version. we're correcting this to the supported `-alpha.10` style and bumping the patch version