### PR TITLE
cli: Lookup address by account name, add support for test accounts

### DIFF
--- a/cli/cmd/common/selector.go
+++ b/cli/cmd/common/selector.go
@@ -8,6 +8,7 @@ import (
 
 	cliConfig "github.com/oasisprotocol/oasis-sdk/cli/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/helpers"
 )
 
 var (
@@ -66,9 +67,15 @@ func GetNPASelection(cfg *cliConfig.Config) *NPASelection {
 		s.AccountName = selectedAccount
 	}
 	if s.AccountName != "" {
-		s.Account = cfg.Wallet.All[s.AccountName]
-		if s.Account == nil {
-			cobra.CheckErr(fmt.Errorf("account '%s' does not exist in the wallet", s.AccountName))
+		if testName := helpers.ParseTestAccountAddress(s.AccountName); testName != "" {
+			testAcc, err := LoadTestAccountConfig(testName)
+			cobra.CheckErr(err)
+			s.Account = testAcc
+		} else {
+			s.Account = cfg.Wallet.All[s.AccountName]
+			if s.Account == nil {
+				cobra.CheckErr(fmt.Errorf("account '%s' does not exist in the wallet", s.AccountName))
+			}
 		}
 	}
 

--- a/cli/cmd/common/wallet.go
+++ b/cli/cmd/common/wallet.go
@@ -8,10 +8,22 @@ import (
 
 	"github.com/oasisprotocol/oasis-sdk/cli/config"
 	"github.com/oasisprotocol/oasis-sdk/cli/wallet"
+	"github.com/oasisprotocol/oasis-sdk/cli/wallet/test"
+	configSdk "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/helpers"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
 // LoadAccount loads the given named account.
 func LoadAccount(cfg *config.Config, name string) wallet.Account {
+	// Check if the specified account is a test account.
+	if testName := helpers.ParseTestAccountAddress(name); testName != "" {
+		acc, err := LoadTestAccount(testName)
+		cobra.CheckErr(err)
+		return acc
+	}
+
 	// Early check for whether the account exists so that we don't ask for passphrase first.
 	var (
 		acfg   *config.Account
@@ -37,4 +49,38 @@ func LoadAccount(cfg *config.Config, name string) wallet.Account {
 	cobra.CheckErr(err)
 
 	return acc
+}
+
+// LoadTestAccount loads the given named test account.
+func LoadTestAccount(name string) (wallet.Account, error) {
+	if testKey, ok := testing.TestAccounts[name]; ok {
+		return test.NewTestAccount(testKey)
+	}
+	return nil, fmt.Errorf("test account %s does not exist", name)
+}
+
+// LoadTestAccountConfig loads config for the given named test account.
+func LoadTestAccountConfig(name string) (*config.Account, error) {
+	testAcc, err := LoadTestAccount(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config.Account{
+		Description: "",
+		Kind:        test.Kind,
+		Address:     testAcc.Address().String(),
+		Config:      nil,
+	}, nil
+}
+
+// ResolveLocalAccountOrAddress resolves a string address into the corresponding account address.
+func ResolveLocalAccountOrAddress(net *configSdk.Network, address string) (*types.Address, error) {
+	// Check, if address is the account name in the wallet.
+	if acc, ok := config.Global().Wallet.All[address]; ok {
+		addr := acc.GetAddress()
+		return &addr, nil
+	}
+
+	return helpers.ResolveAddress(net, address)
 }

--- a/cli/cmd/contracts.go
+++ b/cli/cmd/contracts.go
@@ -331,7 +331,7 @@ func parsePolicy(net *config.Network, wallet *cliConfig.Account, policy string) 
 		return &contracts.Policy{Address: &address}
 	case strings.HasPrefix(policy, "address:"):
 		policy = strings.TrimPrefix(policy, "address:")
-		address, err := helpers.ResolveAddress(net, policy)
+		address, err := common.ResolveLocalAccountOrAddress(net, policy)
 		if err != nil {
 			cobra.CheckErr(fmt.Errorf("malformed address in policy: %w", err))
 		}

--- a/cli/cmd/wallet.go
+++ b/cli/cmd/wallet.go
@@ -41,7 +41,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			table := table.New()
-			table.SetHeader([]string{"Name", "Kind", "Address"})
+			table.SetHeader([]string{"Account", "Kind", "Address"})
 
 			var output [][]string
 			for name, acc := range cfg.Wallet.All {

--- a/cli/wallet/test/test.go
+++ b/cli/wallet/test/test.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"encoding/base64"
+
+	coreSignature "github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+
+	"github.com/oasisprotocol/oasis-sdk/cli/wallet"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+const (
+	// Kind is the account kind for the test accounts.
+	Kind = "test"
+)
+
+type testAccount struct {
+	testKey testing.TestKey
+}
+
+func NewTestAccount(testKey testing.TestKey) (wallet.Account, error) {
+	return &testAccount{testKey: testKey}, nil
+}
+
+func (a *testAccount) ConsensusSigner() coreSignature.Signer {
+	type wrappedSigner interface {
+		Unwrap() coreSignature.Signer
+	}
+
+	if ws, ok := a.testKey.Signer.(wrappedSigner); ok {
+		return ws.Unwrap()
+	}
+	return nil
+}
+
+func (a *testAccount) Signer() signature.Signer {
+	return a.testKey.Signer
+}
+
+func (a *testAccount) Address() types.Address {
+	return a.testKey.Address
+}
+
+func (a *testAccount) SignatureAddressSpec() types.SignatureAddressSpec {
+	return a.testKey.SigSpec
+}
+
+func (a *testAccount) UnsafeExport() string {
+	return base64.StdEncoding.EncodeToString(a.testKey.SecretKey)
+}

--- a/client-sdk/go/helpers/address.go
+++ b/client-sdk/go/helpers/address.go
@@ -12,15 +12,18 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/secp256k1"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
 const (
-	addressPrefixOasis       = "oasis1"
-	addressPrefixEth         = "0x"
+	addressPrefixOasis = "oasis1"
+	addressPrefixEth   = "0x"
+
 	addressExplicitSeparator = ":"
 	addressExplicitParaTime  = "paratime"
 	addressExplicitPool      = "pool"
+	addressExplicitTest      = "test"
 
 	poolRewards = "rewards"
 )
@@ -67,6 +70,12 @@ func ResolveAddress(net *config.Network, address string) (*types.Address, error)
 			default:
 				return nil, fmt.Errorf("unsupported pool kind: %s", data)
 			}
+		case addressExplicitTest:
+			// Test key.
+			if testKey, ok := testing.TestAccounts[data]; ok {
+				return &testKey.Address, nil
+			}
+			return nil, fmt.Errorf("unsupported test account: %s", data)
 		default:
 			// Unsupported kind.
 			return nil, fmt.Errorf("unsupported explicit address kind: %s", kind)
@@ -74,6 +83,19 @@ func ResolveAddress(net *config.Network, address string) (*types.Address, error)
 	default:
 		return nil, fmt.Errorf("unsupported address format")
 	}
+}
+
+// ParseTestAccountAddress extracts test account name from "test:some_test_account" format or
+// returns an empty string, if the format doesn't match.
+func ParseTestAccountAddress(name string) string {
+	if strings.Contains(name, addressExplicitSeparator) {
+		subs := strings.SplitN(name, addressExplicitSeparator, 2)
+		if subs[0] == addressExplicitTest {
+			return subs[1]
+		}
+	}
+
+	return ""
 }
 
 // EthAddressFromPubKey takes public key, extracts the ethereum address and returns its checksummed

--- a/client-sdk/go/helpers/address_test.go
+++ b/client-sdk/go/helpers/address_test.go
@@ -39,6 +39,10 @@ func TestResolveAddress(t *testing.T) {
 		{"pool:", ""},
 		{"pool:invalid", ""},
 		{"pool:rewards", "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav"},
+		{"test:alice", "oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve"},
+		{"test:dave", "oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt"},
+		{"test:frank", "oasis1qqnf0s9p8z79zfutszt0hwlh7w7jjrfqnq997mlw"},
+		{"test:invalid", ""},
 		{"invalid:", ""},
 	} {
 		addr, err := ResolveAddress(&net, tc.address)
@@ -48,6 +52,24 @@ func TestResolveAddress(t *testing.T) {
 		} else {
 			require.Error(err, tc.address)
 		}
+	}
+}
+
+func TestParseTestAccountAddress(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		address  string
+		expected string
+	}{
+		{"test:abc", "abc"},
+		{"testabc", ""},
+		{"testing:abc", ""},
+		{"oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", ""},
+		{"", ""},
+	} {
+		testName := ParseTestAccountAddress(tc.address)
+		require.EqualValues(tc.expected, testName, tc.address)
 	}
 }
 

--- a/client-sdk/go/testing/testing.go
+++ b/client-sdk/go/testing/testing.go
@@ -91,4 +91,15 @@ var (
 	Frank = newSr25519TestKey("oasis-runtime-sdk/test-keys: frank")
 	// Grace is the test key G.
 	Grace = newSr25519TestKey("oasis-runtime-sdk/test-keys: grace")
+
+	// TestAccounts contains all test keys.
+	TestAccounts = map[string]TestKey{
+		"alice":   Alice,
+		"bob":     Bob,
+		"charlie": Charlie,
+		"dave":    Dave,
+		"erin":    Erin,
+		"frank":   Frank,
+		"grace":   Grace,
+	}
 )

--- a/docs/runtime/minimal-runtime.md
+++ b/docs/runtime/minimal-runtime.md
@@ -316,25 +316,14 @@ oasis paratime add localhost minimal 8000000000000000000000000000000000000000000
 ? Denomination decimal places: 9
 ```
 
-Finally, we import _Alice's_ account to our wallet with a private key below:
-
-```bash
-oasis wallet import alice
-? Import kind: private key
-? Algorithm: ed25519-raw
-? Private key (base64-encoded): [Enter 2 empty lines to finish]OPYg5hO22BvHgHmtjo/dZgyn/+efqDhcAfcZ6NsMKhc1w/M1bdhTZP66A1S1Ra2hCdG9s4v11hJoF9uMcs/WkQ==
-
-? Private key (base64-encoded): 
-OPYg5hO22BvHgHmtjo/dZgyn/+efqDhcAfcZ6NsMKhc1w/M1bdhTZP66A1S1Ra2hCdG9s4v11hJoF9uMcs/WkQ==
-? Choose a new passphrase: 
-? Repeat passphrase:
-```
-
 If the Oasis CLI was configured correctly, you should see the balance of Alice's
-account in the runtime:
+account in the runtime. Oasis CLI comes with hidden accounts for Alice, Bob and
+other test users (check the [oasis-sdk testing source] for a complete list).
+You can access the accounts by prepending `test:` literal in front of the test
+user's name, for example `test:alice`.
 
 ```bash
-oasis accounts show --network localhost --paratime minimal --account alice
+oasis accounts show test:alice --network localhost
 Address: oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve
 Nonce: 0
 
@@ -350,10 +339,10 @@ Balances for all denominations:
 ```
 
 Sending some TEST in your runtime should also work. Let's send 0.1 TEST to
-Bob's address `oasis1qrydpazemvuwtnp3efm7vmfvg3tde044qg6cxwzx`:
+Bob's address.
 
 ```bash
-oasis accounts transfer 0.1 oasis1qrydpazemvuwtnp3efm7vmfvg3tde044qg6cxwzx --network localhost --paratime minimal --account alice 
+oasis accounts transfer 0.1 test:bob --network localhost --account test:alice 
 Unlock your account.
 ? Passphrase: 
 You are about to sign the following transaction:
@@ -384,7 +373,7 @@ You are about to sign the following transaction:
   }
 }
 
-Account:  alice
+Account:  test:alice
 Network:  localhost (localhost)
 Paratime: minimal (minimal)
 ? Sign this transaction? Yes
@@ -396,7 +385,10 @@ Transaction hash: 03a73bd08fb23472673ea45938b0871edd9ecd2cd02b3061d49c0906a77234
 Execution successful.
 ```
 
+<!-- markdownlint-disable line-length -->
 [chain context]: /oasis-core/crypto#chain-domain-separation
+[oasis-sdk testing source]: https://github.com/oasisprotocol/oasis-sdk/blob/main/client-sdk/go/testing/testing.go
+<!-- markdownlint-enable line-length -->
 
 ## Testing From a Client
 


### PR DESCRIPTION
Fixes #891.

This PR adds the following to `oasis accounts` command:
- if address equals account name in the wallet, it returns the address corresponding to the account
- if address starts with `test:`, it finds the corresponding testing account (Alice, Bob, Charlie etc.) and returns the testing account address
- if `--account` value starts with `test:`, it takes the testing account key to sign the transaction
- updates minimal-runtime docs accordingly
- fixes crash when calling `oasis accounts withdraw <amount> [to]` without `to` parameter


Example usage:
```
$ oasis accounts show mywallet
Address: oasis1qqgwegnh3h6p0828npmqed0f243fd9pyhcgmmmt4
Nonce: 0

=== CONSENSUS LAYER (testnet) ===
  Total: 0.0 TEST
  Available: 0.0 TEST

$ oasis accounts show test:bob
Address: oasis1qrydpazemvuwtnp3efm7vmfvg3tde044qg6cxwzx
Nonce: 0

=== CONSENSUS LAYER (testnet) ===
  Total: 0.0 TEST
  Available: 0.0 TEST

$ oasis accounts transfer 1 test:alice --paratime emerald --account test:dave
You are about to sign the following transaction:
{
  "v": 1,
  "call": {
    "method": "accounts.Transfer",
    "body": "omJ0b1UA84957B5s/pe0/gbHiYtSqPrbR4NmYW1vdW50gkgN4Lazp2QAAEA="
  },
  "ai": {
    "si": [
      {
        "address_spec": {
          "signature": {
            "secp256k1eth": "AwF6GNjbybMzhi3XRj5R1oTiMMkO1nAwB7NZAlH1X4BE"
          }
        },
        "nonce": 27
      }
    ],
    "fee": {
      "amount": {
        "Amount": "232100000000000",
        "Denomination": ""
      },
      "gas": 2321
    }
  }
}

Account:  test:dave
Network:  testnet
Paratime: emerald
? Sign this transaction? (y/N)

$ oasis accounts withdraw 1 test:erin --paratime emerald --account test:alice
Error: test account 'erin' (oasis1qqcd0qyda6gtwdrfcqawv3s8cr2kupzw9v967au6) will not be able to sign transactions on consensus layer

$ oasis accounts withdraw 1 test:bob --paratime emerald --account test:alice
You are about to sign the following transaction:
{
  "v": 1,
  "call": {
    "method": "consensus.Withdraw",
    "body": "omJ0b1UAyND0Wds45cwxynfmbSxEVty+tQJmYW1vdW50gkgN4Lazp2QAAEA="
  },
  "ai": {
    "si": [
      {
        "address_spec": {
          "signature": {
            "ed25519": "NcPzNW3YU2T+ugNUtUWtoQnRvbOL9dYSaBfbjHLP1pE="
          }
        },
        "nonce": 13
      }
    ],
    "fee": {
      "amount": {
        "Amount": "1131500000000000",
        "Denomination": ""
      },
      "gas": 11315,
      "consensus_messages": 1
    }
  }
}

Account:  test:alice
Network:  testnet
Paratime: emerald
? Sign this transaction? (y/N)
```