### PR TITLE
runtime-sdk: gas estimate binary search

### DIFF
--- a/.github/actions/test-rust/action.yml
+++ b/.github/actions/test-rust/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Unit tests with coverage
       uses: actions-rs/tarpaulin@v0.1
       with:
-        version: '0.18.0'
+        version: '0.20.1'
         args: '--avoid-cfg-tarpaulin --manifest-path ${{ inputs.manfiest_path }} -- --test-threads 1'
       env:
         # Required as tarpaulin doesn't honor .cargo/config.

--- a/runtime-sdk/src/types/transaction.rs
+++ b/runtime-sdk/src/types/transaction.rs
@@ -186,7 +186,7 @@ pub struct Fee {
 }
 
 impl Fee {
-    /// Caculates gas price from fee amount and gas.
+    /// Calculates gas price from fee amount and gas.
     pub fn gas_price(&self) -> u128 {
         self.amount
             .amount()


### PR DESCRIPTION
Adds configurable gas estimation via binary search support. 

Enables fixing some EVM edge cases (https://github.com/oasisprotocol/oasis-sdk/issues/631) where gas estimation depends on actual gas limit used during estimation.


There are some EVM "gotcha's", hopefully the comments explain it well enough.