### PR TITLE
[BREAKING] client-sdk: Fix ETH address format for test accounts

### DIFF
--- a/client-sdk/go/helpers/address.go
+++ b/client-sdk/go/helpers/address.go
@@ -58,7 +58,7 @@ func ResolveAddress(net *config.Network, address string) (*types.Address, *ethCo
 		case addressExplicitTest:
 			// Test key.
 			if testKey, ok := testing.TestAccounts[data]; ok {
-				return &testKey.Address, &testKey.EthAddress, nil
+				return &testKey.Address, testKey.EthAddress, nil
 			}
 			return nil, nil, fmt.Errorf("unsupported test account: %s", data)
 		default:

--- a/client-sdk/go/testing/testing.go
+++ b/client-sdk/go/testing/testing.go
@@ -25,7 +25,7 @@ type TestKey struct {
 	SigSpec   types.SignatureAddressSpec
 
 	// EthAddress is the corresponding Ethereum address if the key is secp256k1.
-	EthAddress ethCommon.Address
+	EthAddress *ethCommon.Address
 }
 
 func newEd25519TestKey(seed string) TestKey {
@@ -48,7 +48,7 @@ func newSecp256k1TestKey(seed string) TestKey {
 	h := sha3.NewLegacyKeccak256()
 	untaggedPk, _ := sigspec.Secp256k1Eth.MarshalBinaryUncompressedUntagged()
 	h.Write(untaggedPk)
-	var ethAddress [20]byte
+	var ethAddress ethCommon.Address
 	copy(ethAddress[:], h.Sum(nil)[32-20:])
 
 	return TestKey{
@@ -56,7 +56,7 @@ func newSecp256k1TestKey(seed string) TestKey {
 		Signer:     signer,
 		Address:    types.NewAddress(sigspec),
 		SigSpec:    sigspec,
-		EthAddress: ethAddress,
+		EthAddress: &ethAddress,
 	}
 }
 

--- a/tools/gen_runtime_vectors/main.go
+++ b/tools/gen_runtime_vectors/main.go
@@ -95,15 +95,15 @@ func main() {
 						// Valid Deposit: Alice -> Dave's native address on ParaTime
 						{testing.Dave.Address.String(), nil, context.ChainContext, true},
 						// Valid Deposit: Alice -> Dave's ethereum address on ParaTime
-						{testing.Dave.EthAddress.String(), &testing.Dave.EthAddress, context.ChainContext, true},
+						{testing.Dave.EthAddress.String(), testing.Dave.EthAddress, context.ChainContext, true},
 						// Valid Deposit: Alice -> Frank's native address on ParaTime
 						{testing.Frank.Address.String(), nil, context.ChainContext, true},
 						// Invalid Deposit: orig_to doesn't match transaction's to
 						{testing.Dave.EthAddress.String(), &unknownEthAddr, context.ChainContext, false},
 						// Invalid Deposit: chain_context empty
-						{testing.Dave.EthAddress.String(), &testing.Dave.EthAddress, emptyChainContext, false},
+						{testing.Dave.EthAddress.String(), testing.Dave.EthAddress, emptyChainContext, false},
 						// Invalid Deposit: chain_context invalid
-						{testing.Dave.EthAddress.String(), &testing.Dave.EthAddress, invalidChainContext, false},
+						{testing.Dave.EthAddress.String(), testing.Dave.EthAddress, invalidChainContext, false},
 					} {
 						to, ethTo, _ := helpers.ResolveAddress(nil, t.to)
 						txBody := &consensusaccounts.Deposit{
@@ -165,13 +165,13 @@ func main() {
 						// Valid Transfer: Alice -> Dave's native address on ParaTime
 						{testing.Dave.Address.String(), nil, testing.Alice, true},
 						// Valid Transfer: Alice -> Dave's ethereum address on ParaTime
-						{testing.Dave.EthAddress.String(), &testing.Dave.EthAddress, testing.Alice, true},
+						{testing.Dave.EthAddress.String(), testing.Dave.EthAddress, testing.Alice, true},
 						// Valid Transfer: Alice -> Frank's native address on ParaTime
 						{testing.Frank.Address.String(), nil, testing.Alice, true},
 						// Valid Transfer: Dave -> Alice's native address on ParaTime
 						{testing.Alice.Address.String(), nil, testing.Dave, true},
 						// Valid Transfer: Dave -> Erin's ethereum address on ParaTime
-						{testing.Erin.EthAddress.String(), &testing.Erin.EthAddress, testing.Dave, true},
+						{testing.Erin.EthAddress.String(), testing.Erin.EthAddress, testing.Dave, true},
 						// Valid Transfer: Frank -> Alice's native address on ParaTime
 						{testing.Alice.Address.String(), nil, testing.Frank, true},
 						// Valid Transfer: Frank -> Grace native address on ParaTime


### PR DESCRIPTION
Fix ETH address handling for non-secp256k1 test accounts.

Fixes https://github.com/oasisprotocol/cli/issues/63