### PR TITLE
ts-web/rt: v0.2.1-alpha.1

### DIFF
--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -20,7 +20,7 @@
         "@oasisprotocol/client": "^0.1.1-alpha.1"
     },
     "devDependencies": {
-        "@oasisprotocol/client-rt": "^0.2.0-alpha10",
+        "@oasisprotocol/client-rt": "^0.2.1-alpha.1",
         "buffer": "^6.0.3",
         "cypress": "^9.6.1",
         "prettier": "^2.6.2",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -1110,7 +1110,7 @@
                 "@oasisprotocol/client": "^0.1.1-alpha.1"
             },
             "devDependencies": {
-                "@oasisprotocol/client-rt": "^0.2.0-alpha10",
+                "@oasisprotocol/client-rt": "^0.2.1-alpha.1",
                 "buffer": "^6.0.3",
                 "cypress": "^9.6.1",
                 "prettier": "^2.6.2",
@@ -8822,7 +8822,7 @@
         },
         "rt": {
             "name": "@oasisprotocol/client-rt",
-            "version": "0.2.0-alpha10",
+            "version": "0.2.1-alpha.1",
             "dependencies": {
                 "@oasisprotocol/client": "^0.1.1-alpha.1",
                 "elliptic": "^6.5.3",
@@ -11707,7 +11707,7 @@
             "version": "file:ext-utils",
             "requires": {
                 "@oasisprotocol/client": "^0.1.1-alpha.1",
-                "@oasisprotocol/client-rt": "^0.2.0-alpha10",
+                "@oasisprotocol/client-rt": "^0.2.1-alpha.1",
                 "buffer": "^6.0.3",
                 "cypress": "^9.6.1",
                 "prettier": "^2.6.2",

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## Unreleased changes
+## v0.2.1-alpha.1
 
-New features:
+Spotlight change:
 
 - We added bindings for several new SDK features, notably including the
   contracts module, the gas used event, and runtime introspection.
+
+New features:
+
 - We've tightened up some TypeScript declarations to work better in strict
   mode.
 

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-rt",
-    "version": "0.2.0-alpha10",
+    "version": "0.2.1-alpha.1",
     "files": [
         "dist"
     ],


### PR DESCRIPTION
typescript changes from #790

turns out we had additions from before, which we never made a release since. using those as the spotlight change

the version numbering is updated, see #948 