### PR TITLE
runtime-sdk: Remove dcap-ql pin since it was fixed upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,9 +908,9 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748bb654a716b7f26ffdae746f3eacd22d72bc1858cef5b582bb68c90bde533e"
+checksum = "0a63d5f9b6526bb82ba697e303d9789a87849753815c84346444e94a5be2de43"
 dependencies = [
  "byteorder",
  "failure",
@@ -2372,7 +2372,6 @@ dependencies = [
  "blake3",
  "byteorder",
  "curve25519-dalek 3.2.0",
- "dcap-ql",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",

--- a/contract-sdk/specs/access/oas173/Cargo.lock
+++ b/contract-sdk/specs/access/oas173/Cargo.lock
@@ -673,9 +673,9 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748bb654a716b7f26ffdae746f3eacd22d72bc1858cef5b582bb68c90bde533e"
+checksum = "0a63d5f9b6526bb82ba697e303d9789a87849753815c84346444e94a5be2de43"
 dependencies = [
  "byteorder",
  "failure",
@@ -1792,7 +1792,6 @@ dependencies = [
  "bech32",
  "byteorder",
  "curve25519-dalek 3.2.0",
- "dcap-ql",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",

--- a/contract-sdk/specs/token/oas20/Cargo.lock
+++ b/contract-sdk/specs/token/oas20/Cargo.lock
@@ -673,9 +673,9 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748bb654a716b7f26ffdae746f3eacd22d72bc1858cef5b582bb68c90bde533e"
+checksum = "0a63d5f9b6526bb82ba697e303d9789a87849753815c84346444e94a5be2de43"
 dependencies = [
  "byteorder",
  "failure",
@@ -1793,7 +1793,6 @@ dependencies = [
  "bech32",
  "byteorder",
  "curve25519-dalek 3.2.0",
- "dcap-ql",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -39,9 +39,6 @@ tokio = { version = "~1.24.1", features = ["rt"] }
 zeroize = "1.4"
 lru = "0.8.0"
 
-# TODO: Remove this once broken version 0.3.6 is yanked upstream (https://github.com/fortanix/rust-sgx/issues/497).
-dcap-ql = { version = ">=0.3.4, <0.3.6", default-features = false, features = ["verify"] }
-
 [dev-dependencies]
 blake3 = { version = "1.3.1", features = ["traits-preview"] }
 

--- a/tests/contracts/hello/Cargo.lock
+++ b/tests/contracts/hello/Cargo.lock
@@ -673,9 +673,9 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748bb654a716b7f26ffdae746f3eacd22d72bc1858cef5b582bb68c90bde533e"
+checksum = "0a63d5f9b6526bb82ba697e303d9789a87849753815c84346444e94a5be2de43"
 dependencies = [
  "byteorder",
  "failure",
@@ -1803,7 +1803,6 @@ dependencies = [
  "bech32",
  "byteorder",
  "curve25519-dalek 3.2.0",
- "dcap-ql",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",


### PR DESCRIPTION
Upstream issue https://github.com/fortanix/rust-sgx/issues/497 was fixed so this is no longer needed.