### PR TITLE
accounts: Check if 'to' address is reserved

### DIFF
--- a/cli/cmd/accounts.go
+++ b/cli/cmd/accounts.go
@@ -299,6 +299,11 @@ var (
 				cobra.CheckErr(err)
 			}
 
+			// Check, if to address is known to be unspendable.
+			if toAddr != nil {
+				cobra.CheckErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
+			}
+
 			// Parse amount.
 			// TODO: This should actually query the ParaTime (or config) to check what the consensus
 			//       layer denomination is in the ParaTime. Assume NATIVE for now.
@@ -401,6 +406,9 @@ var (
 
 			cobra.CheckErr(common.CheckLocalAccountIsConsensusCapable(cfg, addrToCheck))
 
+			// Check, if to address is known to be unspendable.
+			cobra.CheckErr(common.CheckAddressNotReserved(cfg, addrToCheck))
+
 			// Parse amount.
 			// TODO: This should actually query the ParaTime (or config) to check what the consensus
 			//       layer denomination is in the ParaTime. Assume NATIVE for now.
@@ -483,6 +491,9 @@ var (
 			// Resolve destination address.
 			toAddr, err := common.ResolveLocalAccountOrAddress(npa.Network, to)
 			cobra.CheckErr(err)
+
+			// Check, if to address is known to be unspendable.
+			cobra.CheckErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
 
 			acc := common.LoadAccount(cfg, npa.AccountName)
 


### PR DESCRIPTION
Fixes #1173.

This PR checks, if the 'to' address for Transfers, Withdrawals and Deposits is a known unspendable address:
  - reward pool address
  - common pool address
  - fee accumulator address
  - governance deposit address
  - native ParaTime address