### PR TITLE
ts-web/core: switch back to newly fixed getName

### DIFF
--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -572,9 +572,7 @@ export class GRPCWrapper {
         desc: grpcWeb.MethodDescriptor<REQ, RESP>,
         request: REQ,
     ): Promise<RESP> {
-        // @ts-expect-error missing declaration
-        const name = desc.name;
-        const method = this.base + name;
+        const method = this.base + desc.getName();
         // Some browsers with enormous market share aren't able to preserve the stack between here
         // and our `.catch` callback below. Save a copy explicitly.
         const invocationStack = new Error().stack;
@@ -644,10 +642,8 @@ End of invocation stack`;
         desc: grpcWeb.MethodDescriptor<REQ, RESP>,
         request: REQ,
     ): grpcWeb.ClientReadableStream<RESP> {
-        // @ts-expect-error missing declaration
-        const name = desc.name;
         return this.client.serverStreaming(
-            this.base + name,
+            this.base + desc.getName(),
             request,
             // @ts-expect-error metadata nullability not modeled
             null,


### PR DESCRIPTION
method descriptor .getName() will be fixed soon

https://github.com/grpc/grpc-web/commit/4974a7b5a98815113183f19298d9d9ffe93fbdad