### PR TITLE
docs: Migrate docs.oasis.dev -> docs.oasis.io

### DIFF
--- a/client-sdk/go/config/default.go
+++ b/client-sdk/go/config/default.go
@@ -5,7 +5,7 @@ var DefaultNetworks = Networks{
 	Default: "mainnet",
 	All: map[string]*Network{
 		// Mainnet network parameters.
-		// See https://docs.oasis.dev/general/oasis-network/network-parameters.
+		// See https://docs.oasis.io/node/mainnet.
 		"mainnet": {
 			ChainContext: "b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535",
 			RPC:          "grpc.oasis.dev:443",
@@ -41,7 +41,7 @@ var DefaultNetworks = Networks{
 			},
 		},
 		// Oasis Protocol Foundation Testnet parameters.
-		// See https://docs.oasis.dev/general/foundation/testnet.
+		// See https://docs.oasis.io/node/testnet.
 		"testnet": {
 			ChainContext: "50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a",
 			RPC:          "testnet.grpc.oasis.dev:443",

--- a/docs/contract/confidential-smart-contract.md
+++ b/docs/contract/confidential-smart-contract.md
@@ -232,9 +232,9 @@ oasis contracts upload hello_world.wasm
 
 <!-- markdownlint-disable line-length -->
 [PublicCell]:
-  https://api.docs.oasis.dev/oasis-sdk/oasis_contract_sdk_storage/cell/struct.PublicCell.html
+  https://api.docs.oasis.io/oasis-sdk/oasis_contract_sdk_storage/cell/struct.PublicCell.html
 [ConfidentialCell]:
-  https://api.docs.oasis.dev/oasis-sdk/oasis_contract_sdk_storage/cell/struct.ConfidentialCell.html
+  https://api.docs.oasis.io/oasis-sdk/oasis_contract_sdk_storage/cell/struct.ConfidentialCell.html
 <!-- markdownlint-enable line-length -->
 
 ## Confidential Instantiation and Calling
@@ -305,5 +305,5 @@ event][emit_event] will be public.
 
 <!-- markdownlint-disable line-length -->
 [emit_event]:
-  https://api.docs.oasis.dev/oasis-sdk/oasis_contract_sdk/context/trait.Context.html#tymethod.emit_event
+  https://api.docs.oasis.io/oasis-sdk/oasis_contract_sdk/context/trait.Context.html#tymethod.emit_event
 <!-- markdownlint-enable line-length -->


### PR DESCRIPTION
Replaces docs.oasis.dev references with docs.oasis.io.