### PR TITLE
docs: Replace /oasis-core links with full github URLs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ included.
 * [Build a Runtime](runtime/getting-started.md)
 
 <!-- markdownlint-disable line-length -->
-[Oasis Core Runtime Layer]: /oasis-core/runtime
+[Oasis Core Runtime Layer]: https://github.com/oasisprotocol/oasis-core/blob/master/docs/runtime/index.md
 <!-- markdownlint-enable line-length -->
 
 ## Components


### PR DESCRIPTION
In light of the docs restructuring https://github.com/oasisprotocol/docs/pull/200 replace any `/oasis-core/*` or `/general/*` links with full github.com URL.

Redirection back to the documentation's URL should be done by docusaurus preprocessor.