### PR TITLE
api-reference: Add typedoc support, refactor

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -16,9 +16,9 @@ concurrency:
 
 jobs:
 
-  publish-docs:
+  rust-docs:
     # NOTE: This name appears in GitHub's Checks API.
-    name: publish-docs
+    name: rust-docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -39,11 +39,67 @@ jobs:
             --package oasis-contract-sdk-types \
             --package oasis-contract-sdk-storage
 
-      - name: Publish docs
-        uses: crazy-max/ghaction-github-pages@v3
+      - name: Deploy rust to api-reference branch
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          target_branch: api-reference
-          build_dir: target/doc
-          commit_message: Deploy API reference
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc
+          publish_branch: api-reference
+          destination_dir: rust
+          commit_message: Deploy rust API reference ${{ github.event.head_commit.message }}
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+
+  js-docs:
+    name: js-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          cache: npm
+          cache-dependency-path: 'client-sdk/ts-web/package-lock.json'
+
+      - name: Install dependencies and build
+        working-directory: client-sdk/ts-web
+        run: npm ci --foreground-scripts
+
+      - name: core
+        working-directory: client-sdk/ts-web/core
+        run: npx typedoc
+
+      - name: rt
+        working-directory: client-sdk/ts-web/rt
+        run: npx typedoc
+
+      - name: ext-utils
+        working-directory: client-sdk/ts-web/ext-utils
+        run: npx typedoc
+
+      - name: signer-ledger
+        working-directory: client-sdk/ts-web/signer-ledger
+        run: npx typedoc
+
+      - name: Merge docs
+        working-directory: client-sdk/ts-web
+        run: |
+          mkdir docs
+          mv core/docs/api docs/client
+          mv rt/docs/api docs/client-rt
+          mv ext-utils/docs/api docs/client-ext-utils
+          mv signer-ledger/docs/api docs/client-signer-ledger
+
+      - name: Deploy js to api-reference branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: client-sdk/ts-web/docs
+          publish_branch: api-reference
+          destination_dir: js
+          commit_message: Deploy js API reference ${{ github.event.head_commit.message }}
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -149,13 +149,25 @@ jobs:
         working-directory: client-sdk/ts-web/core
         run: npm run-script check-playground
 
+      - name: Check ts-web/core typedoc
+        working-directory: client-sdk/ts-web/core
+        run: npx typedoc
+
       - name: Check ts-web/signer-ledger playground
         working-directory: client-sdk/ts-web/signer-ledger
         run: npm run-script check-playground
 
+      - name: Check ts-web/signer-ledger typedoc
+        working-directory: client-sdk/ts-web/signer-ledger
+        run: npx typedoc
+
       - name: Check ts-web/rt playground
         working-directory: client-sdk/ts-web/rt
         run: npm run-script check-playground
+
+      - name: Check ts-web/rt typedoc
+        working-directory: client-sdk/ts-web/rt
+        run: npx typedoc
 
       - name: Check ts-web/ext-utils sample-page
         working-directory: client-sdk/ts-web/ext-utils
@@ -164,6 +176,10 @@ jobs:
       - name: Check ts-web/ext-utils sample-ext
         working-directory: client-sdk/ts-web/ext-utils
         run: npm run-script check-sample-ext
+
+      - name: Check ts-web/ext-utils typedoc
+        working-directory: client-sdk/ts-web/ext-utils
+        run: npx typedoc
 
   e2e-ts-web-core:
     # NOTE: This name appears in GitHub's Checks API.

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -43,6 +43,7 @@
         "protobufjs-cli": "^1.1.2",
         "stream-browserify": "^3.0.0",
         "ts-jest": "^29.1.1",
+        "typedoc": "^0.25.1",
         "typescript": "^5.2.2",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",

--- a/client-sdk/ts-web/core/tsconfig.json
+++ b/client-sdk/ts-web/core/tsconfig.json
@@ -10,5 +10,11 @@
     },
     "include": [
         "src/**/*"
-    ]
+    ],
+    "typedocOptions": {
+      "entryPoints": ["src/index.ts"],
+      "out": "docs/api",
+      "excludeInternal": true,
+      "excludePrivate": true
+    }
 }

--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -33,6 +33,7 @@
         "prettier": "^3.0.3",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
+        "typedoc": "^0.25.1",
         "typescript": "^5.2.2",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",

--- a/client-sdk/ts-web/ext-utils/tsconfig.json
+++ b/client-sdk/ts-web/ext-utils/tsconfig.json
@@ -10,5 +10,11 @@
     },
     "include": [
         "src/**/*"
-    ]
+    ],
+    "typedocOptions": {
+      "entryPoints": ["src/index.ts"],
+      "out": "docs/api",
+      "excludeInternal": true,
+      "excludePrivate": true
+    }
 }

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -34,6 +34,7 @@
                 "protobufjs-cli": "^1.1.2",
                 "stream-browserify": "^3.0.0",
                 "ts-jest": "^29.1.1",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -55,6 +56,7 @@
                 "prettier": "^3.0.3",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -2046,6 +2048,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+            "dev": true
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -5586,6 +5594,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
         "node_modules/jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -5836,6 +5850,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
@@ -7183,6 +7203,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/shiki": {
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
+            "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
+            }
+        },
         "node_modules/side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -7744,6 +7776,51 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.1.tgz",
+            "integrity": "sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==",
+            "dev": true,
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "marked": "^4.3.0",
+                "minimatch": "^9.0.3",
+                "shiki": "^0.14.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/typescript": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
@@ -7892,6 +7969,18 @@
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+            "dev": true
+        },
+        "node_modules/vscode-textmate": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+            "dev": true
         },
         "node_modules/walker": {
             "version": "1.0.8",
@@ -8465,6 +8554,7 @@
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
                 "ts-jest": "^29.1.1",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -8486,6 +8576,7 @@
                 "prettier": "^3.0.3",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -9427,6 +9518,7 @@
                 "stream-browserify": "^3.0.0",
                 "ts-jest": "^29.1.1",
                 "tweetnacl": "^1.0.3",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -9444,6 +9536,7 @@
                 "prettier": "^3.0.3",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -9470,6 +9563,7 @@
                 "stream-browserify": "^3.0.0",
                 "ts-jest": "^29.1.1",
                 "tweetnacl": "^1.0.3",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -9487,6 +9581,7 @@
                 "prettier": "^3.0.3",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
+                "typedoc": "^0.25.1",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
@@ -10231,6 +10326,12 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true
+        },
+        "ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
             "dev": true
         },
         "ansi-styles": {
@@ -12938,6 +13039,12 @@
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
         "jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -13134,6 +13241,12 @@
             "requires": {
                 "yallist": "^4.0.0"
             }
+        },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
         },
         "make-dir": {
             "version": "4.0.0",
@@ -14161,6 +14274,18 @@
             "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
             "dev": true
         },
+        "shiki": {
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
+            "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+            "dev": true,
+            "requires": {
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
+            }
+        },
         "side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -14575,6 +14700,38 @@
                 "mime-types": "~2.1.24"
             }
         },
+        "typedoc": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.1.tgz",
+            "integrity": "sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==",
+            "dev": true,
+            "requires": {
+                "lunr": "^2.3.9",
+                "marked": "^4.3.0",
+                "minimatch": "^9.0.3",
+                "shiki": "^0.14.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
         "typescript": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
@@ -14686,6 +14843,18 @@
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
             }
+        },
+        "vscode-oniguruma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+            "dev": true
+        },
+        "vscode-textmate": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+            "dev": true
         },
         "walker": {
             "version": "1.0.8",

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -41,6 +41,7 @@
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "ts-jest": "^29.1.1",
+        "typedoc": "^0.25.1",
         "typescript": "^5.2.2",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",

--- a/client-sdk/ts-web/rt/tsconfig.json
+++ b/client-sdk/ts-web/rt/tsconfig.json
@@ -9,5 +9,11 @@
     },
     "include": [
         "src/**/*"
-    ]
+    ],
+    "typedocOptions": {
+      "entryPoints": ["src/index.ts"],
+      "out": "docs/api",
+      "excludeInternal": true,
+      "excludePrivate": true
+    }
 }

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -30,6 +30,7 @@
         "prettier": "^3.0.3",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
+        "typedoc": "^0.25.1",
         "typescript": "^5.2.2",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",

--- a/client-sdk/ts-web/signer-ledger/tsconfig.json
+++ b/client-sdk/ts-web/signer-ledger/tsconfig.json
@@ -10,5 +10,11 @@
     },
     "include": [
         "src/**/*"
-    ]
+    ],
+    "typedocOptions": {
+      "entryPoints": ["src/index.ts"],
+      "out": "docs/api",
+      "excludeInternal": true,
+      "excludePrivate": true
+    }
 }


### PR DESCRIPTION
This PR:
- adds or bumps typedoc of client-sdk/ts-web packages
- adds generation of typedoc to CI
- reorganizes api-reference branch to first include the language and inside the API reference of the corresponding packages (currently rust and js)

## TODO
https://github.com/oasisprotocol/docs-api now also contains symbolic links merging together docs from oasis-sdk and sapphire-paratimes repos of different languages. Rust API reference links used at docs.oasis.io should now point to `https://api.docs.oasis.io/rust/*` instead of `https://api.docs.oasis.io/oasis-sdk`. Remove the `oasis-sdk` symbolic link in `api-reference` branch once the links on docs.oasis.io are updated.