### PR TITLE
runtime-sdk: support dynamic min-gas-price

### DIFF
--- a/runtime-sdk/modules/evm/src/backend.rs
+++ b/runtime-sdk/modules/evm/src/backend.rs
@@ -354,9 +354,10 @@ impl<'ctx, 'backend, 'config, C: TxContext, Cfg: Config> Backend
 
     fn block_base_fee_per_gas(&self) -> U256 {
         <C::Runtime as Runtime>::Core::min_gas_price(
-            &mut self.backend.ctx.borrow_mut(),
+            &self.backend.ctx.borrow_mut(),
             &Cfg::TOKEN_DENOMINATION,
         )
+        .unwrap_or_default()
         .into()
     }
 

--- a/runtime-sdk/modules/evm/src/precompile/testing.rs
+++ b/runtime-sdk/modules/evm/src/precompile/testing.rs
@@ -221,6 +221,7 @@ impl Runtime for TestRuntime {
                     max_multisig_signers: 8,
                     gas_costs: Default::default(),
                     min_gas_price: BTreeMap::from([(token::Denomination::NATIVE, 0)]),
+                    dynamic_min_gas_price: Default::default(),
                 },
             },
             accounts::Genesis {

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -1028,6 +1028,7 @@ mod test {
                             callformat_x25519_deoxysii: 0,
                         },
                         min_gas_price: BTreeMap::from([(token::Denomination::NATIVE, 0)]),
+                        dynamic_min_gas_price: Default::default(),
                     },
                 },
                 (),

--- a/tests/runtimes/benchmarking/src/lib.rs
+++ b/tests/runtimes/benchmarking/src/lib.rs
@@ -59,6 +59,7 @@ impl sdk::Runtime for Runtime {
                         mgp.insert(Denomination::NATIVE, 0);
                         mgp
                     },
+                    dynamic_min_gas_price: Default::default(),
                 },
             },
             modules::accounts::Genesis {

--- a/tests/runtimes/simple-consensus/src/lib.rs
+++ b/tests/runtimes/simple-consensus/src/lib.rs
@@ -76,6 +76,7 @@ impl sdk::Runtime for Runtime {
                         mgp.insert(Denomination::NATIVE, 0);
                         mgp
                     },
+                    dynamic_min_gas_price: Default::default(),
                 },
             },
         )

--- a/tests/runtimes/simple-contracts/src/lib.rs
+++ b/tests/runtimes/simple-contracts/src/lib.rs
@@ -85,6 +85,7 @@ impl sdk::Runtime for Runtime {
                         mgp.insert(Denomination::NATIVE, 0);
                         mgp
                     },
+                    dynamic_min_gas_price: Default::default(),
                 },
             },
             contracts::Genesis {

--- a/tests/runtimes/simple-evm/src/lib.rs
+++ b/tests/runtimes/simple-evm/src/lib.rs
@@ -110,6 +110,7 @@ impl sdk::Runtime for Runtime {
                         mgp.insert(Denomination::NATIVE, 0);
                         mgp
                     },
+                    dynamic_min_gas_price: Default::default(),
                 },
             },
             evm::Genesis {

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -140,6 +140,7 @@ impl sdk::Runtime for Runtime {
                         mgp.insert(Denomination::NATIVE, 0);
                         mgp
                     },
+                    dynamic_min_gas_price: Default::default(),
                 },
             },
         )

--- a/tests/runtimes/simple-keyvalue/src/test.rs
+++ b/tests/runtimes/simple-keyvalue/src/test.rs
@@ -24,6 +24,7 @@ fn test_impl_for_tuple() {
             mgp.insert(token::Denomination::NATIVE, 0);
             mgp
         },
+        dynamic_min_gas_price: Default::default(),
     });
 
     let dummy_bytes = b"you look, you die".to_vec();


### PR DESCRIPTION
Adds support for dynamic min gas price inspired by EIP-1559

