### PR TITLE
examples/contract-sdk: Bump oasis-cbor to 0.5.0

### DIFF
--- a/examples/contract-sdk/c10l-hello-world/Cargo.toml
+++ b/examples/contract-sdk/c10l-hello-world/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-cbor = { version = "0.2.1", package = "oasis-cbor" }
+cbor = { version = "0.5.0", package = "oasis-cbor" }
 oasis-contract-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk" }
 oasis-contract-sdk-storage = { git = "https://github.com/oasisprotocol/oasis-sdk" }
 

--- a/examples/contract-sdk/hello-world/Cargo.toml
+++ b/examples/contract-sdk/hello-world/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-cbor = { version = "0.2.1", package = "oasis-cbor" }
+cbor = { version = "0.5.0", package = "oasis-cbor" }
 oasis-contract-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk" }
 oasis-contract-sdk-storage = { git = "https://github.com/oasisprotocol/oasis-sdk" }
 


### PR DESCRIPTION
Followup to #1118 . Bumps examples/contract-sdk oasis-cbor dependency to avoid compilation errors.