### PR TITLE
runtime-sdk: Allow custom modules to expose call result error

### DIFF
--- a/runtime-sdk/modules/evm/src/lib.rs
+++ b/runtime-sdk/modules/evm/src/lib.rs
@@ -711,10 +711,11 @@ impl<Cfg: Config> Module<Cfg> {
                 message: e.to_string(),
             },
         };
-        Ok(cbor::to_vec(callformat::encode_result(
+        Ok(cbor::to_vec(callformat::encode_result_ex(
             ctx,
             call_result,
             tx_metadata,
+            true,
         )))
     }
 }

--- a/tests/e2e/evmtest.go
+++ b/tests/e2e/evmtest.go
@@ -930,6 +930,9 @@ func evmSuicideTest(log *logging.Logger, rtc client.RuntimeClient, c10l c10lity)
 		return fmt.Errorf("suicide method call should fail")
 	case strings.Contains(err.Error(), "SELFDESTRUCT not supported"):
 		// Expected error message.
+		if !strings.Contains(err.Error(), "module: evm code: 2") {
+			return fmt.Errorf("error should include module and evm code: %w", err)
+		}
 	default:
 		return fmt.Errorf("unexpected suicide call error: %w", err)
 	}


### PR DESCRIPTION
#### Goal
https://app.clickup.com/t/3c16qd5
https://app.clickup.com/t/863g4tpv3

#### Details
Allow modules to customize the disclosure of failures in the pursuit of improved development environment.

_Note_. This is a backwards compatible change and the default is still encryption.

#### TODO
- [x] Add `expose_failure` flag
- [x] Figure out merge/release steps. Presuming a bump on this dependency.