### PR TITLE
ts-web/core: remove incomplete response workaround

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased changes
+
+Little things:
+
+- Requests for scalar values (e.g. `consensusGetSignerNonce`) now properly
+  return falsy values (e.g. 0) instead of `undefined`.
+  Our thanks to the grpc-web team that helped us add support for this in their
+  library!
+
 ## v0.1.1-alpha.2
 
 Spotlight change:

--- a/client-sdk/ts-web/core/playground/src/index.js
+++ b/client-sdk/ts-web/core/playground/src/index.js
@@ -49,11 +49,10 @@ export const playground = (async function () {
         console.log('computed from genesis', ourChainContext);
         if (ourChainContext !== chainContext) throw new Error('computed chain context mismatch');
 
-        const nonce =
-            (await nic.consensusGetSignerNonce({
-                account_address: await oasis.staking.addressFromPublicKey(src.public()),
-                height: oasis.consensus.HEIGHT_LATEST,
-            })) ?? 0;
+        const nonce = await nic.consensusGetSignerNonce({
+            account_address: await oasis.staking.addressFromPublicKey(src.public()),
+            height: oasis.consensus.HEIGHT_LATEST,
+        });
         console.log('nonce', nonce);
 
         const account = await nic.stakingAccount({

--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -585,14 +585,6 @@ export class GRPCWrapper {
                 desc,
             )
             .catch((e) => {
-                if (e.message === 'Incomplete response') {
-                    // This seems to be normal. Void methods don't send back anything, which makes
-                    // grpc-web freak out. I don't know why we don't send a CBOR undefined or
-                    // something.
-                    // TODO: remove after https://github.com/grpc/grpc-web/pull/1230
-                    //       and see TODO in methodDescriptorConsensusGetSignerNonce
-                    return undefined as never;
-                }
                 if (e.metadata?.['grpc-status-details-bin']) {
                     const statusU8 = misc.fromBase64(e.metadata['grpc-status-details-bin']);
                     const status = proto.google.rpc.Status.decode(statusU8);

--- a/client-sdk/ts-web/core/src/client.ts
+++ b/client-sdk/ts-web/core/src/client.ts
@@ -434,9 +434,7 @@ const methodDescriptorConsensusEstimateGas = createMethodDescriptorUnary<
 >('Consensus', 'EstimateGas');
 const methodDescriptorConsensusGetSignerNonce = createMethodDescriptorUnary<
     types.ConsensusGetSignerNonceRequest,
-    // TODO: remove `undefined` after https://github.com/grpc/grpc-web/pull/1230
-    //       and see TODO in callUnary.
-    types.longnum | undefined
+    types.longnum
 >('Consensus', 'GetSignerNonce');
 const methodDescriptorConsensusGetBlock = createMethodDescriptorUnary<
     types.longnum,


### PR DESCRIPTION
grpc-web can now handle falsy responses, such as getting signer nonce when the nonce is 0