### PR TITLE
docs: Refresh minimal-runtime.md

### DIFF
--- a/docs/contract/confidential-smart-contract.md
+++ b/docs/contract/confidential-smart-contract.md
@@ -148,7 +148,7 @@ impl sdk::Contract for HelloWorld {
     }
 }
 
-// Create the required WASM exports required for the contract to be runnable.
+// Create the required Wasm exports required for the contract to be runnable.
 sdk::create_contract!(HelloWorld);
 
 // We define some simple contract tests below.
@@ -223,7 +223,7 @@ works. **Do not put any sensitive data inside the smart contract code!**
 
 :::
 
-Since the smart contracts store is public, uploading the WASM code is
+Since the smart contracts store is public, uploading the Wasm code is
 the same as for the non-confidential ones:
 
 ```shell

--- a/docs/contract/hello-world.md
+++ b/docs/contract/hello-world.md
@@ -193,7 +193,7 @@ impl sdk::Contract for HelloWorld {
     }
 }
 
-// Create the required WASM exports required for the contract to be runnable.
+// Create the required Wasm exports required for the contract to be runnable.
 sdk::create_contract!(HelloWorld);
 
 // We define some simple contract tests below.
@@ -301,7 +301,7 @@ oasis paratime set-default testnet cipher
 ```
 
 The first deployment step that needs to be performed only once for the given
-binary is uploading the WASM binary.
+binary is uploading the Wasm binary.
 
 ```
 oasis contracts upload hello_world.wasm

--- a/docs/runtime/getting-started.md
+++ b/docs/runtime/getting-started.md
@@ -127,18 +127,16 @@ The SDK requires utilities provided by [Oasis Core] in order to be able to run
 a local test network for development purposes.
 
 The recommended way is to download a pre-built release (at least version
-21.3.10) from the [Oasis Core releases page]. After downloading the binary
-release (e.g. into `~/Downloads/oasis_core_21.3.10_linux_amd64.tar.gz`), unpack
-it into a local directory (this guide will use `~/.oasis/core/v21.3.10/bin`) as
-follows:
+22.1.8) from the [Oasis Core releases] page. After downloading the binary
+release (e.g. into `~/Downloads/oasis_core_22.1.8_linux_amd64.tar.gz`), unpack
+it as follows:
 
 ```bash
-# This environment variable is used throughout this guide.
-export OASIS_CORE_PATH=~/.oasis/core/v21.3.10
+cd ~/Downloads
+tar xf ~/Downloads/oasis_core_22.1.8_linux_amd64.tar.gz --strip-components=1
 
-mkdir -p ${OASIS_CORE_PATH}/bin
-cd ${OASIS_CORE_PATH}/bin
-tar xf ~/Downloads/oasis_core_21.3.10_linux_amd64.tar.gz --strip-components=1
+# This environment variable will be used throughout this guide.
+export OASIS_CORE_PATH=~/Downloads/oasis_core_22.1.8_linux_amd64
 ```
 
 [Oasis Core]: /oasis-core


### PR DESCRIPTION
Current minimal-runtime tutorial is broken. It works with oasis-core 21.2.x only (and not 21.3.x, because of the missing `span_context` fields!). This PR bumps the dependencies and the example code in rust to match oasis-core 22.1.8 and oasis-sdk post-0.2.0 which is not released yet (currently it will use the `main` branch of oasis-sdk repo).

PR also adds a new subsection on how to connect and send tokens from/to minimal runtime with Oasis CLI.

Preview:
https://github.com/oasisprotocol/oasis-sdk/blob/matevz/docs/bump-runtime-tutorial/docs/runtime/minimal-runtime.md

To be merged **after oasis-core 22.1.8 is released** which contains https://github.com/oasisprotocol/oasis-core/pull/4808 and https://github.com/oasisprotocol/oasis-core/pull/4813.