### PR TITLE
client-sdk: Add Context helpers for encoding Metadata used by hw wallets

### DIFF
--- a/client-sdk/go/client/client.go
+++ b/client-sdk/go/client/client.go
@@ -169,8 +169,12 @@ func (rc *runtimeClient) GetInfo(ctx context.Context) (*types.RuntimeInfo, error
 	}
 
 	rc.runtimeInfo = &types.RuntimeInfo{
-		ID:           rc.runtimeID,
-		ChainContext: signature.DeriveChainContext(rc.runtimeID, chainCtx),
+		ID: rc.runtimeID,
+		ChainContext: &signature.RichContext{
+			RuntimeID:    rc.runtimeID,
+			ChainContext: chainCtx,
+			Base:         types.SignatureContextBase,
+		},
 	}
 	return rc.runtimeInfo, nil
 }

--- a/client-sdk/go/crypto/signature/context.go
+++ b/client-sdk/go/crypto/signature/context.go
@@ -1,27 +1,81 @@
 package signature
 
 import (
+	"encoding/hex"
+
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
 const chainContextSeparator = " for chain "
 
-// Context is the chain domain separation context.
-type Context string
+// Context is the interface used to derive the chain domain separation context.
+type Context interface {
+	// Derive derives the chain domain separation context used for signing transactions.
+	Derive() []byte
+}
 
-func (c Context) New(base []byte) []byte {
-	ctx := append([]byte{}, base...)
+// RawContext is chain domain separation which can be directly used for signing.
+type RawContext []byte
+
+// Derive derives the chain domain separation context used for signing transactions.
+func (rc RawContext) Derive() []byte {
+	return rc
+}
+
+// RichContext stores runtime ID, consensus chain context and optional
+// transaction-specific details.
+type RichContext struct {
+	// RuntimeID used for deriving the signature context.
+	RuntimeID common.Namespace
+
+	// ChainContext used for deriving the signature context.
+	ChainContext string
+
+	// Base contains chain context separator base.
+	Base []byte
+
+	// TxDetails contains optional transaction-specific details.
+	TxDetails *TxDetails
+}
+
+// Derive derives the chain domain separation context used for signing transactions.
+func (sc *RichContext) Derive() []byte {
+	ctx := append([]byte{}, sc.Base...)
 	ctx = append(ctx, []byte(chainContextSeparator)...)
+
+	c := hash.NewFromBytes(
+		sc.RuntimeID[:],
+		[]byte(sc.ChainContext),
+	).String()
 	ctx = append(ctx, []byte(c)...)
+
 	return ctx
 }
 
-// DeriveChainContext derives the chain domain separation context for a given runtime.
-func DeriveChainContext(runtimeID common.Namespace, consensusChainContext string) Context {
-	rawRuntimeID, _ := runtimeID.MarshalBinary()
-	return Context(hash.NewFromBytes(
-		rawRuntimeID,
-		[]byte(consensusChainContext),
-	).String())
+// TxDetails contains transaction-specific details.
+type TxDetails struct {
+	OrigTo *ethCommon.Address
+}
+
+// HwContext is ADR 14-compatible struct appropriate for CBOR encoding as Meta component.
+type HwContext struct {
+	RuntimeID    string `json:"runtime_id"`
+	ChainContext string `json:"chain_context"`
+	OrigTo       string `json:"orig_to,omitempty"`
+}
+
+// NewHwContext creates a new hardware-wallet context from in-memory Context object.
+func NewHwContext(sc *RichContext) *HwContext {
+	origTo := ""
+	if sc.TxDetails != nil && sc.TxDetails.OrigTo != nil {
+		origTo = hex.EncodeToString(sc.TxDetails.OrigTo.Bytes())
+	}
+	return &HwContext{
+		RuntimeID:    sc.RuntimeID.Hex(),
+		ChainContext: sc.ChainContext,
+		OrigTo:       origTo,
+	}
 }

--- a/client-sdk/go/crypto/signature/context_test.go
+++ b/client-sdk/go/crypto/signature/context_test.go
@@ -14,9 +14,10 @@ func TestDeriveChainContext(t *testing.T) {
 	var runtimeID common.Namespace
 	_ = runtimeID.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000")
 
-	chainCtx := DeriveChainContext(runtimeID, "643fb06848be7e970af3b5b2d772eb8cfb30499c8162bc18ac03df2f5e22520e")
-	require.Equal("ca4842870b97a6d5c0d025adce0b6a0dec94d2ba192ede70f96349cfbe3628b9", string(chainCtx))
-
-	ctx1 := chainCtx.New([]byte("oasis-runtime-sdk/tx: v0"))
-	require.Equal("oasis-runtime-sdk/tx: v0 for chain ca4842870b97a6d5c0d025adce0b6a0dec94d2ba192ede70f96349cfbe3628b9", string(ctx1))
+	ctx := RichContext{
+		RuntimeID:    runtimeID,
+		ChainContext: "643fb06848be7e970af3b5b2d772eb8cfb30499c8162bc18ac03df2f5e22520e",
+		Base:         []byte("oasis-runtime-sdk/tx: v0"),
+	}
+	require.Equal("oasis-runtime-sdk/tx: v0 for chain ca4842870b97a6d5c0d025adce0b6a0dec94d2ba192ede70f96349cfbe3628b9", string(ctx.Derive()))
 }

--- a/client-sdk/go/crypto/signature/ed25519/signer.go
+++ b/client-sdk/go/crypto/signature/ed25519/signer.go
@@ -16,8 +16,8 @@ func (w wrappedSigner) Public() signature.PublicKey {
 	return PublicKey(w.signer.Public())
 }
 
-func (w wrappedSigner) ContextSign(context, message []byte) ([]byte, error) {
-	return w.signer.ContextSign(coreSignature.Context(context), message)
+func (w wrappedSigner) ContextSign(context signature.Context, message []byte) ([]byte, error) {
+	return w.signer.ContextSign(coreSignature.Context(context.Derive()), message)
 }
 
 func (w wrappedSigner) Sign(message []byte) ([]byte, error) {

--- a/client-sdk/go/crypto/signature/secp256k1/secp256k1.go
+++ b/client-sdk/go/crypto/signature/secp256k1/secp256k1.go
@@ -71,7 +71,7 @@ func (pk PublicKey) Verify(context, message, signature []byte) bool {
 	if err != nil {
 		return false
 	}
-	data, err := PrepareSignerMessage(sdkSignature.Context(context), message)
+	data, err := PrepareSignerMessage(context, message)
 	if err != nil {
 		return false
 	}

--- a/client-sdk/go/crypto/signature/secp256k1/signer.go
+++ b/client-sdk/go/crypto/signature/secp256k1/signer.go
@@ -19,8 +19,8 @@ func (s Signer) Public() sdkSignature.PublicKey {
 	return PublicKey(*s.privateKey.PubKey())
 }
 
-func (s Signer) ContextSign(context, message []byte) ([]byte, error) {
-	data, err := PrepareSignerMessage(sdkSignature.Context(context), message)
+func (s Signer) ContextSign(context sdkSignature.Context, message []byte) ([]byte, error) {
+	data, err := PrepareSignerMessage(context.Derive(), message)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func NewSigner(pk []byte) sdkSignature.Signer {
 }
 
 // PrepareSignerMessage prepares a context and message for signing by a Signer.
-func PrepareSignerMessage(context sdkSignature.Context, message []byte) ([]byte, error) {
-	h := hash.NewFromBytes([]byte(context), message)
+func PrepareSignerMessage(context, message []byte) ([]byte, error) {
+	h := hash.NewFromBytes(context, message)
 	return h.MarshalBinary()
 }

--- a/client-sdk/go/crypto/signature/signer.go
+++ b/client-sdk/go/crypto/signature/signer.go
@@ -8,7 +8,7 @@ type Signer interface {
 
 	// ContextSign generates a signature with the private key over the context and
 	// message.
-	ContextSign(context, message []byte) ([]byte, error)
+	ContextSign(context Context, message []byte) ([]byte, error)
 
 	// Sign generates a signature with the private key over the message only.
 	Sign(message []byte) ([]byte, error)

--- a/client-sdk/go/crypto/signature/sr25519/signer.go
+++ b/client-sdk/go/crypto/signature/sr25519/signer.go
@@ -18,8 +18,8 @@ func (s *signer) Public() signature.PublicKey {
 	}
 }
 
-func (s *signer) ContextSign(context, message []byte) ([]byte, error) {
-	transcript := newSigningTranscript(context, message)
+func (s *signer) ContextSign(context signature.Context, message []byte) ([]byte, error) {
+	transcript := newSigningTranscript(context.Derive(), message)
 
 	sig, err := s.keyPair.Sign(nil, transcript)
 	if err != nil {

--- a/client-sdk/go/helpers/address_test.go
+++ b/client-sdk/go/helpers/address_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"testing"
 
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
@@ -23,32 +24,36 @@ func TestResolveAddress(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		address  string
-		expected string
+		address         string
+		expectedAddr    string
+		expectedEthAddr string
 	}{
-		{"", ""},
-		{"oasis1", ""},
-		{"oasis1blah", ""},
-		{"oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", "oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz"},
-		{"0x", ""},
-		{"0xblah", ""},
-		{"0x60a6321eA71d37102Dbf923AAe2E08d005C4e403", "oasis1qpaqumrpewltmh9mr73hteycfzveus2rvvn8w5sp"},
-		{"paratime:", ""},
-		{"paratime:invalid", ""},
-		{"paratime:pt1", "oasis1qqdn25n5a2jtet2s5amc7gmchsqqgs4j0qcg5k0t"},
-		{"pool:", ""},
-		{"pool:invalid", ""},
-		{"pool:rewards", "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav"},
-		{"test:alice", "oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve"},
-		{"test:dave", "oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt"},
-		{"test:frank", "oasis1qqnf0s9p8z79zfutszt0hwlh7w7jjrfqnq997mlw"},
-		{"test:invalid", ""},
-		{"invalid:", ""},
+		{"", "", ""},
+		{"oasis1", "", ""},
+		{"oasis1blah", "", ""},
+		{"oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", "oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", ""},
+		{"0x", "", ""},
+		{"0xblah", "", ""},
+		{"0x60a6321eA71d37102Dbf923AAe2E08d005C4e403", "oasis1qpaqumrpewltmh9mr73hteycfzveus2rvvn8w5sp", "0x60a6321eA71d37102Dbf923AAe2E08d005C4e403"},
+		{"paratime:", "", ""},
+		{"paratime:invalid", "", ""},
+		{"paratime:pt1", "oasis1qqdn25n5a2jtet2s5amc7gmchsqqgs4j0qcg5k0t", ""},
+		{"pool:", "", ""},
+		{"pool:invalid", "", ""},
+		{"pool:rewards", "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav", ""},
+		{"test:alice", "oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve", ""},
+		{"test:dave", "oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt", "0xDce075E1C39b1ae0b75D554558b6451A226ffe00"},
+		{"test:frank", "oasis1qqnf0s9p8z79zfutszt0hwlh7w7jjrfqnq997mlw", ""},
+		{"test:invalid", "", ""},
+		{"invalid:", "", ""},
 	} {
-		addr, err := ResolveAddress(&net, tc.address)
-		if len(tc.expected) > 0 {
+		addr, ethAddr, err := ResolveAddress(&net, tc.address)
+		if len(tc.expectedAddr) > 0 {
 			require.NoError(err, tc.address)
-			require.EqualValues(tc.expected, addr.String(), tc.address)
+			require.EqualValues(tc.expectedAddr, addr.String(), tc.address)
+			if len(tc.expectedEthAddr) > 0 {
+				require.EqualValues(tc.expectedEthAddr, ethAddr.String())
+			}
 		} else {
 			require.Error(err, tc.address)
 		}
@@ -84,6 +89,6 @@ func TestEthAddressFromPubKey(t *testing.T) {
 	} {
 		pubkey := secp256k1.PublicKey{}
 		_ = pubkey.UnmarshalText([]byte(pk.pubkey))
-		require.Equal(t, pk.address, EthAddressFromPubKey(pubkey))
+		require.Equal(t, ethCommon.HexToAddress(pk.address), EthAddressFromPubKey(pubkey))
 	}
 }

--- a/client-sdk/go/types/transaction.go
+++ b/client-sdk/go/types/transaction.go
@@ -62,7 +62,7 @@ func (ut *UnverifiedTransaction) Verify(ctx signature.Context) (*Transaction, er
 	}
 
 	// Verify all signatures.
-	txCtx := ctx.New(SignatureContextBase)
+	txCtx := ctx.Derive()
 	// We'll need at least one signature per proof, so we might as well preallocate that.
 	// Could be more though.
 	publicKeys := make([]PublicKey, 0, len(ut.AuthProofs))
@@ -121,7 +121,7 @@ func (ts *TransactionSigner) AppendSign(ctx signature.Context, signer signature.
 
 			any = true
 			ts.allocateProofs()
-			sig, err := signer.ContextSign(ctx.New(SignatureContextBase), ts.ut.Body)
+			sig, err := signer.ContextSign(ctx, ts.ut.Body)
 			if err != nil {
 				return fmt.Errorf("signer info %d: failed to sign transaction: %w", i, err)
 			}
@@ -134,7 +134,7 @@ func (ts *TransactionSigner) AppendSign(ctx signature.Context, signer signature.
 
 				any = true
 				ts.allocateProofs()
-				sig, err := signer.ContextSign(ctx.New(SignatureContextBase), ts.ut.Body)
+				sig, err := signer.ContextSign(ctx, ts.ut.Body)
 				if err != nil {
 					return fmt.Errorf("signer info %d: failed to sign transaction: %w", i, err)
 				}

--- a/client-sdk/go/types/transaction_test.go
+++ b/client-sdk/go/types/transaction_test.go
@@ -63,7 +63,11 @@ func TestTransactionSigning(t *testing.T) {
 	var runtimeID common.Namespace
 	_ = runtimeID.UnmarshalHex("8000000000000000000000000000000000000000000000000000000000000000")
 
-	chainCtx := signature.DeriveChainContext(runtimeID, "0000000000000000000000000000000000000000000000000000000000000001")
+	chainCtx := &signature.RichContext{
+		RuntimeID:    runtimeID,
+		ChainContext: "0000000000000000000000000000000000000000000000000000000000000001",
+		Base:         SignatureContextBase,
+	}
 
 	ts := tx.PrepareForSigning()
 	err = ts.AppendSign(chainCtx, signer)

--- a/tests/e2e/simplekvtest.go
+++ b/tests/e2e/simplekvtest.go
@@ -114,7 +114,7 @@ func sigspecForSigner(signer signature.Signer) types.SignatureAddressSpec {
 func GetChainContext(ctx context.Context, rtc client.RuntimeClient) (signature.Context, error) {
 	info, err := rtc.GetInfo(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return info.ChainContext, nil
 }
@@ -303,7 +303,8 @@ func kvInsertSpecialGreeting(rtc client.RuntimeClient, signer signature.Signer, 
 		Nonce:    nonce,
 		Greeting: greeting,
 	})
-	sig, err := signer.ContextSign([]byte("oasis-runtime-sdk-test/simplekv-special-greeting: v0"), paramsCBOR)
+	sigCtx := signature.RawContext("oasis-runtime-sdk-test/simplekv-special-greeting: v0")
+	sig, err := signer.ContextSign(sigCtx, paramsCBOR)
 	if err != nil {
 		return fmt.Errorf("signing special greeting: %w", err)
 	}

--- a/tests/e2e/txgen/txgen.go
+++ b/tests/e2e/txgen/txgen.go
@@ -71,7 +71,7 @@ func NewClient(clientNodeUnixSocketPath string, runtimeID common.Namespace) (cli
 func GetChainContext(ctx context.Context, rtc client.RuntimeClient) (signature.Context, error) {
 	info, err := rtc.GetInfo(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return info.ChainContext, nil
 }

--- a/tools/gen_runtime_vectors/README.md
+++ b/tools/gen_runtime_vectors/README.md
@@ -12,19 +12,19 @@ array of objects (test vectors). Each test vector has the following fields:
   given test vector is describing (e.g., `"oasis-sdk runtime test vectors:
   consensus.Deposit"`).
 
+* `meta` are meta-data sent to the hardware wallet containing `runtime_id`,
+  `chain_context` and optional `orig_to` field. `runtime_id` and
+  `chain_context` are used by the hardware wallet to compute the [domain
+  separation context] needed to sign the transaction. Check [chain context
+  derivation] code for more information. `orig_to` is used by the hardware
+  wallet to show a human-readable Ethereum address, because the transaction
+  itself only contains the oasis native address.
+
 * `tx` is the human-readable _interpreted_ unsigned transaction. Its purpose is
   to make it easier for the developer to understand what the content of the
   transaction is. For example `call.body` is represented as a readable JSON
   while in the encoded transaction this would be CBOR-encoded blob or an
   encrypted content.
-
-* `meta` are meta-data sent to the hardware wallet containing `sig_context`,
-  `runtime_id`, `chain_context` and optional `orig_to` field. `sig_context` is
-  the [domain separation context] used for signing the transaction derived
-  from `runtime_id` and `chain_context`. Check [chain context derivation] code
-  for more information. `orig_to` is used by the hardware wallet to show a
-  human-readable Ethereum address, because the transaction itself only contains
-  the oasis native address.
 
 * `signed_tx` is the human-readable signed transaction to make it easier for the
   developer to understand how the `call.body` and `ai` fields looks like in

--- a/tools/gen_runtime_vectors/testvectors.go
+++ b/tools/gen_runtime_vectors/testvectors.go
@@ -21,11 +21,12 @@ var chainContext hash.Hash
 type RuntimeTestVector struct {
 	Kind string      `json:"kind"`
 	Tx   interface{} `json:"tx"`
-	// Meta stores tx-specific information needed to compute
+	// Meta stores transaction-specific information needed to compute
 	// sig_context and to verify the recipient's address.
 	// e.g. For EVM transactions the user needs to see the ethereum-formatted recipient on
-	// Ledger and Ledger needs to verify that the shown address really maps to Tx.Body.To.
-	Meta interface{} `json:"meta"`
+	// hardware wallet and the firmware needs to verify that the shown address really maps
+	// to Tx.Body.To.
+	Meta signature.HwContext `json:"meta"`
 	// Expected signature context derived from Meta.runtime_id and Meta.chain_context.
 	SigCtx          string                      `json:"sig_context"`
 	SignedTx        types.UnverifiedTransaction `json:"signed_tx"`
@@ -45,17 +46,8 @@ func init() {
 	chainContext.FromBytes([]byte(chainContextSeed))
 }
 
-// MakeMeta creates a meta field for the test vector.
-func MakeMeta(runtimeId string, chainContext string) map[string]string {
-	return map[string]string{
-		"runtime_id":    runtimeId,
-		"chain_context": chainContext,
-	}
-
-}
-
 // MakeRuntimeTestVector generates a new test vector from a transaction using a specific signer.
-func MakeRuntimeTestVector(tx *types.Transaction, txBody interface{}, meta interface{}, valid bool, w testing.TestKey, nonce uint64, sigCtx signature.Context) RuntimeTestVector {
+func MakeRuntimeTestVector(tx *types.Transaction, txBody interface{}, sigCtx *signature.RichContext, valid bool, w testing.TestKey, nonce uint64) RuntimeTestVector {
 	tx.AppendAuthSignature(w.SigSpec, nonce)
 
 	// Sign the transaction.
@@ -74,11 +66,12 @@ func MakeRuntimeTestVector(tx *types.Transaction, txBody interface{}, meta inter
 		prettyMethod = tx.Call.Method
 	}
 
+	meta := signature.NewHwContext(sigCtx)
 	return RuntimeTestVector{
 		Kind:             keySeedPrefix + prettyMethod,
 		Tx:               prettyTx,
-		Meta:             meta,
-		SigCtx:           string(sigCtx.New(types.SignatureContextBase)),
+		Meta:             *meta,
+		SigCtx:           string(sigCtx.Derive()),
 		SignedTx:         *sigTx,
 		EncodedTx:        ts.UnverifiedTransaction().Body,
 		EncodedMeta:      cbor.Marshal(meta),


### PR DESCRIPTION
- Adds helpers for encoding the new `Meta` object used by Ledger for signing runtime transactions.
- BREAKING: Refactoring of `resolveAddress()` and `signature.Signer.ContextSign`