### PR TITLE
cli: Add contracts state dump support

### DIFF
--- a/cli/cmd/common/json.go
+++ b/cli/cmd/common/json.go
@@ -3,6 +3,13 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/contracts"
 )
 
 // PrettyJSONMarshal returns pretty-printed JSON encoding of v.
@@ -12,4 +19,82 @@ func PrettyJSONMarshal(v interface{}) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal to pretty JSON: %w", err)
 	}
 	return formatted, nil
+}
+
+// JSONMarshalKey encodes k as UTF-8 string if valid, or Base64 otherwise.
+func JSONMarshalKey(k interface{}) (keyJSON []byte, err error) {
+	keyBytes, ok := k.([]byte)
+	if ok && utf8.Valid(keyBytes) {
+		// Marshal valid UTF-8 string.
+		keyJSON, err = json.Marshal(string(keyBytes))
+	} else {
+		// Marshal string or Base64 otherwise.
+		keyJSON, err = json.Marshal(k)
+	}
+	return
+}
+
+// JSONPrintKeyValueTuple traverses potentially large number of items and prints JSON representation
+// of them.
+//
+// Marshalling is done externally without holding resulting JSON string in-memory.
+// Cbor decoding of each value is tried first. If it fails, the binary content is preserved.
+// Universal marshalling of map[interface{}]interface{} types is also supported.
+// Each key is encoded as string if it contains valid UTF-8 value. Otherwise, Base64 is used.
+func JSONPrintKeyValueTuple(items []contracts.InstanceStorageKeyValue) {
+	first := true
+	fmt.Printf("{")
+	for _, kv := range items {
+		if !first {
+			fmt.Printf(",")
+		}
+		first = false
+		var val interface{}
+		err := cbor.Unmarshal(kv.Value, &val)
+		if err != nil {
+			// Value is not CBOR, use raw value instead.
+			val = kv.Value
+		}
+		keyJSON, err := JSONMarshalKey(kv.Key)
+		cobra.CheckErr(err)
+
+		valJSON := JSONMarshalUniversalValue(val)
+		fmt.Printf("%s:%s", keyJSON, valJSON)
+	}
+	fmt.Printf("}\n")
+}
+
+// JSONMarshalUniversalValue is a wrapper for the built-in JSON encoder which adds support for
+// marshalling map[interface{}]interface{}.
+//
+// Each key is encoded as string if it contains valid UTF-8 value. Otherwise, Base64 is used.
+func JSONMarshalUniversalValue(v interface{}) []byte {
+	// Try array.
+	if valTest, ok := v.([]interface{}); ok {
+		e := make([]string, 0, len(valTest))
+		for _, v := range valTest {
+			valJSON := JSONMarshalUniversalValue(v)
+			e = append(e, string(valJSON))
+		}
+		return []byte(fmt.Sprintf("[%s]", strings.Join(e, ",")))
+	}
+
+	// Try universal map.
+	if valTest, ok := v.(map[interface{}]interface{}); ok {
+		e := make([]string, 0, len(valTest))
+		for k, v := range valTest {
+			keyJSON, err := JSONMarshalKey(k)
+			cobra.CheckErr(err)
+
+			valJSON := JSONMarshalUniversalValue(v)
+
+			e = append(e, fmt.Sprintf("%s:%s", keyJSON, valJSON))
+		}
+		return []byte(fmt.Sprintf("{%s}", strings.Join(e, ",")))
+	}
+
+	// Primitive type - use built-in JSON encoder.
+	vJSON, err := json.Marshal(v)
+	cobra.CheckErr(err)
+	return vJSON
 }

--- a/client-sdk/go/modules/contracts/contracts.go
+++ b/client-sdk/go/modules/contracts/contracts.go
@@ -23,13 +23,14 @@ const (
 	methodChangeUpgradePolicy = "contracts.ChangeUpgradePolicy"
 
 	// Queries.
-	methodCode            = "contracts.Code"
-	methodCodeStorage     = "contracts.CodeStorage"
-	methodInstance        = "contracts.Instance"
-	methodInstanceStorage = "contracts.InstanceStorage"
-	methodPublicKey       = "contracts.PublicKey"
-	methodCustom          = "contracts.Custom"
-	methodParameters      = "contracts.Parameters"
+	methodCode               = "contracts.Code"
+	methodCodeStorage        = "contracts.CodeStorage"
+	methodInstance           = "contracts.Instance"
+	methodInstanceStorage    = "contracts.InstanceStorage"
+	methodInstanceRawStorage = "contracts.InstanceRawStorage"
+	methodPublicKey          = "contracts.PublicKey"
+	methodCustom             = "contracts.Custom"
+	methodParameters         = "contracts.Parameters"
 )
 
 // V1 is the v1 contracts module interface.
@@ -87,8 +88,11 @@ type V1 interface {
 	// Instance queries the given instance information.
 	Instance(ctx context.Context, round uint64, id InstanceID) (*Instance, error)
 
-	// InstanceStorage queries the given instance's storage.
+	// InstanceStorage queries the given instance's public storage.
 	InstanceStorage(ctx context.Context, round uint64, id InstanceID, key []byte) (*InstanceStorageQueryResult, error)
+
+	// InstanceRawStorage returns the key-value pairs of contract instance storage.
+	InstanceRawStorage(ctx context.Context, round uint64, id InstanceID, kind StoreKind, limit, offset uint64) (*InstanceRawStorageQueryResult, error)
 
 	// PublicKey queries the given instance's public key.
 	PublicKey(ctx context.Context, round uint64, id InstanceID, kind PublicKeyKind) (*PublicKeyQueryResult, error)
@@ -211,6 +215,16 @@ func (a *v1) Instance(ctx context.Context, round uint64, id InstanceID) (*Instan
 func (a *v1) InstanceStorage(ctx context.Context, round uint64, id InstanceID, key []byte) (*InstanceStorageQueryResult, error) {
 	var rsp InstanceStorageQueryResult
 	err := a.rc.Query(ctx, round, methodInstanceStorage, &InstanceStorageQuery{ID: id, Key: key}, &rsp)
+	if err != nil {
+		return nil, err
+	}
+	return &rsp, nil
+}
+
+// Implements V1.
+func (a *v1) InstanceRawStorage(ctx context.Context, round uint64, id InstanceID, storeKind StoreKind, limit uint64, offset uint64) (*InstanceRawStorageQueryResult, error) {
+	var rsp InstanceRawStorageQueryResult
+	err := a.rc.Query(ctx, round, methodInstanceRawStorage, &InstanceRawStorageQuery{ID: id, StoreKind: storeKind, Limit: limit, Offset: offset}, &rsp)
 	if err != nil {
 		return nil, err
 	}

--- a/client-sdk/go/modules/contracts/types.go
+++ b/client-sdk/go/modules/contracts/types.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 
@@ -177,6 +178,78 @@ type InstanceStorageQuery struct {
 type InstanceStorageQueryResult struct {
 	// Value is the storage value or nil if key doesn't exist.
 	Value []byte `json:"value"`
+}
+
+// StoreKind defines the public or confidential store type for performing queries.
+type StoreKind uint32
+
+const (
+	// StoreKindPublicName is a human-readable name for public store kind.
+	StoreKindPublicName = "public"
+
+	// StoreKindConfidentialName is a human-readable name for confidential store kind.
+	StoreKindConfidentialName = "confidential"
+)
+
+// MarshalText returns human-readable name of StoreKind.
+func (sk StoreKind) MarshalText() (data []byte, err error) {
+	switch sk {
+	case StoreKindPublic:
+		return []byte(StoreKindPublicName), nil
+	case StoreKindConfidential:
+		return []byte(StoreKindConfidentialName), nil
+	}
+
+	return nil, fmt.Errorf("unsupported store kind '%d'", sk)
+}
+
+// UnmarshalText converts human-readable name of store kind to StoreKind.
+func (sk *StoreKind) UnmarshalText(s []byte) error {
+	switch string(s) {
+	case StoreKindPublicName:
+		*sk = StoreKindPublic
+	case StoreKindConfidentialName:
+		*sk = StoreKindConfidential
+	default:
+		return fmt.Errorf("unsupported store kind name '%v'", sk)
+	}
+
+	return nil
+}
+
+// These constants represent the kinds of store that the queries support.
+const (
+	StoreKindPublic       StoreKind = 0
+	StoreKindConfidential StoreKind = 1
+)
+
+// InstanceRawStorageQuery is the body of the contracts.InstanceRawStorage query.
+type InstanceRawStorageQuery struct {
+	// ID is the instance identifier.
+	ID InstanceID `json:"id"`
+
+	// StoreKind is type of store to query.
+	StoreKind StoreKind `json:"store_kind"`
+
+	// Limit is the maximum number of items per page.
+	Limit uint64 `json:"limit,omitempty"`
+
+	// Offset is the number of skipped items.
+	Offset uint64 `json:"offset,omitempty"`
+}
+
+// InstanceRawStorageQueryResult is the result of the contracts.InstanceRawStorage query.
+type InstanceRawStorageQueryResult struct {
+	// Items is a list of key-value pairs in contract's public store.
+	Items []InstanceStorageKeyValue `json:"items"`
+}
+
+// InstanceStorageKeyValue is used as a tuple type for the contract storage.
+type InstanceStorageKeyValue struct {
+	_ struct{} `cbor:",toarray"`
+
+	Key   []byte
+	Value []byte
 }
 
 // PublicKeyKind is the public key kind.

--- a/client-sdk/ts-web/rt/src/contracts.ts
+++ b/client-sdk/ts-web/rt/src/contracts.ts
@@ -39,8 +39,13 @@ export const METHOD_CODE = 'contracts.Code';
 export const METHOD_CODE_STORAGE = 'contracts.CodeStorage';
 export const METHOD_INSTANCE = 'contracts.Instance';
 export const METHOD_INSTANCE_STORAGE = 'contracts.InstanceStorage';
+export const METHOD_INSTANCE_RAW_STORAGE = 'contracts.InstanceRawStorage';
 export const METHOD_PUBLIC_KEY = 'contracts.PublicKey';
 export const METHOD_CUSTOM = 'contracts.Custom';
+
+// Store kind.
+export const STORE_KIND_PUBLIC = 0;
+export const STORE_KIND_CONFIDENTIAL = 1;
 
 // Public key kind.
 export const PUBLIC_KEY_KIND_TRANSACTION = 1;
@@ -83,6 +88,12 @@ export class Wrapper extends wrapper.Base {
             types.ContractsInstanceStorageQuery,
             types.ContractsInstanceStorageQueryResult
         >(METHOD_INSTANCE_STORAGE);
+    }
+    queryInstanceRawStorage() {
+        return this.query<
+            types.ContractsInstanceRawStorageQuery,
+            types.ContractsInstanceRawStorageQueryResult
+        >(METHOD_INSTANCE_RAW_STORAGE);
     }
     queryPublicKey() {
         return this.query<types.ContractsPublicKeyQuery, types.ContractsPublicKeyQueryResult>(

--- a/client-sdk/ts-web/rt/src/types.ts
+++ b/client-sdk/ts-web/rt/src/types.ts
@@ -704,6 +704,43 @@ export interface ContractsInstanceStorageQueryResult {
 }
 
 /**
+ * Kind of store to query.
+ */
+export type StoreKind = number;
+
+/**
+ * Instance raw storage query.
+ */
+export interface ContractsInstanceRawStorageQuery {
+    /**
+     * Instance identifier.
+     */
+    id: oasis.types.longnum;
+
+    /**
+     * Kind of store to query.
+     */
+    store_kind: StoreKind;
+
+    /**
+     * Maximum number of items per page.
+     */
+    limit?: oasis.types.longnum;
+
+    /**
+     * Number of skipped items.
+     */
+    offset?: oasis.types.longnum;
+}
+
+export interface ContractsInstanceRawStorageQueryResult {
+    /**
+     * List of key-value pairs in contract's public store.
+     */
+    items: [Uint8Array, Uint8Array][];
+}
+
+/**
  * Public key query.
  */
 export interface ContractsPublicKeyQuery {

--- a/runtime-sdk/modules/contracts/src/store.rs
+++ b/runtime-sdk/modules/contracts/src/store.rs
@@ -59,13 +59,7 @@ pub fn for_instance<'a, C: Context>(
         None
     };
 
-    let store = storage::PrefixStore::new(ctx.runtime_state(), &MODULE_NAME);
-    let instance_prefix = instance_info.id.to_storage_key();
-    let contract_state = storage::PrefixStore::new(
-        storage::PrefixStore::new(store, &state::INSTANCE_STATE),
-        instance_prefix,
-    );
-    let contract_state = storage::PrefixStore::new(contract_state, store_kind.prefix());
+    let contract_state = get_instance_raw_store(ctx, instance_info, store_kind);
 
     match store_kind {
         // For public storage we use a hashed store using the Blake3 hash function.
@@ -86,4 +80,20 @@ pub fn for_instance<'a, C: Context>(
             Ok(Box::new(confidential_store))
         }
     }
+}
+
+/// Return the public of confidential raw store of the provided contract instance.
+pub fn get_instance_raw_store<'a, C: Context>(
+    ctx: &'a mut C,
+    instance_info: &types::Instance,
+    store_kind: StoreKind,
+) -> impl Store + 'a {
+    let store = storage::PrefixStore::new(ctx.runtime_state(), &MODULE_NAME);
+    let instance_prefix = instance_info.id.to_storage_key();
+    let contract_state = storage::PrefixStore::new(
+        storage::PrefixStore::new(store, &state::INSTANCE_STATE),
+        instance_prefix,
+    );
+
+    storage::PrefixStore::new(contract_state, store_kind.prefix())
 }

--- a/runtime-sdk/modules/contracts/src/types.rs
+++ b/runtime-sdk/modules/contracts/src/types.rs
@@ -227,6 +227,39 @@ pub struct InstanceStorageQueryResult {
     pub value: Option<Vec<u8>>,
 }
 
+/// Exposed wrapper for oasis-contract-sdk-types::StoreKind.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+#[repr(u32)]
+pub enum StoreKind {
+    Public = 0,
+    Confidential = 1,
+}
+
+/// Instance raw storage query.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct InstanceRawStorageQuery {
+    /// Instance identifier.
+    pub id: InstanceId,
+
+    /// Kind of the store to query.
+    pub store_kind: StoreKind,
+
+    /// Maximum number of items per page.
+    #[cbor(optional, default)]
+    pub limit: Option<u64>,
+
+    /// Number of skipped items.
+    #[cbor(optional, default)]
+    pub offset: Option<u64>,
+}
+
+/// Instance raw storage query result.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+pub struct InstanceRawStorageQueryResult {
+    /// List of key-value pairs in contract's public store.
+    pub items: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
 /// Public key kind.
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
 #[repr(u8)]


### PR DESCRIPTION
- Adds `contracts.InstanceRawStorage` to runtime API which returns a complete contract store for provided instance.
- Updates client-sdk/go bindings.
- Updates client-sdk/ts-web bindings
- Adds `oasis contracts storage get <instance-id> <key>` to Oasis CLI which calls `contracts.InstanceStorageQuery` and prints the value of given key in JSON stored in public contract store
- Adds `oasis contracts storage dump <instance-id> [--kind {public|confidential}] [--limit LIMIT] [--offset OFFSET]` to Oasis CLI which calls `contracts.InstanceRawStorageQuery` and prints the complete contract state in JSON

Example:
```
$ oasis contracts storage dump 0 --network localhost 
Showing 2 public record(s) of contract 0:
{"c2Vuc29yc1zFnd5u3TSZ":{"storage_granularity":600,"name":"esp2866_bedroom","measurement_types":[1,3],"query_granularity":14400},"owner":"APOPeewebP6XtP4Gx4mLUqj620eD"}
$ oasis contracts storage dump 0 --network localhost  --kind confidential
Showing 2 confidential record(s) of contract 0:
{"jYxrNIpsHghPWmvTwyERY2hOJOmR2XPagflUUUJd9ji2+00=":"xzw+ckvEnQ24nGg=","wIh08EsBeVs817ydl++eYs/VjNP3Rmy2Xq2i18Me4dd/yX4=":46939}
$ oasis contracts storage dump 0 --network localhost --limit 1
Showing 1 public record(s) of contract 0:
{"c2Vuc29yc1zFnd5u3TSZ":{"query_granularity":14400,"storage_granularity":600,"name":"esp2866_bedroom","measurement_types":[1,3]}}
$ oasis contracts storage get 0 owner --network localhost
"APOPeewebP6XtP4Gx4mLUqj620eD"
$ oasis contracts storage get 0 b3duZXI= --network localhost 
"APOPeewebP6XtP4Gx4mLUqj620eD"
$ oasis contracts storage get 0 c2Vuc29yc1zFnd5u3TSZ --network localhost 
{"measurement_types":[1,3],"query_granularity":14400,"storage_granularity":600,"name":"esp2866_bedroom"}
```