### PR TITLE
cargo: Ignore RUSTSEC-2022-0093 until we can update ed25519-dalek to v2

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2020-0071", # Remove once upstream dependencies are updated.
+    "RUSTSEC-2022-0093", # Remove once we can update to ed25519-dalek to v2.
 ]


### PR DESCRIPTION
This vulnerability does not affect our current use of the library.