### PR TITLE
runtime-sdk/modules/contracts: Fix subcall dispatch

### DIFF
--- a/runtime-sdk/modules/contracts/src/results.rs
+++ b/runtime-sdk/modules/contracts/src/results.rs
@@ -181,7 +181,9 @@ fn process_subcalls<Cfg: Config, C: TxContext>(
                         },
                     };
 
-                    let result = ctx.with_tx(0, 0, tx, |mut ctx, call| {
+                    let result = ctx.with_tx(0, 0, tx, |ctx, call| {
+                        // Mark this sub-context as internal as it belongs to an existing transaction.
+                        let mut ctx = ctx.internal();
                         // Propagate call depth.
                         ctx.value(CONTEXT_KEY_DEPTH).set(current_depth + 1);
 


### PR DESCRIPTION
Previously various gas and fee checks were performed even for internal
subcalls (e.g. when smart contracts called into other modules) which
was wrong and also caused failures due to minimum gas price not being
met (the fee is always set to zero for subcalls).