### PR TITLE
evm: don't encode contract create output

### DIFF
--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -366,11 +366,14 @@ impl<Cfg: Config> API for Module<Cfg> {
             return Ok(vec![]);
         }
 
-        let (init_code, tx_metadata) =
+        // Create output (the contract address) does not need to be encrypted because it's
+        // trivially computable by anyone who can observe the create tx and receipt status.
+        // Therefore, we don't need the `tx_metadata` or to encode the result.
+        let (init_code, _tx_metadata) =
             Self::decode_call_data(ctx, init_code, ctx.tx_call_format(), ctx.tx_index(), true)?
                 .expect("processing always proceeds");
 
-        let evm_result = Self::do_evm(
+        Self::do_evm(
             caller,
             ctx,
             |exec, gas_limit| {
@@ -391,8 +394,7 @@ impl<Cfg: Config> API for Module<Cfg> {
             // Use estimate mode if not doing binary search for exact gas costs.
             ctx.is_simulation()
                 && <C::Runtime as Runtime>::Core::estimate_gas_search_max_iters(ctx) == 0,
-        );
-        Self::encode_evm_result(ctx, evm_result, tx_metadata, ctx.tx_call_format())
+        )
     }
 
     fn call<C: TxContext>(

--- a/runtime-sdk/modules/evm/src/test.rs
+++ b/runtime-sdk/modules/evm/src/test.rs
@@ -216,20 +216,10 @@ fn do_test_evm_calls<C: Config>() {
 
     let erc20_addr = ctx.with_tx(0, 0, create_tx, |mut tx_ctx, call| {
         let addr = H160::from_slice(
-            &cbor::from_value::<Vec<u8>>(
-                decode_result!(
-                    tx_ctx,
-                    EVMModule::<C>::tx_create(&mut tx_ctx, cbor::from_value(call.body).unwrap())
-                )
-                .unwrap(),
-            )
-            .unwrap(),
+            &EVMModule::<C>::tx_create(&mut tx_ctx, cbor::from_value(call.body).unwrap()).unwrap(),
         );
-
         EVMModule::<C>::check_invariants(&mut tx_ctx).expect("invariants should hold");
-
         tx_ctx.commit();
-
         addr
     });
 
@@ -534,20 +524,10 @@ fn do_test_evm_runtime<C: Config>() {
 
     let erc20_addr = ctx.with_tx(0, 0, create_tx, |mut tx_ctx, call| {
         let addr = H160::from_slice(
-            &cbor::from_value::<Vec<u8>>(
-                decode_result!(
-                    tx_ctx,
-                    EVMModule::<C>::tx_create(&mut tx_ctx, cbor::from_value(call.body).unwrap())
-                )
-                .unwrap(),
-            )
-            .unwrap(),
+            &EVMModule::<C>::tx_create(&mut tx_ctx, cbor::from_value(call.body).unwrap()).unwrap(),
         );
-
         EVMModule::<C>::check_invariants(&mut tx_ctx).expect("invariants should hold");
-
         tx_ctx.commit();
-
         addr
     });
 


### PR DESCRIPTION
This PR changes the confidential EVM create function to return the address, as would a non-confidential EVM. This will cause the gateway and downstream tools like the block explorer to display the correct address in the tx receipt.

There is no security risk to exposing the contract address, as it can be easily computed by observing that a transaction deposited new code (meaning a contract has been created) and then computing the address using the public sender address and nonce.

This PR should go in ASAP, as it's very annoying for devs who aren't able to use the block explorer as effectively.