### PR TITLE
cli: Add support for dumping deployed WASM of contracts

### DIFF
--- a/client-sdk/go/modules/contracts/contracts.go
+++ b/client-sdk/go/modules/contracts/contracts.go
@@ -23,6 +23,7 @@ const (
 
 	// Queries.
 	methodCode            = "contracts.Code"
+	methodCodeStorage     = "contracts.CodeStorage"
 	methodInstance        = "contracts.Instance"
 	methodInstanceStorage = "contracts.InstanceStorage"
 	methodPublicKey       = "contracts.PublicKey"
@@ -75,6 +76,9 @@ type V1 interface {
 
 	// Code queries the given code information.
 	Code(ctx context.Context, round uint64, id CodeID) (*Code, error)
+
+	// CodeStorage queries the given code's storage.
+	CodeStorage(ctx context.Context, round uint64, id CodeID) (*CodeStorageQueryResult, error)
 
 	// Instance queries the given instance information.
 	Instance(ctx context.Context, round uint64, id InstanceID) (*Instance, error)
@@ -169,6 +173,16 @@ func (a *v1) Code(ctx context.Context, round uint64, id CodeID) (*Code, error) {
 		return nil, err
 	}
 	return &code, nil
+}
+
+// Implements V1.
+func (a *v1) CodeStorage(ctx context.Context, round uint64, id CodeID) (*CodeStorageQueryResult, error) {
+	var rsp CodeStorageQueryResult
+	err := a.rc.Query(ctx, round, methodCodeStorage, &CodeStorageQuery{ID: id}, &rsp)
+	if err != nil {
+		return nil, err
+	}
+	return &rsp, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/contracts/types.go
+++ b/client-sdk/go/modules/contracts/types.go
@@ -139,6 +139,18 @@ type CodeQuery struct {
 	ID CodeID `json:"id"`
 }
 
+// CodeStorageQuery is the body of the contracts.CodeStorage query.
+type CodeStorageQuery struct {
+	// ID is the code identifier.
+	ID CodeID `json:"id"`
+}
+
+// CodeStorageQueryResult is the result of the contracts.CodeStorage query.
+type CodeStorageQueryResult struct {
+	// Code is the stored contract code.
+	Code []byte `json:"code"`
+}
+
 // InstanceQuery is the body of the contracts.Instance query.
 type InstanceQuery struct {
 	// ID is the instance identifier.

--- a/client-sdk/ts-web/rt/src/contracts.ts
+++ b/client-sdk/ts-web/rt/src/contracts.ts
@@ -34,6 +34,7 @@ export const METHOD_CALL = 'contracts.Call';
 export const METHOD_UPGRADE = 'contracts.Upgrade';
 // Queries.
 export const METHOD_CODE = 'contracts.Code';
+export const METHOD_CODE_STORAGE = 'contracts.CodeStorage';
 export const METHOD_INSTANCE = 'contracts.Instance';
 export const METHOD_INSTANCE_STORAGE = 'contracts.InstanceStorage';
 export const METHOD_PUBLIC_KEY = 'contracts.PublicKey';
@@ -63,6 +64,11 @@ export class Wrapper extends wrapper.Base {
     }
     queryCode() {
         return this.query<types.ContractsCodeQuery, types.ContractsCode>(METHOD_CODE);
+    }
+    queryCodeStorage() {
+        return this.query<types.ContractsCodeStorageQuery, types.ContractsCodeStorageQueryResult>(
+            METHOD_CODE_STORAGE,
+        );
     }
     queryInstance() {
         return this.query<types.ContractsInstanceQuery, types.ContractsInstance>(METHOD_INSTANCE);

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -620,6 +620,23 @@ export interface ContractsCode {
 }
 
 /**
+ * Code storage information query.
+ */
+export interface ContractsCodeStorageQuery {
+    /**
+     * Code identifier.
+     */
+    id: oasis.types.longnum;
+}
+
+export interface ContractsCodeStorageQueryResult {
+    /**
+     * Stored contract code.
+     */
+    code: Uint8Array;
+}
+
+/**
  * Instance information query.
  */
 export interface ContractsInstanceQuery {

--- a/runtime-sdk/modules/contracts/src/code.rs
+++ b/runtime-sdk/modules/contracts/src/code.rs
@@ -19,14 +19,14 @@ static CODE_CACHE: Lazy<Mutex<lru::LruCache<Hash, Vec<u8>>>> =
     Lazy::new(|| Mutex::new(lru::LruCache::new(128)));
 
 impl<Cfg: Config> Module<Cfg> {
-    /// Stores specified code information.
+    /// Loads code with the specified code identifier.
     pub fn load_code<C: Context>(ctx: &mut C, code_info: &types::Code) -> Result<Vec<u8>, Error> {
         let mut cache = CODE_CACHE.lock().unwrap();
         if let Some(code) = cache.get(&code_info.hash) {
             return Ok(code.clone());
         }
 
-        // TODO: Spport local untrusted cache to avoid storage queries.
+        // TODO: Support local untrusted cache to avoid storage queries.
         let mut store = storage::PrefixStore::new(ctx.runtime_state(), &MODULE_NAME);
         let code_store = storage::PrefixStore::new(&mut store, &state::CODE);
         let code = code_store

--- a/runtime-sdk/modules/contracts/src/lib.rs
+++ b/runtime-sdk/modules/contracts/src/lib.rs
@@ -309,7 +309,7 @@ impl<Cfg: Config> Module<Cfg> {
         let mut store = storage::PrefixStore::new(ctx.runtime_state(), &MODULE_NAME);
         let code_info_store =
             storage::TypedStore::new(storage::PrefixStore::new(&mut store, &state::CODE_INFO));
-        let code_info: types::Code = code_info_store
+        let code_info = code_info_store
             .get(code_id.to_storage_key())
             .ok_or_else(|| Error::CodeNotFound(code_id.as_u64()))?;
 
@@ -644,6 +644,17 @@ impl<Cfg: Config> Module<Cfg> {
         args: types::CodeQuery,
     ) -> Result<types::Code, Error> {
         Self::load_code_info(ctx, args.id)
+    }
+
+    #[handler(query = "contracts.CodeStorage")]
+    pub fn query_code_storage<C: Context>(
+        ctx: &mut C,
+        args: types::CodeStorageQuery,
+    ) -> Result<types::CodeStorageQueryResult, Error> {
+        let code_info = Self::load_code_info(ctx, args.id)?;
+        let code = Self::load_code(ctx, &code_info)?;
+
+        Ok(types::CodeStorageQueryResult { code })
     }
 
     #[handler(query = "contracts.Instance")]

--- a/runtime-sdk/modules/contracts/src/test.rs
+++ b/runtime-sdk/modules/contracts/src/test.rs
@@ -395,6 +395,18 @@ fn test_hello_contract_call() {
     assert_eq!(result.id, 0.into());
     assert_eq!(result.abi, types::ABI::OasisV1);
 
+    // Test code storage query.
+    let result = Contracts::query_code_storage(&mut ctx, types::CodeStorageQuery { id: 0.into() })
+        .expect("code storage query should succeed");
+    // Stored code is the original code plus some injected gas billing calls.
+    assert_eq!(result.code.len() >= HELLO_CONTRACT_CODE.len(), true);
+
+    // Invalid code queries should fail.
+    Contracts::query_code(&mut ctx, types::CodeQuery { id: 9999.into() })
+        .expect_err("invalid code query should fail");
+    Contracts::query_code_storage(&mut ctx, types::CodeStorageQuery { id: 9999.into() })
+        .expect_err("invalid code storage query should fail");
+
     // Test storage query for the counter key.
     let result = Contracts::query_instance_storage(
         &mut ctx,

--- a/runtime-sdk/modules/contracts/src/types.rs
+++ b/runtime-sdk/modules/contracts/src/types.rs
@@ -180,6 +180,20 @@ pub struct CodeQuery {
     pub id: CodeId,
 }
 
+/// Code storage information query.
+#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct CodeStorageQuery {
+    /// Code identifier.
+    pub id: CodeId,
+}
+
+/// Code storage query result.
+#[derive(Clone, Debug, Default, cbor::Encode, cbor::Decode)]
+pub struct CodeStorageQueryResult {
+    /// Stored contract code.
+    pub code: Vec<u8>,
+}
+
 /// Instance information query.
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 pub struct InstanceQuery {


### PR DESCRIPTION
- Adds `contracts.CodeStorage` to runtime API which returns the stored Wasm code.
- Updates client-sdk/go bindings.
- Updates client-sdk/ts-web bindings
- Implements it in oasis CLI (`oasis contracts dump-code`).