### PR TITLE
feat(go): Make sapphire default ParaTime

### DIFF
--- a/client-sdk/go/config/default.go
+++ b/client-sdk/go/config/default.go
@@ -14,7 +14,7 @@ var DefaultNetworks = Networks{
 				Decimals: 9,
 			},
 			ParaTimes: ParaTimes{
-				Default: "emerald",
+				Default: "sapphire",
 				All: map[string]*ParaTime{
 					// Cipher on Mainnet.
 					"cipher": {
@@ -61,7 +61,7 @@ var DefaultNetworks = Networks{
 				Decimals: 9,
 			},
 			ParaTimes: ParaTimes{
-				Default: "emerald",
+				Default: "sapphire",
 				All: map[string]*ParaTime{
 					// Cipher on Testnet.
 					"cipher": {


### PR DESCRIPTION
Sets `sapphire` as default ParaTime in go client-sdk. E.g. to be used by Oasis CLI when running it for the first time.