### PR TITLE
ts-web/core: add debonding_amount to StakingTakeEscrowEvent

### DIFF
--- a/client-sdk/ts-web/core/src/types.ts
+++ b/client-sdk/ts-web/core/src/types.ts
@@ -2965,7 +2965,14 @@ export interface StakingStakeThreshold {
  */
 export interface StakingTakeEscrowEvent {
     owner: Uint8Array;
+    /**
+     * amount is the sum of amounts slashed from active and debonding escrow balances.
+     */
     amount: Uint8Array;
+    /**
+     * debonding_amount is the amount slashed from the debonding escrow balance.
+     */
+    debonding_amount: Uint8Array;
 }
 
 /**


### PR DESCRIPTION
Updates the types with the field introduced in https://github.com/oasisprotocol/oasis-core/pull/5016

The type change is backwards-compatible, so it doesn't hurt much to have the new type in ts-web even before https://github.com/oasisprotocol/oasis-core/pull/5016 is widely deployed; users will just see `debonding_amount=0` when decoding an event from an old node.