### PR TITLE
runtime-sdk: Charge precompile extra cost

### DIFF
--- a/runtime-sdk/modules/evm/src/precompile/mod.rs
+++ b/runtime-sdk/modules/evm/src/precompile/mod.rs
@@ -93,8 +93,15 @@ impl<Cfg: Config, B: EVMBackendExt> PrecompileSet for Precompiles<'_, Cfg, B> {
         match self.is_precompile(address, handle.remaining_gas()) {
             IsPrecompileResult::Answer {
                 is_precompile: true,
-                ..
-            } => { /* Ok. */ }
+                extra_cost,
+            } => {
+                if let Err(e) = handle.record_cost(extra_cost) {
+                    return Some(Err(e.into()));
+                }
+            }
+            IsPrecompileResult::OutOfGas => {
+                return Some(Err(ExitError::OutOfGas.into()));
+            }
             _ => {
                 return None;
             }


### PR DESCRIPTION
Commenting _bump evm to 0.39.1_ commit that was merged in #1420 .