### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/contract/getting-started.md
+++ b/docs/contract/getting-started.md
@@ -91,7 +91,7 @@ rustup target add wasm32-unknown-unknown
 [rust-upstream-rustup]: https://www.rust-lang.org/tools/install
 [download `rustup-init` executable for your platform]: https://rust-lang.github.io/rustup/installation/other.html
 [Rust]: https://www.rust-lang.org/
-[rust-toolchain]: https://github.com/oasisprotocol/oasis-core/tree/master/rust-toolchain
+[rust-toolchain]: https://github.com/oasisprotocol/oasis-sdk/tree/master/rust-toolchain
 [rust-toolchain-precedence]: https://github.com/rust-lang/rustup/blob/master/README.md#override-precedence
 <!-- markdownlint-enable line-length -->
 

--- a/docs/runtime/getting-started.md
+++ b/docs/runtime/getting-started.md
@@ -93,7 +93,7 @@ rustup target add x86_64-fortanix-unknown-sgx
 [rust-upstream-rustup]: https://www.rust-lang.org/tools/install
 [download `rustup-init` executable for your platform]: https://rust-lang.github.io/rustup/installation/other.html
 [Rust]: https://www.rust-lang.org/
-[rust-toolchain]: https://github.com/oasisprotocol/oasis-core/tree/master/rust-toolchain
+[rust-toolchain]: https://github.com/oasisprotocol/oasis-sdk/tree/master/rust-toolchain
 [rust-toolchain-precedence]: https://github.com/rust-lang/rustup/blob/master/README.md#override-precedence
 <!-- markdownlint-enable line-length -->
 


### PR DESCRIPTION
Fixes regression introduced in f41342b1d68da4cffbb1fac3b97be6dd8022d318. Also needs backport to 0.2.x.