### PR TITLE
evm: expose public data in signed queries

### DIFF
--- a/client-sdk/go/modules/evm/signed_calls_test.go
+++ b/client-sdk/go/modules/evm/signed_calls_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 )
 
 type rsvSigner struct {
@@ -39,14 +40,14 @@ func TestMakeSignedCall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := EncodeSignedCall(rsvSigner{sk}, 0x5afe, caller, callee, 10, big.NewInt(123), big.NewInt(42), []byte{1, 2, 3, 4}, leash)
+	dataPack, err := NewSignedCallDataPack(rsvSigner{sk}, 0x5afe, caller, callee, 10, big.NewInt(123), big.NewInt(42), []byte{1, 2, 3, 4}, leash)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	dataHex := hex.EncodeToString(data)
+	encodedDataPack := hex.EncodeToString(cbor.Marshal(dataPack))
 	// From the JS reference impl:
-	if dataHex != "a2657175657279a764646174614401020304656c65617368a4656e6f6e63651903e76a626c6f636b5f686173685820c92b675c7013e33aa88feaae520eb0ede155e7cacb3c4587e0923cba9953f8bb6b626c6f636b5f72616e6765036c626c6f636b5f6e756d626572182a6576616c75655820000000000000000000000000000000000000000000000000000000000000002a6663616c6c65725411e244400cf165ade687077984f09c3a037b868f676164647265737354b5ed90452aac09f294a0be877cbf2dc4d55e096f696761735f6c696d69740a696761735f70726963655820000000000000000000000000000000000000000000000000000000000000007b697369676e6174757265584148bca100e84d13a80b131c62b9b87caf07e4da6542a9e1ea16d8042ba08cc1e31f10ae924d8c137882204e9217423194014ce04fa2130c14f27b148858733c7b1c" {
-		t.Fatalf("got invalid signed call data: %s", dataHex)
+	if encodedDataPack != "a36464617461a164626f64794401020304656c65617368a4656e6f6e63651903e76a626c6f636b5f686173685820c92b675c7013e33aa88feaae520eb0ede155e7cacb3c4587e0923cba9953f8bb6b626c6f636b5f72616e6765036c626c6f636b5f6e756d626572182a697369676e6174757265584148bca100e84d13a80b131c62b9b87caf07e4da6542a9e1ea16d8042ba08cc1e31f10ae924d8c137882204e9217423194014ce04fa2130c14f27b148858733c7b1c" {
+		t.Fatalf("got invalid signed call data: %s", encodedDataPack)
 	}
 }

--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -664,7 +664,7 @@ impl<Cfg: Config> Module<Cfg> {
             ));
         }
 
-        // The call is not signed, but it must be encoded as an oaiss-sdk call.
+        // The call is not signed, but it must be encoded as an oasis-sdk call.
         let tx_call_format = transaction::CallFormat::Plain; // Queries cannot be encrypted.
         let (data, tx_metadata) = Self::decode_call_data(ctx, call.data, tx_call_format, 0, true)?
             .expect("processing always proceeds");

--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -4,7 +4,7 @@ pub mod backend;
 pub mod derive_caller;
 pub mod precompile;
 pub mod raw_tx;
-mod signed_query;
+mod signed_call;
 pub mod state;
 pub mod types;
 
@@ -140,9 +140,9 @@ pub enum Error {
     #[sdk_error(code = 9)]
     SimulationTooExpensive(u64),
 
-    #[error("invalid signed query: {0}")]
+    #[error("invalid signed simulate call query: {0}")]
     #[sdk_error(code = 10)]
-    InvalidSignedQuery(&'static str),
+    InvalidSignedSimulateCall(&'static str),
 
     #[error("core: {0}")]
     #[sdk_error(transparent)]
@@ -335,8 +335,8 @@ pub trait API {
     /// Simulate an Ethereum CALL.
     ///
     /// If the EVM is confidential, it may accept _signed queries_, which are formatted as
-    /// an encrypted [`types::SignedQueryEnvelope`] packed into the `data` field of
-    /// [`types::SimulateCallQuery`].
+    /// an either a [`sdk::types::transaction::Call`] or [`types::SignedCallDataPack`] encoded
+    /// and packed into the `data` field of the [`types::SimulateCallQuery`].
     fn simulate_call<C: Context>(
         ctx: &mut C,
         call: types::SimulateCallQuery,
@@ -446,19 +446,17 @@ impl<Cfg: Config> API for Module<Cfg> {
         ctx: &mut C,
         call: types::SimulateCallQuery,
     ) -> Result<Vec<u8>, Error> {
-        let types::SimulateCallQuery {
-            gas_price,
-            gas_limit,
-            caller,
-            address,
-            value,
-            data,
-            ..
-        } = Self::decode_simulate_call_query(ctx, call)?;
-
-        let (data, tx_metadata) =
-            Self::decode_call_data(ctx, data, transaction::CallFormat::Plain, 0, true)?
-                .expect("processing always proceeds");
+        let (
+            types::SimulateCallQuery {
+                gas_price,
+                gas_limit,
+                caller,
+                address,
+                value,
+                data,
+            },
+            tx_metadata,
+        ) = Self::decode_simulate_call_query(ctx, call)?;
 
         let evm_result = ctx.with_simulation(|mut sctx| {
             let call_tx = transaction::Transaction {
@@ -603,7 +601,7 @@ impl<Cfg: Config> Module<Cfg> {
     fn decode_call_data<C: Context>(
         ctx: &C,
         data: Vec<u8>,
-        format: transaction::CallFormat,
+        format: transaction::CallFormat, // The tx call format.
         tx_index: usize,
         assume_km_reachable: bool,
     ) -> Result<Option<(Vec<u8>, callformat::Metadata)>, Error> {
@@ -614,6 +612,17 @@ impl<Cfg: Config> Module<Cfg> {
         }
         let call = cbor::from_slice(&data)
             .map_err(|_| CoreError::InvalidCallFormat(anyhow::anyhow!("invalid packed call")))?;
+        Self::decode_call(ctx, call, tx_index, assume_km_reachable)
+    }
+
+    /// Returns the decrypted call data or `None` if this transaction is simulated in
+    /// a context that may not include a key manager (i.e. SimulateCall but not EstimateGas).
+    fn decode_call<C: Context>(
+        ctx: &C,
+        call: transaction::Call,
+        tx_index: usize,
+        assume_km_reachable: bool,
+    ) -> Result<Option<(Vec<u8>, callformat::Metadata)>, Error> {
         match callformat::decode_call_ex(ctx, call, tx_index, assume_km_reachable)? {
             Some((
                 transaction::Call {
@@ -627,6 +636,46 @@ impl<Cfg: Config> Module<Cfg> {
             }
             None => Ok(None),
         }
+    }
+
+    fn decode_simulate_call_query<C: Context>(
+        ctx: &mut C,
+        call: types::SimulateCallQuery,
+    ) -> Result<(types::SimulateCallQuery, callformat::Metadata), Error> {
+        if !Cfg::CONFIDENTIAL {
+            return Ok((call, callformat::Metadata::Empty));
+        }
+        if let Ok(types::SignedCallDataPack {
+            data,
+            leash,
+            signature,
+        }) = cbor::from_slice(&call.data)
+        {
+            let (data, tx_metadata) =
+                Self::decode_call(ctx, data, 0, true)?.expect("processing always proceeds");
+            return Ok((
+                signed_call::verify::<_, Cfg>(
+                    ctx,
+                    types::SimulateCallQuery { data, ..call },
+                    leash,
+                    signature,
+                )?,
+                tx_metadata,
+            ));
+        }
+
+        // The call is not signed, but it must be encoded as an oaiss-sdk call.
+        let tx_call_format = transaction::CallFormat::Plain; // Queries cannot be encrypted.
+        let (data, tx_metadata) = Self::decode_call_data(ctx, call.data, tx_call_format, 0, true)?
+            .expect("processing always proceeds");
+        Ok((
+            types::SimulateCallQuery {
+                caller: Default::default(), // The sender cannot be spoofed.
+                data,
+                ..call
+            },
+            tx_metadata,
+        ))
     }
 
     fn encode_evm_result<C: Context>(
@@ -710,26 +759,6 @@ impl<Cfg: Config> Module<Cfg> {
     fn migrate<C: Context>(_ctx: &mut C, _from: u32) -> bool {
         // No migrations currently supported.
         false
-    }
-
-    fn decode_simulate_call_query<C: Context>(
-        ctx: &mut C,
-        body: types::SimulateCallQuery,
-    ) -> Result<types::SimulateCallQuery, Error> {
-        if !Cfg::CONFIDENTIAL {
-            return Ok(body);
-        }
-        match cbor::from_slice(&body.data) {
-            Ok(types::SignedQueryEnvelope { query, signature }) => {
-                signed_query::verify::<_, Cfg>(ctx, query, signature)
-            }
-            Err(_) => Ok(types::SimulateCallQuery {
-                // If the ParaTime is confidential, but the query isn't signed, zero out
-                // the caller address to preserve that `msg.sender` is not spoofable.
-                caller: Default::default(),
-                ..body
-            }),
-        }
     }
 }
 

--- a/runtime-sdk/modules/evm/src/types.rs
+++ b/runtime-sdk/modules/evm/src/types.rs
@@ -34,8 +34,21 @@ pub struct BalanceQuery {
     pub address: H160,
 }
 
-/// An envelope containing a non-encrypted [`SimulateCallQuery`] and a signture
-/// generated according to [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
+/// Transaction body for simulating an EVM call.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+#[cfg_attr(test, derive(Default, PartialEq, Eq))]
+pub struct SimulateCallQuery {
+    pub gas_price: U256,
+    pub gas_limit: u64,
+    pub caller: H160,
+    pub address: H160,
+    pub value: U256,
+    pub data: Vec<u8>,
+}
+
+/// An envelope containing the encryption-enveloped data of a [`SimulateCallQuery`]
+/// and a signature generated according to [EIP-712](https://eips.ethereum.org/EIPS/eip-712)
+/// over the unmodified Eth call.
 ///
 /// EIP-712 is used so that the signed message can be easily verified by the user.
 /// MetaMask, for instance, shows each field as itself, whereas a standard `eth_personalSign`
@@ -69,23 +82,10 @@ pub struct BalanceQuery {
 /// }
 /// ```
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
-pub struct SignedQueryEnvelope {
-    pub query: SimulateCallQuery,
+pub struct SignedCallDataPack {
+    pub data: oasis_runtime_sdk::types::transaction::Call,
+    pub leash: Leash,
     pub signature: [u8; 65],
-}
-
-/// Transaction body for simulating an EVM call.
-#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
-#[cfg_attr(test, derive(Default, PartialEq, Eq))]
-pub struct SimulateCallQuery {
-    pub gas_price: U256,
-    pub gas_limit: u64,
-    pub caller: H160,
-    pub address: H160,
-    pub value: U256,
-    pub data: Vec<u8>,
-    #[cbor(optional, default)]
-    pub leash: Option<Leash>,
 }
 
 #[derive(Clone, Debug, cbor::Encode, cbor::Decode)]

--- a/runtime-sdk/src/callformat.rs
+++ b/runtime-sdk/src/callformat.rs
@@ -30,6 +30,19 @@ pub enum Metadata {
     },
 }
 
+impl std::fmt::Debug for Metadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => f.debug_struct("Metadata::Empty").finish(),
+            Self::EncryptedX25519DeoxysII { pk, index, .. } => f
+                .debug_struct("Metadata::EncryptedX25519DeoxysII")
+                .field("pk", pk)
+                .field("index", index)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
 /// Derive the key pair ID for the call data encryption key pair.
 pub fn get_key_pair_id(epoch: beacon::EpochTime) -> keymanager::KeyPairId {
     keymanager::get_key_pair_id(&[


### PR DESCRIPTION
Previously, the entire signed query was encoded into the `data` field and then encrypted, which makes it very difficult for tools and middleboxes to examine public data. This PR modifies the signed query format such that only the data is encrypted. Just the minimum of extensions are packed into the `data` field.

related: https://github.com/oasisprotocol/sapphire-paratime/pull/31