### PR TITLE
evm: don't require encryption of empty string

### DIFF
--- a/runtime-sdk/modules/evm/src/backend.rs
+++ b/runtime-sdk/modules/evm/src/backend.rs
@@ -277,9 +277,7 @@ impl<'c, C: Context, Cfg: Config> ApplyBackendResult for Backend<'c, C, Cfg> {
                         let val: H256 = value.into();
 
                         let ctx = self.ctx.get_mut();
-                        if value == primitive_types::H256::default()
-                            && (Cfg::CONFIDENTIAL && !Cfg::CONFIDENTIAL_CONSTIFY)
-                        {
+                        if value == primitive_types::H256::default() {
                             with_storage!(*ctx, &addr, |store| store.remove(&idx));
                         } else {
                             with_storage!(*ctx, &addr, |store| store.insert(&idx, val));

--- a/runtime-sdk/modules/evm/src/backend.rs
+++ b/runtime-sdk/modules/evm/src/backend.rs
@@ -277,7 +277,9 @@ impl<'c, C: Context, Cfg: Config> ApplyBackendResult for Backend<'c, C, Cfg> {
                         let val: H256 = value.into();
 
                         let ctx = self.ctx.get_mut();
-                        if value == primitive_types::H256::default() {
+                        if value == primitive_types::H256::default()
+                            && (Cfg::CONFIDENTIAL && !Cfg::CONFIDENTIAL_CONSTIFY)
+                        {
                             with_storage!(*ctx, &addr, |store| store.remove(&idx));
                         } else {
                             with_storage!(*ctx, &addr, |store| store.insert(&idx, val));

--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -60,6 +60,8 @@ pub trait Config: 'static {
 
     /// Whether to use confidential storage by default, and transaction data encryption.
     const CONFIDENTIAL: bool = false;
+    /// Whether to modify some gas costs and storage ops to not be data-dependent.
+    const CONFIDENTIAL_CONSTIFY: bool = false;
 
     /// Maps an Ethereum address into an SDK account address.
     fn map_address(address: primitive_types::H160) -> Address {
@@ -91,7 +93,7 @@ pub trait Config: 'static {
         } else {
             EVM_CONFIG.get_or_init(|| {
                 let mut cfg = EVMConfig::london();
-                if Self::CONFIDENTIAL {
+                if Self::CONFIDENTIAL && Self::CONFIDENTIAL_CONSTIFY {
                     // Data-dependent gas costs are made constant, where possible, by setting
                     // the value to the maximum of alternatives. Maximum is chosen to frustrate
                     // DoS. If the gas costs are too high, the block gas limit may be raised


### PR DESCRIPTION
This PR enables native token transfers from MetaMask (or any other unmodified client). ~It also allows constifying some gas costs/storage ops†.~

~There's another question of whether confidential EVM should pass through txs that fail to decrypt, assuming that they're not encrypted. That's not super safe for least reason of which that it won't be rejected by the client node before the entire network sees the plaintext.~


~† I don't think that we should enable these by default since they're possible for the application/client to mitigate, leaving applications that don't need/care about it lower costs. It's left as a config option just in case (and for others who may wish to use the module).~
 * ~the difference between non-zero/zero values in tx data can be fixed by~
    - ~having the call contain random bytes inserted into the call data to obfuscate the number of zero/non-zero bytes~
    - ~having the contract either calculate or caller specify the number of zeros so that the contract can waste gas to make up the differences~
* ~the difference between storage set and reset can be fixed by using a sentinel value instead of zero~