### PR TITLE
client-sdk/go: add evm NewCreateTx

### DIFF
--- a/client-sdk/go/modules/evm/evm.go
+++ b/client-sdk/go/modules/evm/evm.go
@@ -190,6 +190,11 @@ func NewV1(rtc client.RuntimeClient) V1 {
 	return &v1{rtc: rtc}
 }
 
+// NewCreateTx generates a new evm.Create transaction.
+func NewCreateTx(fee *types.Fee, body *Create) *types.Transaction {
+	return types.NewTransaction(fee, methodCreate, body)
+}
+
 // NewCallTx generates a new evm.Call transaction.
 func NewCallTx(fee *types.Fee, body *Call) *types.Transaction {
 	return types.NewTransaction(fee, methodCall, body)


### PR DESCRIPTION
match up with NewCallTx

context: we're making a simulation of the rust raw-eth-format tx decoding in go, so there's the desire to construct a evm.Create tx to represent the decoded tx without intending to send it over a runtime client