### PR TITLE
docs: Wrap references to examples inside EXAMPLE block

### DIFF
--- a/docs/contract/confidential-smart-contract.md
+++ b/docs/contract/confidential-smart-contract.md
@@ -143,7 +143,7 @@ event][emit_event] will be public.
 
 :::
 
-:::info
+:::info Example
 
 You can view and download a [complete example] from the Oasis SDK repository.
 

--- a/docs/contract/hello-world.md
+++ b/docs/contract/hello-world.md
@@ -146,7 +146,7 @@ the instantiated contract. Next, you can test calling the contract.
 oasis contracts call INSTANCEID '{say_hello: {who: "me"}}'
 ```
 
-:::info
+:::info Example
 
 You can view and download a [complete example] from the Oasis SDK repository.
 

--- a/docs/runtime/minimal-runtime.md
+++ b/docs/runtime/minimal-runtime.md
@@ -385,7 +385,7 @@ preserved.
 
 Congratulations, you have successfully built and deployed your first runtime!
 
-:::info
+:::info Example
 
 You can view and download complete [runtime example] and [client code in Go]
 from the Oasis SDK repository.


### PR DESCRIPTION
For consistency with recent Sapphire tutorials, wrap Cipher and ParaTime examples inside a special EXAMPLE block too.

| before | after |
|---------|--------|
| ![image](https://user-images.githubusercontent.com/83672/200822558-54c5db38-dc41-48a7-8990-17c403e3e731.png) | ![image](https://user-images.githubusercontent.com/83672/200822631-e7f1abdf-1308-4220-90e6-8575fb5268d4.png) |

