### PR TITLE
PrettyPrinter for runtime txes

### DIFF
--- a/client-sdk/go/client/client.go
+++ b/client-sdk/go/client/client.go
@@ -87,7 +87,7 @@ type RuntimeClient interface {
 	WatchEvents(ctx context.Context, decoders []EventDecoder, includeUndecoded bool) (<-chan *BlockEvents, error)
 
 	// Query makes a runtime-specific query.
-	Query(ctx context.Context, round uint64, method string, args, rsp interface{}) error
+	Query(ctx context.Context, round uint64, method types.MethodName, args, rsp interface{}) error
 }
 
 // EventDecoder is an event decoder interface.
@@ -448,11 +448,11 @@ func (rc *runtimeClient) WatchEvents(ctx context.Context, decoders []EventDecode
 }
 
 // Implements RuntimeClient.
-func (rc *runtimeClient) Query(ctx context.Context, round uint64, method string, args, rsp interface{}) error {
+func (rc *runtimeClient) Query(ctx context.Context, round uint64, method types.MethodName, args, rsp interface{}) error {
 	raw, err := rc.cc.Query(ctx, &coreClient.QueryRequest{
 		RuntimeID: rc.runtimeID,
 		Round:     round,
-		Method:    method,
+		Method:    string(method),
 		Args:      cbor.Marshal(args),
 	})
 	if err != nil {

--- a/client-sdk/go/client/transaction.go
+++ b/client-sdk/go/client/transaction.go
@@ -20,7 +20,7 @@ type TransactionBuilder struct {
 }
 
 // NewTransactionBuilder creates a new transaction builder.
-func NewTransactionBuilder(rc RuntimeClient, method string, body interface{}) *TransactionBuilder {
+func NewTransactionBuilder(rc RuntimeClient, method types.MethodName, body interface{}) *TransactionBuilder {
 	return &TransactionBuilder{
 		rc: rc,
 		tx: types.NewTransaction(nil, method, body),

--- a/client-sdk/go/config/paratime.go
+++ b/client-sdk/go/config/paratime.go
@@ -4,11 +4,17 @@ import (
 	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-// NativeDenominationKey is the key used to signify the native denomination.
-const NativeDenominationKey = "_"
+type contextKey string
+
+const (
+	// NativeDenominationKey is the key used to signify the native denomination.
+	NativeDenominationKey = "_"
+
+	// ContextKeyParaTimeCfg is the key to retrieve the current ParaTime config from a context.
+	ContextKeyParaTimeCfg = contextKey("runtime/paratime-cfg")
+)
 
 // ParaTimes contains the configuration of supported paratimes.
 type ParaTimes struct {
@@ -145,12 +151,12 @@ func (p *ParaTime) Namespace() common.Namespace {
 // GetDenominationInfo returns the denomination information for the given denomination.
 //
 // In case the given denomination does not exist, it provides sane defaults.
-func (p *ParaTime) GetDenominationInfo(d types.Denomination) *DenominationInfo {
+func (p *ParaTime) GetDenominationInfo(d string) *DenominationInfo {
 	var di *DenominationInfo
-	if d.IsNative() {
+	if len(d) == 0 {
 		di = p.Denominations[NativeDenominationKey]
 	} else {
-		di = p.Denominations[string(d)]
+		di = p.Denominations[d]
 	}
 
 	if di != nil {
@@ -159,6 +165,6 @@ func (p *ParaTime) GetDenominationInfo(d types.Denomination) *DenominationInfo {
 
 	return &DenominationInfo{
 		Decimals: 9,
-		Symbol:   string(d),
+		Symbol:   d,
 	}
 }

--- a/client-sdk/go/crypto/signature/context.go
+++ b/client-sdk/go/crypto/signature/context.go
@@ -9,7 +9,15 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
-const chainContextSeparator = " for chain "
+type contextKey string
+
+const (
+	chainContextSeparator = " for chain "
+
+	// ContextKeySigContext is the key to retrieve the transaction's signature context object from a
+	// context.
+	ContextKeySigContext = contextKey("runtime/signature-context")
+)
 
 // Context is the interface used to derive the chain domain separation context.
 type Context interface {

--- a/client-sdk/go/helpers/denomination.go
+++ b/client-sdk/go/helpers/denomination.go
@@ -21,7 +21,7 @@ func ParseConsensusDenomination(net *config.Network, amount string) (*types.Quan
 
 // ParseParaTimeDenomination parses an amount for the given ParaTime denomination.
 func ParseParaTimeDenomination(pt *config.ParaTime, amount string, denom types.Denomination) (*types.BaseUnits, error) {
-	return parseDenomination(pt.GetDenominationInfo(denom), amount, denom)
+	return parseDenomination(pt.GetDenominationInfo(string(denom)), amount, denom)
 }
 
 func parseDenomination(di *config.DenominationInfo, amount string, denom types.Denomination) (*types.BaseUnits, error) {
@@ -47,7 +47,7 @@ func FormatConsensusDenomination(net *config.Network, amount types.Quantity) str
 
 // FormatParaTimeDenomination formats the given base unit amount as a ParaTime denomination.
 func FormatParaTimeDenomination(pt *config.ParaTime, amount types.BaseUnits) string {
-	return formatDenomination(pt.GetDenominationInfo(amount.Denomination), amount.Amount)
+	return formatDenomination(pt.GetDenominationInfo(string(amount.Denomination)), amount.Amount)
 }
 
 func formatDenomination(di *config.DenominationInfo, amount types.Quantity) string {

--- a/client-sdk/go/modules/accounts/accounts.go
+++ b/client-sdk/go/modules/accounts/accounts.go
@@ -10,16 +10,16 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
+var (
 	// Callable methods.
-	methodTransfer = "accounts.Transfer"
+	methodTransfer = types.NewMethodName("accounts.Transfer", Transfer{})
 
 	// Queries.
-	methodParameters       = "accounts.Parameters"
-	methodNonce            = "accounts.Nonce"
-	methodBalances         = "accounts.Balances"
-	methodAddresses        = "accounts.Addresses"
-	methodDenominationInfo = "accounts.DenominationInfo"
+	methodParameters       = types.NewMethodName("accounts.Parameters", nil)
+	methodNonce            = types.NewMethodName("accounts.Nonce", NonceQuery{})
+	methodBalances         = types.NewMethodName("accounts.Balances", BalancesQuery{})
+	methodAddresses        = types.NewMethodName("accounts.Addresses", AddressesQuery{})
+	methodDenominationInfo = types.NewMethodName("accounts.DenominationInfo", DenominationInfoQuery{})
 )
 
 // V1 is the v1 accounts module interface.

--- a/client-sdk/go/modules/accounts/types.go
+++ b/client-sdk/go/modules/accounts/types.go
@@ -1,6 +1,9 @@
 package accounts
 
 import (
+	"context"
+	"io"
+
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
@@ -8,6 +11,16 @@ import (
 type Transfer struct {
 	To     types.Address   `json:"to"`
 	Amount types.BaseUnits `json:"amount"`
+}
+
+// PrettyPrint writes a pretty-printed representation of the transaction to the given writer.
+func (f *Transfer) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	types.PrettyPrintToAmount(ctx, prefix, w, &f.To, f.Amount)
+}
+
+// PrettyType returns a representation of the type that can be used for pretty printing.
+func (f *Transfer) PrettyType() (interface{}, error) {
+	return f, nil
 }
 
 // NonceQuery are the arguments for the accounts.Nonce query.

--- a/client-sdk/go/modules/consensus/consensus.go
+++ b/client-sdk/go/modules/consensus/consensus.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
-	// Queries.
-	methodParameters = "consensus.Parameters"
-)
+// Queries.
+var methodParameters = types.NewMethodName("consensus.Parameters", nil)
 
 // V1 is the v1 consensus module interface.
 type V1 interface {

--- a/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
+++ b/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
@@ -11,15 +11,15 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
+var (
 	// Callable methods.
-	methodDeposit  = "consensus.Deposit"
-	methodWithdraw = "consensus.Withdraw"
+	methodDeposit  = types.NewMethodName("consensus.Deposit", Deposit{})
+	methodWithdraw = types.NewMethodName("consensus.Withdraw", Withdraw{})
 
 	// Queries.
-	methodParameters = "consensus_accounts.Parameters"
-	methodBalance    = "consensus.Balance"
-	methodAccount    = "consensus.Account"
+	methodParameters = types.NewMethodName("consensus_accounts.Parameters", nil)
+	methodBalance    = types.NewMethodName("consensus.Balance", BalanceQuery{})
+	methodAccount    = types.NewMethodName("consensus.Account", AccountQuery{})
 )
 
 // V1 is the v1 consensus accounts module interface.

--- a/client-sdk/go/modules/consensusaccounts/types.go
+++ b/client-sdk/go/modules/consensusaccounts/types.go
@@ -1,6 +1,11 @@
 package consensusaccounts
 
-import "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+import (
+	"context"
+	"io"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
 
 // Deposit are the arguments for consensus.Deposit method.
 type Deposit struct {
@@ -8,10 +13,30 @@ type Deposit struct {
 	Amount types.BaseUnits `json:"amount"`
 }
 
+// PrettyPrint writes a pretty-printed representation of the transaction to the given writer.
+func (f *Deposit) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	types.PrettyPrintToAmount(ctx, prefix, w, f.To, f.Amount)
+}
+
+// PrettyType returns a representation of the type that can be used for pretty printing.
+func (f *Deposit) PrettyType() (interface{}, error) {
+	return f, nil
+}
+
 // Withdraw are the arguments for consensus.Withdraw method.
 type Withdraw struct {
 	To     *types.Address  `json:"to,omitempty"`
 	Amount types.BaseUnits `json:"amount"`
+}
+
+// PrettyPrint writes a pretty-printed representation of the transaction to the given writer.
+func (f *Withdraw) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	types.PrettyPrintToAmount(ctx, prefix, w, f.To, f.Amount)
+}
+
+// PrettyType returns a representation of the type that can be used for pretty printing.
+func (f *Withdraw) PrettyType() (interface{}, error) {
+	return f, nil
 }
 
 // BalanceQuery are the arguments for consensus.Balance method.

--- a/client-sdk/go/modules/contracts/contracts.go
+++ b/client-sdk/go/modules/contracts/contracts.go
@@ -14,23 +14,23 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
+var (
 	// Callable methods.
-	methodUpload              = "contracts.Upload"
-	methodInstantiate         = "contracts.Instantiate"
-	methodCall                = "contracts.Call"
-	methodUpgrade             = "contracts.Upgrade"
-	methodChangeUpgradePolicy = "contracts.ChangeUpgradePolicy"
+	methodUpload              = types.NewMethodName("contracts.Upload", Upload{})
+	methodInstantiate         = types.NewMethodName("contracts.Instantiate", Instantiate{})
+	methodCall                = types.NewMethodName("contracts.Call", Call{})
+	methodUpgrade             = types.NewMethodName("contracts.Upgrade", Upgrade{})
+	methodChangeUpgradePolicy = types.NewMethodName("contracts.ChangeUpgradePolicy", ChangeUpgradePolicy{})
 
 	// Queries.
-	methodCode               = "contracts.Code"
-	methodCodeStorage        = "contracts.CodeStorage"
-	methodInstance           = "contracts.Instance"
-	methodInstanceStorage    = "contracts.InstanceStorage"
-	methodInstanceRawStorage = "contracts.InstanceRawStorage"
-	methodPublicKey          = "contracts.PublicKey"
-	methodCustom             = "contracts.Custom"
-	methodParameters         = "contracts.Parameters"
+	methodCode               = types.NewMethodName("contracts.Code", CodeQuery{})
+	methodCodeStorage        = types.NewMethodName("contracts.CodeStorage", CodeStorageQuery{})
+	methodInstance           = types.NewMethodName("contracts.Instance", InstanceQuery{})
+	methodInstanceStorage    = types.NewMethodName("contracts.InstanceStorage", InstanceStorageQuery{})
+	methodInstanceRawStorage = types.NewMethodName("contracts.InstanceRawStorage", InstanceRawStorageQuery{})
+	methodPublicKey          = types.NewMethodName("contracts.PublicKey", PublicKeyQuery{})
+	methodCustom             = types.NewMethodName("contracts.Custom", CustomQuery{})
+	methodParameters         = types.NewMethodName("contracts.Parameters", nil)
 )
 
 // V1 is the v1 contracts module interface.

--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -10,14 +10,14 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
+var (
 	// Queries.
-	methodParameters        = "core.Parameters"
-	methodEstimateGas       = "core.EstimateGas"
-	methodMinGasPrice       = "core.MinGasPrice"
-	methodRuntimeInfo       = "core.RuntimeInfo"
-	methodCallDataPublicKey = "core.CallDataPublicKey"
-	methodExecuteReadOnlyTx = "core.ExecuteReadOnlyTx"
+	methodParameters        = types.NewMethodName("core.Parameters", nil)
+	methodEstimateGas       = types.NewMethodName("core.EstimateGas", EstimateGasQuery{})
+	methodMinGasPrice       = types.NewMethodName("core.MinGasPrice", nil)
+	methodRuntimeInfo       = types.NewMethodName("core.RuntimeInfo", nil)
+	methodCallDataPublicKey = types.NewMethodName("core.CallDataPublicKey", nil)
+	methodExecuteReadOnlyTx = types.NewMethodName("core.ExecuteReadOnlyTx", ExecuteReadOnlyTxQuery{})
 )
 
 // V1 is the v1 core module interface.

--- a/client-sdk/go/modules/evm/evm.go
+++ b/client-sdk/go/modules/evm/evm.go
@@ -10,17 +10,17 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
+var (
 	// Callable methods.
-	methodCreate = "evm.Create"
-	methodCall   = "evm.Call"
+	methodCreate = types.NewMethodName("evm.Create", Create{})
+	methodCall   = types.NewMethodName("evm.Call", Call{})
 
 	// Queries.
-	methodStorage      = "evm.Storage"
-	methodCode         = "evm.Code"
-	methodBalance      = "evm.Balance"
-	methodSimulateCall = "evm.SimulateCall"
-	methodParameters   = "evm.Parameters"
+	methodStorage      = types.NewMethodName("evm.Storage", StorageQuery{})
+	methodCode         = types.NewMethodName("evm.Code", CodeQuery{})
+	methodBalance      = types.NewMethodName("evm.Balance", BalanceQuery{})
+	methodSimulateCall = types.NewMethodName("evm.SimulateCall", SimulateCallQuery{})
+	methodParameters   = types.NewMethodName("evm.Parameters", nil)
 )
 
 // V1 is the v1 EVM module interface.

--- a/client-sdk/go/modules/rewards/rewards.go
+++ b/client-sdk/go/modules/rewards/rewards.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-const (
-	// Queries.
-	methodParameters = "rewards.Parameters"
-)
+// Queries.
+var methodParameters = types.NewMethodName("rewards.Parameters", nil)
 
 // V1 is the v1 rewards module interface.
 type V1 interface {

--- a/client-sdk/go/types/address.go
+++ b/client-sdk/go/types/address.go
@@ -38,6 +38,14 @@ var (
 	_ encoding.TextUnmarshaler   = (*Address)(nil)
 )
 
+type contextKey string
+
+// ContextKeyAccountNames is the key to retrieve the public key to account name map from context.
+const ContextKeyAccountNames = contextKey("runtime/account-names")
+
+// AccountNames maps public key or address to user-defined account name for pretty printing.
+type AccountNames map[string]string
+
 // SignatureAddressSpec is information for signature-based authentication and public key-based
 // address derivation.
 type SignatureAddressSpec struct {

--- a/client-sdk/go/types/token.go
+++ b/client-sdk/go/types/token.go
@@ -1,9 +1,14 @@
 package types
 
 import (
+	"context"
 	"fmt"
+	"io"
 
+	"github.com/oasisprotocol/oasis-core/go/common/prettyprint"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 )
 
 // Quantity is a arbitrary precision unsigned integer that never underflows.
@@ -58,10 +63,44 @@ func (bu BaseUnits) String() string {
 	return fmt.Sprintf("%s %s", bu.Amount.String(), bu.Denomination.String())
 }
 
+// PrettyPrint writes a pretty-printed representation of the base units to the given writer.
+func (bu *BaseUnits) PrettyPrint(ctx context.Context, prefix string, w io.Writer) {
+	pt, ok := ctx.Value(config.ContextKeyParaTimeCfg).(*config.ParaTime)
+	if !ok {
+		fmt.Fprintf(w, "<error: ParaTime information not available>")
+		return
+	}
+	di := pt.GetDenominationInfo(string(bu.Denomination))
+	fmt.Fprintf(w, "%s %s", prettyprint.QuantityFrac(bu.Amount, di.Decimals), di.Symbol)
+}
+
+// PrettyType returns a representation of the type that can be used for pretty printing.
+func (bu *BaseUnits) PrettyType() (interface{}, error) {
+	return bu, nil
+}
+
 // NewBaseUnits creates a new token amount of given denomination.
 func NewBaseUnits(amount quantity.Quantity, denomination Denomination) BaseUnits {
 	return BaseUnits{
 		Amount:       amount,
 		Denomination: denomination,
 	}
+}
+
+// PrettyPrintToAmount is a helper for printing To-Amount transaction bodies (e.g. transfer, deposit, withdraw).
+func PrettyPrintToAmount(ctx context.Context, prefix string, w io.Writer, to *Address, amount BaseUnits) {
+	toStr := "Self"
+	if to != nil {
+		toStr = to.String()
+		an, ok := ctx.Value(ContextKeyAccountNames).(AccountNames)
+		if ok {
+			if name, ok := an[to.String()]; ok {
+				toStr = fmt.Sprintf("%s (%s)", name, to)
+			}
+		}
+	}
+	fmt.Fprintf(w, "%sTo: %s\n", prefix, toStr)
+	fmt.Fprintf(w, "%sAmount: ", prefix)
+	amount.PrettyPrint(ctx, prefix, w)
+	fmt.Fprintln(w)
 }

--- a/client-sdk/go/types/token_test.go
+++ b/client-sdk/go/types/token_test.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"bytes"
+	"context"
 	"encoding/hex"
 	"testing"
 
@@ -8,6 +10,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 )
 
 func TestToken(t *testing.T) {
@@ -37,4 +40,44 @@ func TestToken(t *testing.T) {
 		require.NoError(err, "deserialization should succeed")
 		require.EqualValues(token, dec, "serialization should round-trip")
 	}
+}
+
+func TestPrettyPrintToAmount(t *testing.T) {
+	require := require.New(t)
+
+	ptCfg := &config.ParaTime{
+		Denominations: map[string]*config.DenominationInfo{
+			"_": {
+				Symbol:   "TEST",
+				Decimals: 18,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, config.ContextKeyParaTimeCfg, ptCfg)
+	ctx = context.WithValue(ctx, ContextKeyAccountNames, AccountNames{
+		"oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt": "test:dave",
+	})
+
+	to := Address{}
+	err := to.UnmarshalText([]byte("oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt"))
+	require.NoError(err)
+	qt := Quantity{}
+	err = qt.UnmarshalText([]byte("50000000000000000000"))
+	require.NoError(err)
+	amt := BaseUnits{
+		Amount:       qt,
+		Denomination: NativeDenomination,
+	}
+
+	var buf bytes.Buffer
+	PrettyPrintToAmount(ctx, "", &buf, &to, amt)
+	require.Equal("To: test:dave (oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt)\nAmount: 50.0 TEST\n", buf.String())
+
+	// No ParaTime set. Amount cannot be correctly determined.
+	buf.Reset()
+	ctx = context.WithValue(ctx, config.ContextKeyParaTimeCfg, nil)
+	PrettyPrintToAmount(ctx, "", &buf, &to, amt)
+	require.Equal("To: test:dave (oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt)\nAmount: <error: ParaTime information not available>\n", buf.String())
 }

--- a/client-sdk/go/types/transaction_test.go
+++ b/client-sdk/go/types/transaction_test.go
@@ -1,8 +1,11 @@
 package types
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-core/go/common"
@@ -80,4 +83,98 @@ func TestTransactionSigning(t *testing.T) {
 	require.NoError(err, "Verify")
 	err = tx.ValidateBasic()
 	require.NoError(err, "ValidateBasic")
+}
+
+func TestPrettyPrintTransaction(t *testing.T) {
+	require := require.New(t)
+
+	ptCfg := &config.ParaTime{
+		Denominations: map[string]*config.DenominationInfo{
+			"_": {
+				Symbol:   "TEST",
+				Decimals: 18,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, config.ContextKeyParaTimeCfg, ptCfg)
+
+	pk := ed25519.PublicKey{}
+	err := pk.UnmarshalText([]byte("NcPzNW3YU2T+ugNUtUWtoQnRvbOL9dYSaBfbjHLP1pE="))
+	require.NoError(err)
+
+	// Try different transaction bodies.
+	cborBody := cbor.Marshal(map[string]interface{}{"to": "oasis123", "amount": "100 BANANAS"})
+	for _, testBody := range []struct {
+		Format   CallFormat
+		Body     []byte
+		Expected string
+	}{
+		{Format: CallFormatPlain, Body: cborBody, Expected: "Body:\n  {\n    \"amount\": \"100 BANANAS\",\n    \"to\": \"oasis123\"\n  }\n"},
+		{Format: CallFormatPlain, Body: []byte("some-unknown-encoding"), Expected: "Body:\n  \"c29tZS11bmtub3duLWVuY29kaW5n\""},
+		{Format: CallFormatEncryptedX25519DeoxysII, Body: []byte("some-unknown-encoding"), Expected: "Body:\n  \"c29tZS11bmtub3duLWVuY29kaW5n\""},
+	} {
+		tx := Transaction{
+			Versioned: cbor.Versioned{V: LatestTransactionVersion},
+			Call: Call{
+				Format:   testBody.Format,
+				Method:   "consensus.Deposit",
+				Body:     testBody.Body,
+				ReadOnly: false,
+			},
+			AuthInfo: AuthInfo{
+				SignerInfo: []SignerInfo{
+					{
+						AddressSpec: AddressSpec{Signature: &SignatureAddressSpec{Ed25519: &pk}},
+						Nonce:       15,
+					},
+				},
+			},
+		}
+
+		var buf bytes.Buffer
+		tx.PrettyPrint(ctx, "", &buf)
+		if testBody.Format == CallFormatPlain {
+			require.Contains(buf.String(), "Format: plain")
+		} else {
+			require.Contains(buf.String(), "Format: encrypted/x25519-deoxysii")
+		}
+		require.Contains(buf.String(), "Method: consensus.Deposit")
+		require.Contains(buf.String(), testBody.Expected)
+		require.Contains(buf.String(), "Authorized signer(s):\n1. NcPzNW3YU2T+ugNUtUWtoQnRvbOL9dYSaBfbjHLP1pE= (ed25519)\n   Nonce: 15\n")
+		require.Contains(buf.String(), "Fee:\n")
+	}
+}
+
+func TestPrettyPrintFee(t *testing.T) {
+	require := require.New(t)
+
+	ptCfg := &config.ParaTime{
+		Denominations: map[string]*config.DenominationInfo{
+			"_": {
+				Symbol:   "TEST",
+				Decimals: 18,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, config.ContextKeyParaTimeCfg, ptCfg)
+
+	feeQt := Quantity{}
+	err := feeQt.UnmarshalText([]byte("200000000000000000"))
+	require.NoError(err)
+	feeAmt := BaseUnits{
+		Amount:       feeQt,
+		Denomination: NativeDenomination,
+	}
+
+	fee := Fee{
+		Amount: feeAmt,
+		Gas:    1000,
+	}
+	var buf bytes.Buffer
+	fee.PrettyPrint(ctx, "", &buf)
+	require.Equal("Amount: 0.2 TEST\nGas limit: 1000\n(gas price: 0.0002 TEST per gas unit)\n", buf.String())
 }

--- a/tools/gen_runtime_vectors/testvectors.go
+++ b/tools/gen_runtime_vectors/testvectors.go
@@ -57,13 +57,13 @@ func MakeRuntimeTestVector(tx *types.Transaction, txBody interface{}, sigCtx *si
 	}
 
 	sigTx := ts.UnverifiedTransaction()
-	prettyTx, err := tx.PrettyType(txBody)
+	prettyTx, err := tx.PrettyType()
 	if err != nil {
 		log.Fatalf("failed to obtain pretty tx: %v", err)
 	}
 	prettyMethod := "[unknown]"
 	if tx.Call.Method != "" {
-		prettyMethod = tx.Call.Method
+		prettyMethod = string(tx.Call.Method)
 	}
 
 	meta := signature.NewHwContext(sigCtx)


### PR DESCRIPTION
Required by oasisprotocol/cli#8.

- registers all known runtime methods using `NewMethodName` similar to oasis-core
- adds `PrettyTransaction` which actually knows how to print `Transaction` in a user-friendly way
- implements PrettyPrinter for runtime `Transaction`, `UnverifiedTransaction` and `Fee`
- implements PrettyPrinter for `BaseUnits`
- implements PrettyPrinter for token transfer transactions (Transfer, Deposit, Withdraw)
- adds unit tests