### PR TITLE
[runtime-sdk] add txhash to Event

### DIFF
--- a/client-sdk/go/client/client.go
+++ b/client-sdk/go/client/client.go
@@ -337,7 +337,7 @@ func (rc *runtimeClient) GetTransactionsWithResults(ctx context.Context, round u
 
 		for _, rawEv := range raw.Events {
 			var ev types.Event
-			if err := ev.UnmarshalRaw(rawEv.Key, rawEv.Value); err != nil {
+			if err := ev.UnmarshalRaw(rawEv.Key, rawEv.Value, nil); err != nil {
 				continue
 			}
 
@@ -362,7 +362,7 @@ func (rc *runtimeClient) GetEventsRaw(ctx context.Context, round uint64) ([]*typ
 	evs := make([]*types.Event, len(rawEvs))
 	for i, rawEv := range rawEvs {
 		var ev types.Event
-		if err := ev.UnmarshalRaw(rawEv.Key, rawEv.Value); err != nil {
+		if err := ev.UnmarshalRaw(rawEv.Key, rawEv.Value, &rawEv.TxHash); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal event '%v': %w", rawEv, err)
 		}
 		evs[i] = &ev
@@ -385,7 +385,7 @@ func (rc *runtimeClient) GetEvents(ctx context.Context, round uint64, decoders [
 OUTER:
 	for _, rawEv := range rawEvs {
 		var ev types.Event
-		if err := ev.UnmarshalRaw(rawEv.Key, rawEv.Value); err != nil {
+		if err := ev.UnmarshalRaw(rawEv.Key, rawEv.Value, &rawEv.TxHash); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal event '%v': %w", rawEv, err)
 		}
 		for _, decoder := range decoders {

--- a/client-sdk/go/types/event.go
+++ b/client-sdk/go/types/event.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 )
 
 // Event is an event emitted by a runtime in the form of a runtime transaction tag.
@@ -13,10 +15,11 @@ type Event struct {
 	Module string
 	Code   uint32
 	Value  []byte
+	TxHash *hash.Hash
 }
 
 // UnmarshalRaw decodes the event from a raw key/value pair.
-func (ev *Event) UnmarshalRaw(key, value []byte) error {
+func (ev *Event) UnmarshalRaw(key, value []byte, txHash *hash.Hash) error {
 	if len(key) < 4 {
 		return fmt.Errorf("malformed event key")
 	}
@@ -24,6 +27,7 @@ func (ev *Event) UnmarshalRaw(key, value []byte) error {
 	ev.Module = string(key[:len(key)-4])
 	ev.Code = binary.BigEndian.Uint32(key[len(key)-4:])
 	ev.Value = value
+	ev.TxHash = txHash
 	return nil
 }
 

--- a/client-sdk/go/types/event_test.go
+++ b/client-sdk/go/types/event_test.go
@@ -4,26 +4,29 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEventUnmarshal(t *testing.T) {
 	require := require.New(t)
 
+	txHash1 := hash.NewFromBytes([]byte("my-hash-1"))
 	for _, tc := range []struct {
 		key      string
 		value    string
+		txhash   hash.Hash
 		ok       bool
 		expected *Event
 		msg      string
 	}{
-		{"", "", false, nil, "should fail on empty key/value"},
-		{"00", "", false, nil, "should fail on too small key"},
-		{"0000", "", false, nil, "should fail on too small key"},
-		{"000000", "", false, nil, "should fail on too small key"},
-		{"00000001", "", true, &Event{Module: "", Code: 1, Value: []byte{}}, "should succeed without module"},
-		{"666f6f00000002", "", true, &Event{Module: "foo", Code: 2, Value: []byte{}}, "should succeed"},
-		{"666f6f00000003", "ffff", true, &Event{Module: "foo", Code: 3, Value: []byte{0xff, 0xff}}, "should succeed"},
+		{"", "", txHash1, false, nil, "should fail on empty key/value"},
+		{"00", "", txHash1, false, nil, "should fail on too small key"},
+		{"0000", "", txHash1, false, nil, "should fail on too small key"},
+		{"000000", "", txHash1, false, nil, "should fail on too small key"},
+		{"00000001", "", txHash1, true, &Event{Module: "", Code: 1, Value: []byte{}, TxHash: &txHash1}, "should succeed without module"},
+		{"666f6f00000002", "", txHash1, true, &Event{Module: "foo", Code: 2, Value: []byte{}, TxHash: &txHash1}, "should succeed"},
+		{"666f6f00000003", "ffff", txHash1, true, &Event{Module: "foo", Code: 3, Value: []byte{0xff, 0xff}, TxHash: &txHash1}, "should succeed"},
 	} {
 		key, err := hex.DecodeString(tc.key)
 		require.NoError(err)
@@ -31,7 +34,7 @@ func TestEventUnmarshal(t *testing.T) {
 		require.NoError(err)
 
 		var ev Event
-		err = ev.UnmarshalRaw(key, value)
+		err = ev.UnmarshalRaw(key, value, &tc.txhash)
 		switch tc.ok {
 		case false:
 			require.Error(err, tc.msg)


### PR DESCRIPTION
Adds the related tx hash, if it exists, to runtime events returned by the runtime client.

Open questions: Do we need to support `evm` and `contracts` modules? Do those events have a related transaction? If yes, how do we want to update the `evm.Event` and `contracts.Event` without breaking the api? (Currently they are cbor-unmarshalled directly so updating the `Event` is not possible. Ideally we would wrap the event in a larger struct similar to the other modules, but this seems like a breaking change)

Edit**: We will leave the module level `Event`s unchanged.