### PR TITLE
ts-web/core: v0.1.1-alpha.2

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.1.1-alpha.2
+
+Spotlight change:
+
+- We fixed an incompatibility with grpc-web 1.4.0.
+
+Materials:
+
+- Fixed a broken link to the account key generation specification.
+- We've filled in the `homepage` field in our package.json files so now you
+  can easily navigate from npm to GitHub.
+
 ## v0.1.1-alpha.1
 
 Spotlight change:

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client",
-    "version": "0.1.1-alpha.1",
+    "version": "0.1.1-alpha.2",
     "license": "Apache-2.0",
     "homepage": "https://github.com/oasisprotocol/oasis-sdk/tree/main/client-sdk/ts-web/core",
     "files": [

--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -18,7 +18,7 @@
         "prepare": "tsc"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.1-alpha.1"
+        "@oasisprotocol/client": "^0.1.1-alpha.2"
     },
     "devDependencies": {
         "@oasisprotocol/client-rt": "^0.2.1-alpha.2",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -13,7 +13,7 @@
         },
         "core": {
             "name": "@oasisprotocol/client",
-            "version": "0.1.1-alpha.1",
+            "version": "0.1.1-alpha.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^2.0.0",
@@ -45,7 +45,7 @@
             "version": "0.1.1-alpha.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.1-alpha.1"
+                "@oasisprotocol/client": "^0.1.1-alpha.2"
             },
             "devDependencies": {
                 "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
@@ -8700,7 +8700,7 @@
             "version": "0.2.1-alpha.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.1-alpha.1",
+                "@oasisprotocol/client": "^0.1.1-alpha.2",
                 "deoxysii": "^0.0.2",
                 "elliptic": "^6.5.3",
                 "js-sha512": "^0.8.0",
@@ -8730,7 +8730,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^6.27.6",
-                "@oasisprotocol/client": "^0.1.1-alpha.1",
+                "@oasisprotocol/client": "^0.1.1-alpha.2",
                 "@oasisprotocol/ledger": "^0.2.3"
             },
             "devDependencies": {
@@ -9670,7 +9670,7 @@
         "@oasisprotocol/client-ext-utils": {
             "version": "file:ext-utils",
             "requires": {
-                "@oasisprotocol/client": "^0.1.1-alpha.1",
+                "@oasisprotocol/client": "^0.1.1-alpha.2",
                 "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
                 "buffer": "^6.0.3",
                 "cypress": "^10.9.0",
@@ -9686,7 +9686,7 @@
         "@oasisprotocol/client-rt": {
             "version": "file:rt",
             "requires": {
-                "@oasisprotocol/client": "^0.1.1-alpha.1",
+                "@oasisprotocol/client": "^0.1.1-alpha.2",
                 "@types/elliptic": "^6.4.14",
                 "@types/jest": "^29.1.0",
                 "buffer": "^6.0.3",
@@ -9712,7 +9712,7 @@
             "version": "file:signer-ledger",
             "requires": {
                 "@ledgerhq/hw-transport-webusb": "^6.27.6",
-                "@oasisprotocol/client": "^0.1.1-alpha.1",
+                "@oasisprotocol/client": "^0.1.1-alpha.2",
                 "@oasisprotocol/ledger": "^0.2.3",
                 "@types/w3c-web-usb": "^1.0.6",
                 "buffer": "^6.0.3",

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -16,7 +16,7 @@
         "test": "jest"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.1-alpha.1",
+        "@oasisprotocol/client": "^0.1.1-alpha.2",
         "deoxysii": "^0.0.2",
         "elliptic": "^6.5.3",
         "js-sha512": "^0.8.0",

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.27.6",
-        "@oasisprotocol/client": "^0.1.1-alpha.1",
+        "@oasisprotocol/client": "^0.1.1-alpha.2",
         "@oasisprotocol/ledger": "^0.2.3"
     },
     "devDependencies": {


### PR DESCRIPTION
a dependency that we use to communicate with the node, grpc-web, got rid of a method that we use. this happened in a minor version. let's release a version that's compatible so that things won't break if downstream projects update grpc-web.

fixes #1160