### PR TITLE
ci: bump nodejs to 16

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -135,12 +135,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -137,12 +137,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web
@@ -179,12 +176,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web
@@ -251,12 +245,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web
@@ -292,12 +283,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web
@@ -399,12 +387,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web
@@ -424,12 +409,9 @@ jobs:
       - name: Set up Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
           cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
-
-      - name: Set up npm
-        run: npm install npm@7 -g
 
       - name: Install dependencies and build
         working-directory: client-sdk/ts-web


### PR DESCRIPTION
14 is eol, so we probably don't have to support it