### PR TITLE
ci: allow passing setup code to hash-rust

### DIFF
--- a/.github/actions/hash-rust/action.yml
+++ b/.github/actions/hash-rust/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: Control whether to produce sgxs binaries
     default: no
     required: false
+  setup:
+    description: Code to run before building
+    default: ""
+    required: false
 outputs:
   hashes:
     description: Comma-separated list of binary hashes
@@ -39,6 +43,7 @@ runs:
       run: |
         docker run --rm -i -v ${{ inputs.dir }}:/src ${{ inputs.image }} /bin/bash <<-'EOF'
           set -e
+          ${{ inputs.setup }}
           cd /src
           CARGO_TARGET_ROOT="/src/target"
           TARGET=""
@@ -51,7 +56,7 @@ runs:
 
             for pkg in $PKG_DIRS; do
               pushd ${pkg}
-              cargo build --release --target $TARGET
+              cargo build --release --locked --target $TARGET
               cargo elf2sgxs --release
               popd
             done
@@ -60,7 +65,7 @@ runs:
 
             for pkg in $PKG_DIRS; do
               pushd ${pkg}
-              cargo build --release
+              cargo build --release --locked
               popd
             done
           fi


### PR DESCRIPTION
For me, this is to allow `rustup target add x86_64-fortanix-unknown-sgx` before building, as I cannot have a `rust-toolchain.toml` auto-install it because [actions-rs does not support it](https://github.com/actions-rs/toolchain/pull/209). 