### PR TITLE
client-sdk: Add pending-withdrawal and pending-delegation addresses

### DIFF
--- a/client-sdk/go/modules/accounts/accounts.go
+++ b/client-sdk/go/modules/accounts/accounts.go
@@ -12,9 +12,9 @@ import (
 
 var (
 	// CommonPoolAddress is the address of the internal common pool account in the accounts module.
-	CommonPoolAddress = types.NewAddressForModule("accounts", []byte("common-pool"))
+	CommonPoolAddress = types.NewAddressForModule(ModuleName, []byte("common-pool"))
 	// FeeAccumulatorAddress is the address of the internal fee accumulator account in the accounts module.
-	FeeAccumulatorAddress = types.NewAddressForModule("accounts", []byte("fee-accumulator"))
+	FeeAccumulatorAddress = types.NewAddressForModule(ModuleName, []byte("fee-accumulator"))
 )
 
 var (

--- a/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
+++ b/client-sdk/go/modules/consensusaccounts/consensus_accounts.go
@@ -12,6 +12,13 @@ import (
 )
 
 var (
+	// PendingWithdrawalAddress is the address of the internal pending withdrawal account in the consensus_accounts module.
+	PendingWithdrawalAddress = types.NewAddressForModule(ModuleName, []byte("pending-withdrawal"))
+	// PendingDelegationAddress is the address of the internal pending delegation account in the consensus_accounts module.
+	PendingDelegationAddress = types.NewAddressForModule(ModuleName, []byte("pending-delegation"))
+)
+
+var (
 	// Callable methods.
 	methodDeposit    = types.NewMethodName("consensus.Deposit", Deposit{})
 	methodWithdraw   = types.NewMethodName("consensus.Withdraw", Withdraw{})

--- a/client-sdk/go/modules/contracts/types.go
+++ b/client-sdk/go/modules/contracts/types.go
@@ -19,7 +19,7 @@ type InstanceID uint64
 func (i *InstanceID) Address() types.Address {
 	id := make([]byte, 8)
 	binary.BigEndian.PutUint64(id, uint64(*i))
-	return types.NewAddressForModule("contracts", id)
+	return types.NewAddressForModule(ModuleName, id)
 }
 
 // Policy is a generic policy that specifies who is allowed to perform an action.

--- a/client-sdk/go/modules/rewards/types.go
+++ b/client-sdk/go/modules/rewards/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 // RewardPoolAddress is the address of the reward pool.
-var RewardPoolAddress = types.NewAddressForModule("rewards", []byte("reward-pool"))
+var RewardPoolAddress = types.NewAddressForModule(ModuleName, []byte("reward-pool"))
 
 // RewardStep is one of the time periods in the reward schedule.
 type RewardStep struct {
@@ -27,3 +27,6 @@ type Parameters struct {
 	ParticipationThresholdNumerator   uint64 `json:"participation_threshold_numerator"`
 	ParticipationThresholdDenominator uint64 `json:"participation_threshold_denominator"`
 }
+
+// ModuleName is the rewards module name.
+const ModuleName = "rewards"

--- a/runtime-sdk/src/modules/accounts/mod.rs
+++ b/runtime-sdk/src/modules/accounts/mod.rs
@@ -243,9 +243,13 @@ pub mod state {
 pub struct Module;
 
 /// Module's address that has the common pool.
+///
+/// oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30
 pub static ADDRESS_COMMON_POOL: Lazy<Address> =
     Lazy::new(|| Address::from_module(MODULE_NAME, "common-pool"));
 /// Module's address that has the fee accumulator.
+///
+/// oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4
 pub static ADDRESS_FEE_ACCUMULATOR: Lazy<Address> =
     Lazy::new(|| Address::from_module(MODULE_NAME, "fee-accumulator"));
 

--- a/runtime-sdk/src/modules/consensus_accounts/mod.rs
+++ b/runtime-sdk/src/modules/consensus_accounts/mod.rs
@@ -230,10 +230,14 @@ pub struct Module<Accounts: modules::accounts::API, Consensus: modules::consensu
 }
 
 /// Module's address that has the tokens pending withdrawal.
+///
+/// oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln
 pub static ADDRESS_PENDING_WITHDRAWAL: Lazy<Address> =
     Lazy::new(|| Address::from_module(MODULE_NAME, "pending-withdrawal"));
 
 /// Module's address that has the tokens pending delegation.
+///
+/// oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r
 pub static ADDRESS_PENDING_DELEGATION: Lazy<Address> =
     Lazy::new(|| Address::from_module(MODULE_NAME, "pending-delegation"));
 

--- a/runtime-sdk/src/modules/rewards/mod.rs
+++ b/runtime-sdk/src/modules/rewards/mod.rs
@@ -88,6 +88,8 @@ pub struct Module<Accounts: modules::accounts::API> {
 }
 
 /// Module's address that has the reward pool.
+///
+/// oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav
 pub static ADDRESS_REWARD_POOL: Lazy<Address> =
     Lazy::new(|| Address::from_module(MODULE_NAME, "reward-pool"));
 


### PR DESCRIPTION
This PR:
- Mentions the pool address in the comments similar to how we do it in [oasis-core](https://github.com/oasisprotocol/oasis-core/blob/master/go/staking/api/address_internal.go).
- Adds missing pending-withdrawal and pending-delegations addresses

Tag `runtime-sdk/v0.8.4` after merge.

Blocked by https://github.com/oasisprotocol/oasis-sdk/pull/1617

Required by https://github.com/oasisprotocol/cli/pull/134