### PR TITLE
runtime-sdk: bump crypto deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
@@ -389,7 +389,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -401,12 +400,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
@@ -820,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -830,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher",
 ]
@@ -865,6 +858,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version 0.4.0",
@@ -881,19 +875,6 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 2.0.32",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -1118,7 +1099,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature 2.0.0",
  "spki 0.7.2",
 ]
 
@@ -1132,16 +1113,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "ed25519 2.2.2",
+ "serde",
+ "sha2 0.10.8",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -1229,7 +1234,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3 0.10.8",
+ "sha3",
  "thiserror",
  "uint",
 ]
@@ -1263,7 +1268,7 @@ dependencies = [
  "rlp",
  "scale-info",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "triehash",
 ]
 
@@ -1300,7 +1305,7 @@ dependencies = [
  "rlp",
  "scale-info",
  "serde",
- "sha3 0.10.8",
+ "sha3",
 ]
 
 [[package]]
@@ -1334,7 +1339,7 @@ dependencies = [
  "environmental",
  "evm-core",
  "primitive-types",
- "sha3 0.10.8",
+ "sha3",
 ]
 
 [[package]]
@@ -1876,8 +1881,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.7",
- "signature 2.1.0",
+ "sha2 0.10.8",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -2348,13 +2353,13 @@ name = "oasis-contract-sdk-crypto"
 version = "0.3.0"
 dependencies = [
  "hex",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "k256",
  "oasis-cbor",
  "oasis-runtime-sdk",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
- "x25519-dalek",
+ "x25519-dalek 2.0.0",
 ]
 
 [[package]]
@@ -2408,7 +2413,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
@@ -2429,7 +2434,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "dcap-ql",
  "deoxysii",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "futures",
  "hmac 0.11.0",
  "honggfuzz",
@@ -2465,7 +2470,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "x509-parser",
  "yasna 0.5.2",
  "zeroize",
@@ -2482,10 +2487,9 @@ dependencies = [
  "byteorder",
  "curve25519-dalek 3.2.0",
  "digest 0.10.7",
- "digest 0.9.0",
- "ed25519-dalek",
+ "ed25519-dalek 2.0.0",
  "hex",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "impl-trait-for-tuples",
  "io-context",
  "k256",
@@ -2500,9 +2504,8 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "schnorrkel",
- "sha2 0.9.9",
- "sha3 0.10.8",
- "sha3 0.9.1",
+ "sha2 0.10.8",
+ "sha3",
  "slog",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -2548,7 +2551,7 @@ dependencies = [
  "evm",
  "fixed-hash",
  "hex",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "honggfuzz",
  "k256",
  "num 0.4.1",
@@ -2562,12 +2565,12 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "sha3 0.10.8",
+ "sha2 0.10.8",
+ "sha3",
  "substrate-bn",
  "thiserror",
  "uint",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
 ]
 
 [[package]]
@@ -2626,7 +2629,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3333,18 +3336,19 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
+checksum = "6b3cebf217f367b9d6f2f27ca0ebd14c7d1dfb1ae3cdbf6f3fa1e5c3e4f67bb8"
 dependencies = [
  "arrayref",
  "arrayvec",
- "curve25519-dalek-ng",
+ "curve25519-dalek 4.1.0",
  "merlin",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.9.9",
- "subtle-ng",
+ "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
@@ -3474,25 +3478,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -3534,9 +3526,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -3615,7 +3607,7 @@ dependencies = [
  "curve25519-dalek 4.1.0",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
 ]
 
@@ -3698,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subtle-encoding"
@@ -3710,12 +3702,6 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -3776,8 +3762,8 @@ checksum = "a8b18e007aee6b81b449e92ea6e8c2dceec5e26d340a8f244450caf40938c5d9"
 dependencies = [
  "async-trait",
  "bytes",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 1.5.3",
+ "ed25519-dalek 1.0.1",
  "flex-error",
  "futures",
  "num-traits",
@@ -4178,9 +4164,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle",
@@ -4628,6 +4614,18 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 

--- a/contract-sdk/crypto/Cargo.toml
+++ b/contract-sdk/crypto/Cargo.toml
@@ -13,9 +13,9 @@ oasis-runtime-sdk = { path = "../../runtime-sdk" }
 # Third party.
 k256 = "0.13.1"
 thiserror = "1.0.30"
-x25519-dalek = "1.1.0"
-sha2 = "0.9.8"
-hmac = "0.11.0"
+x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
+sha2 = "0.10.8"
+hmac = "0.12.1"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/contract-sdk/crypto/src/x25519.rs
+++ b/contract-sdk/crypto/src/x25519.rs
@@ -1,5 +1,5 @@
-use hmac::{Hmac, Mac as _, NewMac as _};
-use sha2::Sha512Trunc256;
+use hmac::{Hmac, Mac as _};
+use sha2::Sha512_256;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 pub use oasis_runtime_sdk::core::common::crypto::mrae::deoxysii::KEY_SIZE;
@@ -33,7 +33,7 @@ pub fn derive_symmetric(public_key: &[u8], private_key: &[u8]) -> Result<[u8; KE
     let public = PublicKey::from(public);
     let private = StaticSecret::from(private);
 
-    let mut kdf = Hmac::<Sha512Trunc256>::new_from_slice(b"MRAE_Box_Deoxys-II-256-128")
+    let mut kdf = Hmac::<Sha512_256>::new_from_slice(b"MRAE_Box_Deoxys-II-256-128")
         .map_err(|_| Error::KeyDerivationFunctionFailure)?;
     kdf.update(private.diffie_hellman(&public).as_bytes());
 

--- a/contract-sdk/specs/access/oas173/Cargo.lock
+++ b/contract-sdk/specs/access/oas173/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
@@ -296,7 +296,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -308,12 +307,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
@@ -597,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -607,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher",
 ]
@@ -636,6 +629,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version 0.4.0",
@@ -652,19 +646,6 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 2.0.32",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -877,7 +858,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature 2.0.0",
  "spki 0.7.2",
 ]
 
@@ -891,16 +872,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "ed25519 2.2.2",
+ "serde",
+ "sha2 0.10.8",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -1375,8 +1380,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.7",
- "signature 2.1.0",
+ "sha2 0.10.8",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -1795,13 +1800,13 @@ dependencies = [
 name = "oasis-contract-sdk-crypto"
 version = "0.3.0"
 dependencies = [
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "k256",
  "oasis-cbor",
  "oasis-runtime-sdk",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
- "x25519-dalek",
+ "x25519-dalek 2.0.0",
 ]
 
 [[package]]
@@ -1863,7 +1868,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
@@ -1884,7 +1889,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "dcap-ql",
  "deoxysii",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "futures",
  "hmac 0.11.0",
  "honggfuzz",
@@ -1920,7 +1925,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "x509-parser",
  "yasna 0.5.2",
  "zeroize",
@@ -1936,10 +1941,9 @@ dependencies = [
  "byteorder",
  "curve25519-dalek 3.2.0",
  "digest 0.10.7",
- "digest 0.9.0",
- "ed25519-dalek",
+ "ed25519-dalek 2.0.0",
  "hex",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "impl-trait-for-tuples",
  "io-context",
  "k256",
@@ -1954,9 +1958,8 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "schnorrkel",
- "sha2 0.9.9",
- "sha3 0.10.8",
- "sha3 0.9.1",
+ "sha2 0.10.8",
+ "sha3",
  "slog",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -2013,7 +2016,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2317,6 +2320,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -2530,18 +2534,19 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
+checksum = "6b3cebf217f367b9d6f2f27ca0ebd14c7d1dfb1ae3cdbf6f3fa1e5c3e4f67bb8"
 dependencies = [
  "arrayref",
  "arrayvec",
- "curve25519-dalek-ng",
+ "curve25519-dalek 4.1.0",
  "merlin",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.9.9",
- "subtle-ng",
+ "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
@@ -2671,25 +2676,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2725,9 +2718,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -2800,7 +2793,7 @@ dependencies = [
  "curve25519-dalek 4.1.0",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
 ]
 
@@ -2864,9 +2857,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subtle-encoding"
@@ -2876,12 +2869,6 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -2936,8 +2923,8 @@ checksum = "a8b18e007aee6b81b449e92ea6e8c2dceec5e26d340a8f244450caf40938c5d9"
 dependencies = [
  "async-trait",
  "bytes",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 1.5.3",
+ "ed25519-dalek 1.0.1",
  "flex-error",
  "futures",
  "num-traits",
@@ -3227,9 +3214,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle",
@@ -3538,6 +3525,18 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 

--- a/contract-sdk/specs/token/oas20/Cargo.lock
+++ b/contract-sdk/specs/token/oas20/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
@@ -296,7 +296,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -308,12 +307,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
@@ -597,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -607,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher",
 ]
@@ -636,6 +629,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version 0.4.0",
@@ -652,19 +646,6 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 2.0.32",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -877,7 +858,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature 2.0.0",
  "spki 0.7.2",
 ]
 
@@ -891,16 +872,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "ed25519 2.2.2",
+ "serde",
+ "sha2 0.10.8",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -1375,8 +1380,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.7",
- "signature 2.1.0",
+ "sha2 0.10.8",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -1795,13 +1800,13 @@ dependencies = [
 name = "oasis-contract-sdk-crypto"
 version = "0.3.0"
 dependencies = [
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "k256",
  "oasis-cbor",
  "oasis-runtime-sdk",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
- "x25519-dalek",
+ "x25519-dalek 2.0.0",
 ]
 
 [[package]]
@@ -1864,7 +1869,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
@@ -1885,7 +1890,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "dcap-ql",
  "deoxysii",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "futures",
  "hmac 0.11.0",
  "honggfuzz",
@@ -1921,7 +1926,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "x509-parser",
  "yasna 0.5.2",
  "zeroize",
@@ -1937,10 +1942,9 @@ dependencies = [
  "byteorder",
  "curve25519-dalek 3.2.0",
  "digest 0.10.7",
- "digest 0.9.0",
- "ed25519-dalek",
+ "ed25519-dalek 2.0.0",
  "hex",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "impl-trait-for-tuples",
  "io-context",
  "k256",
@@ -1955,9 +1959,8 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "schnorrkel",
- "sha2 0.9.9",
- "sha3 0.10.8",
- "sha3 0.9.1",
+ "sha2 0.10.8",
+ "sha3",
  "slog",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -2014,7 +2017,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2318,6 +2321,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -2531,18 +2535,19 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
+checksum = "6b3cebf217f367b9d6f2f27ca0ebd14c7d1dfb1ae3cdbf6f3fa1e5c3e4f67bb8"
 dependencies = [
  "arrayref",
  "arrayvec",
- "curve25519-dalek-ng",
+ "curve25519-dalek 4.1.0",
  "merlin",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.9.9",
- "subtle-ng",
+ "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
@@ -2672,25 +2677,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2726,9 +2719,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -2801,7 +2794,7 @@ dependencies = [
  "curve25519-dalek 4.1.0",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
 ]
 
@@ -2865,9 +2858,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subtle-encoding"
@@ -2877,12 +2870,6 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -2937,8 +2924,8 @@ checksum = "a8b18e007aee6b81b449e92ea6e8c2dceec5e26d340a8f244450caf40938c5d9"
 dependencies = [
  "async-trait",
  "bytes",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 1.5.3",
+ "ed25519-dalek 1.0.1",
  "flex-error",
  "futures",
  "num-traits",
@@ -3228,9 +3215,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle",
@@ -3539,6 +3526,18 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -14,7 +14,7 @@ oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 # Third party.
 byteorder = "1.4.3"
 curve25519-dalek = "3.2.0"
-ed25519-dalek = { version = "2.0.0", features = ["digest"] }
+ed25519-dalek = { version = "2.0.0", features = ["digest", "hazmat"] }
 digest = "0.10.3"
 hmac = "0.12.1"
 sha2 = "0.10.8"

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -14,16 +14,14 @@ oasis-runtime-sdk-macros = { path = "../runtime-sdk-macros", optional = true }
 # Third party.
 byteorder = "1.4.3"
 curve25519-dalek = "3.2.0"
-ed25519-dalek = "1.0.1"
+ed25519-dalek = { version = "2.0.0", features = ["digest"] }
 digest = "0.10.3"
-digest_0_9 = { package = "digest", version = "0.9" } # Needed for ed25519-dalek.
-hmac = "0.11.0"
-sha2 = "0.9.8"
+hmac = "0.12.1"
+sha2 = "0.10.8"
 sha3 = { version = "0.10.1", default-features = false }
-sha3_0_9_1 = { package = "sha3", version = "0.9.1", default-features = false }
 k256 = "0.13.1"
 p256 = "0.13.2"
-schnorrkel = "0.10.2"
+schnorrkel = "0.11.2"
 merlin = "3.0.0"
 thiserror = "1.0.30"
 hex = "0.4.2"

--- a/runtime-sdk/modules/evm/Cargo.toml
+++ b/runtime-sdk/modules/evm/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.13.0"
 blake3 = { version = "~1.3.1", features = ["traits-preview"] }
 thiserror = "1.0"
 hex = "0.4.2"
-sha2 = "0.9.5"
+sha2 = "0.10.8"
 substrate-bn = "0.6.0"
 ripemd160 = { version = "0.9", default-features = false }
 k256 = "0.13.1"
@@ -24,7 +24,7 @@ sha3 = { version = "0.10", default-features = false }
 num = { version = "0.4", features = ["alloc"], default-features = false }
 once_cell = "1.8.0"
 x25519-dalek = "1.1.0"
-hmac = "0.11.0"
+hmac = "0.12.1"
 rand_core = { version = "0.6.4", default-features = false }
 
 # Ethereum.

--- a/runtime-sdk/modules/evm/src/precompile/sha512.rs
+++ b/runtime-sdk/modules/evm/src/precompile/sha512.rs
@@ -3,8 +3,7 @@ use evm::{
     executor::stack::{PrecompileHandle, PrecompileOutput},
     ExitSucceed,
 };
-use ripemd160::Digest as _;
-use sha2::{Sha512, Sha512Trunc256};
+use sha2::{digest::Digest as _, Sha512, Sha512_256};
 
 use super::{record_linear_cost, PrecompileResult};
 
@@ -13,7 +12,7 @@ pub(super) fn call_sha512_256(handle: &mut impl PrecompileHandle) -> PrecompileR
     // See benches/criterion_benchmark.rs for the benchmarks.
     record_linear_cost(handle, handle.input().len() as u64, 115, 13)?;
 
-    let mut hasher = Sha512Trunc256::new();
+    let mut hasher = Sha512_256::new();
     hasher.update(handle.input());
     let digest = hasher.finalize();
 

--- a/runtime-sdk/src/crypto/signature/digests.rs
+++ b/runtime-sdk/src/crypto/signature/digests.rs
@@ -47,13 +47,6 @@ where
     }
 }
 
-impl<D> digest_0_9::BlockInput for DummyDigest<D>
-where
-    D: digest_0_9::BlockInput,
-{
-    type BlockSize = <D as digest_0_9::BlockInput>::BlockSize;
-}
-
 impl<D> digest::OutputSizeUser for DummyDigest<D>
 where
     D: digest::OutputSizeUser,
@@ -94,51 +87,9 @@ where
     }
 }
 
-impl<D> digest_0_9::FixedOutput for DummyDigest<D>
-where
-    D: digest_0_9::FixedOutput,
-{
-    type OutputSize = <D as digest_0_9::FixedOutput>::OutputSize;
-
-    fn finalize_into(
-        self,
-        out: &mut digest_0_9::generic_array::GenericArray<u8, Self::OutputSize>,
-    ) {
-        if let Some(digest) = self.underlying {
-            digest.finalize_into(out);
-        } else {
-            out.as_mut_slice().copy_from_slice(&self.preexisting);
-        }
-    }
-
-    fn finalize_into_reset(
-        &mut self,
-        out: &mut digest_0_9::generic_array::GenericArray<u8, Self::OutputSize>,
-    ) {
-        if let Some(ref mut digest) = self.underlying {
-            digest.finalize_into_reset(out);
-        } else {
-            out.as_mut_slice().copy_from_slice(&self.preexisting);
-        }
-    }
-}
-
 impl<D> digest::Reset for DummyDigest<D>
 where
     D: digest::Reset,
-{
-    fn reset(&mut self) {
-        if let Some(ref mut digest) = self.underlying {
-            digest.reset();
-        } else {
-            panic!("mutating dummy digest with precomputed hash");
-        }
-    }
-}
-
-impl<D> digest_0_9::Reset for DummyDigest<D>
-where
-    D: digest_0_9::Reset,
 {
     fn reset(&mut self) {
         if let Some(ref mut digest) = self.underlying {
@@ -154,19 +105,6 @@ where
     D: digest::Update,
 {
     fn update(&mut self, data: &[u8]) {
-        if let Some(ref mut digest) = self.underlying {
-            digest.update(data);
-        } else {
-            panic!("mutating dummy digest with precomputed hash");
-        }
-    }
-}
-
-impl<D> digest_0_9::Update for DummyDigest<D>
-where
-    D: digest_0_9::Update,
-{
-    fn update(&mut self, data: impl AsRef<[u8]>) {
         if let Some(ref mut digest) = self.underlying {
             digest.update(data);
         } else {

--- a/runtime-sdk/src/crypto/signature/ed25519.rs
+++ b/runtime-sdk/src/crypto/signature/ed25519.rs
@@ -3,13 +3,13 @@ use std::convert::TryInto;
 
 use curve25519_dalek::{digest::consts::U64, edwards::CompressedEdwardsY};
 use ed25519_dalek::Signer as _;
-use sha2::{Digest as _, Sha512_256};
+use sha2::{Digest as _, Sha512, Sha512_256};
 
 use oasis_core_runtime::common::crypto::signature::{
     PublicKey as CorePublicKey, Signature as CoreSignature,
 };
 
-use crate::crypto::signature::{Error, Signature};
+use crate::crypto::signature::{Error, Signature, Signer};
 
 /// An Ed25519 public key.
 #[derive(Clone, Debug, PartialEq, Eq, cbor::Encode, cbor::Decode)]
@@ -118,7 +118,91 @@ impl From<PublicKey> for CorePublicKey {
 
 /// A memory-backed signer for Ed25519.
 pub struct MemorySigner {
-    sk: ed25519_dalek::SigningKey,
+    key: Key,
+}
+
+/// The original version of the Ed25519 signer returned the "expanded" secret key from `to_bytes`.
+/// A contract may have stored the "expanded" key and expects its use to continue to succeed.
+/// For backwards compatibility, the signer works with both "expanded" and regular keys.
+/// New invocations receive a regular/proper key, and from-"expanded" ones get the old behavior.
+enum Key {
+    Expanded {
+        esk: ed25519_dalek::hazmat::ExpandedSecretKey,
+        /// The hash output that is used to create the "expanded" secret key.
+        /// It is stored to return from `from_bytes` because it is not recoverable from `esk`.
+        hash: zeroize::Zeroizing<[u8; 64]>,
+    },
+    Regular(ed25519_dalek::SigningKey),
+}
+
+impl Key {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        match bytes.len() {
+            // It's a new/correct-style secret key.
+            32 => bytes
+                .try_into()
+                .map(ed25519_dalek::SigningKey::from_bytes)
+                .map(Self::Regular)
+                .map_err(|_| Error::MalformedPrivateKey),
+            // It's an "expanded" secret key, which is treated as the output of a 64-byte hash function.
+            64 => bytes
+                .try_into()
+                .map(|hash| Self::Expanded {
+                    esk: ed25519_dalek::hazmat::ExpandedSecretKey::from_bytes(&hash),
+                    hash: hash.into(),
+                })
+                .map_err(|_| Error::MalformedPrivateKey),
+            _ => Err(Error::MalformedPrivateKey),
+        }
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Expanded { hash, .. } => hash.to_vec(),
+            Self::Regular(sk) => sk.to_bytes().to_vec(),
+        }
+    }
+
+    fn sign(&self, message: &[u8]) -> Signature {
+        match self {
+            Self::Expanded { esk, .. } => {
+                let verifying_key = ed25519_dalek::VerifyingKey::from(esk);
+                ed25519_dalek::hazmat::raw_sign::<Sha512>(esk, message, &verifying_key)
+            }
+            Self::Regular(sk) => sk.sign(message),
+        }
+        .to_bytes()
+        .to_vec()
+        .into()
+    }
+
+    fn sign_digest<D>(&self, digest: D) -> Result<Signature, Error>
+    where
+        D: ed25519_dalek::Digest<OutputSize = U64>,
+    {
+        match self {
+            Key::Expanded { esk, .. } => {
+                let verifying_key = ed25519_dalek::VerifyingKey::from(esk);
+                ed25519_dalek::hazmat::raw_sign_prehashed::<Sha512, _>(
+                    esk,
+                    digest,
+                    &verifying_key,
+                    None,
+                )
+            }
+            Key::Regular(sk) => sk.sign_prehashed(digest, None),
+        }
+        .map_err(|_| Error::SigningError)
+        .map(|sig| sig.to_bytes().to_vec().into())
+    }
+
+    fn public_key(&self) -> super::PublicKey {
+        let pk = match self {
+            Self::Expanded { esk, .. } => ed25519_dalek::VerifyingKey::from(esk),
+            Self::Regular(sk) => sk.verifying_key(),
+        };
+        super::PublicKey::Ed25519(PublicKey::from_bytes(pk.as_bytes()).unwrap())
+    }
 }
 
 impl MemorySigner {
@@ -126,46 +210,93 @@ impl MemorySigner {
     where
         D: ed25519_dalek::Digest<OutputSize = U64>,
     {
-        self.sk
-            .sign_prehashed(digest, None)
-            .map_err(|_| Error::SigningError)
-            .map(|sig| sig.to_bytes().to_vec().into())
+        self.key.sign_digest(digest)
     }
 }
 
-impl super::Signer for MemorySigner {
+impl Signer for MemorySigner {
     fn new_from_seed(seed: &[u8]) -> Result<Self, Error> {
+        if seed.len() != 32 {
+            return Err(Error::MalformedPublicKey);
+        }
         Self::from_bytes(seed)
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Ok(Self {
-            sk: bytes.try_into().map_err(|_| Error::MalformedPrivateKey)?,
+            key: Key::from_bytes(bytes)?,
         })
     }
 
     fn to_bytes(&self) -> Vec<u8> {
-        self.sk.to_bytes().to_vec()
+        self.key.to_bytes()
     }
 
     fn public_key(&self) -> super::PublicKey {
-        let pk = ed25519_dalek::VerifyingKey::from(&self.sk);
-        super::PublicKey::Ed25519(PublicKey::from_bytes(pk.as_bytes()).unwrap())
+        self.key.public_key()
     }
 
     fn sign(&self, context: &[u8], message: &[u8]) -> Result<Signature, Error> {
         let mut digest = Sha512_256::new();
         digest.update(context);
         digest.update(message);
-        let message = digest.finalize();
-
-        let signature = self.sk.sign(&message);
-
-        Ok(signature.to_bytes().to_vec().into())
+        Ok(self.key.sign(&digest.finalize()))
     }
 
     fn sign_raw(&self, message: &[u8]) -> Result<Signature, Error> {
-        let signature = self.sk.sign(message);
-        Ok(signature.to_bytes().to_vec().into())
+        Ok(self.key.sign(message))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn legacy_esk_equivalence() {
+        let seed = [42u8; 32];
+        let signer = MemorySigner::new_from_seed(&seed).unwrap();
+
+        let esk = ed25519_dalek::hazmat::ExpandedSecretKey::from(&seed);
+        let esk_hash = Sha512::digest(seed);
+        let esk_signer = MemorySigner::from_bytes(&esk_hash).unwrap();
+
+        let esk_public_key = super::super::PublicKey::Ed25519(
+            PublicKey::from_bytes(&ed25519_dalek::VerifyingKey::from(&esk).to_bytes()).unwrap(),
+        );
+
+        assert_eq!(
+            esk_signer.to_bytes().as_slice(),
+            esk_hash.as_slice(),
+            "esk roundtrip"
+        );
+        assert_eq!(signer.to_bytes(), seed, "sk roundtrip");
+
+        let context = b"tests";
+        let message = b"hello, world!";
+        let digest = Sha512::new().chain_update(context).chain_update(message);
+
+        let sig = signer.sign(context, message).unwrap();
+        let esk_sig = esk_signer.sign(context, message).unwrap();
+        assert_eq!(sig, esk_sig, "sig != esk_sig");
+
+        let raw_sig = signer.sign_raw(message).unwrap();
+        let esk_raw_sig = esk_signer.sign_raw(message).unwrap();
+        assert_eq!(raw_sig, esk_raw_sig, "raw_sig != esk_raw_sig");
+
+        let digest_sig = signer.sign_digest(digest.clone()).unwrap();
+        let esk_digest_sig = esk_signer.sign_digest(digest).unwrap();
+        assert_eq!(digest_sig, esk_digest_sig, "digest_sig != esk_digest_sig");
+
+        assert_eq!(
+            signer.public_key(),
+            esk_public_key,
+            "signer pk != esk_public_key"
+        );
+        assert_eq!(
+            esk_signer.public_key(),
+            esk_public_key,
+            "esk_signer pk != esk_pubic_key"
+        );
     }
 }

--- a/runtime-sdk/src/crypto/signature/mod.rs
+++ b/runtime-sdk/src/crypto/signature/mod.rs
@@ -2,7 +2,7 @@
 use std::convert::TryFrom;
 
 use digest::typenum::Unsigned as _;
-use sha2::{Digest as _, Sha512, Sha512Trunc256};
+use sha2::{Digest as _, Sha512, Sha512_256};
 use thiserror::Error;
 
 pub mod context;
@@ -203,7 +203,7 @@ impl PublicKey {
                 SignatureType::Ed25519_Pure => pk.verify_raw(message, signature),
                 SignatureType::Ed25519_PrehashedSha512 => {
                     if context_or_hash.len()
-                        != <Sha512 as sha2::digest::FixedOutput>::OutputSize::USIZE
+                        != <Sha512 as sha2::digest::OutputSizeUser>::OutputSize::USIZE
                     {
                         return Err(Error::InvalidArgument);
                     }
@@ -215,7 +215,9 @@ impl PublicKey {
             Self::Secp256k1(pk) => match signature_type {
                 SignatureType::Secp256k1_Oasis => pk.verify(context_or_hash, message, signature),
                 SignatureType::Secp256k1_PrehashedKeccak256 => {
-                    if context_or_hash.len() != <sha3_0_9_1::Keccak256 as sha3_0_9_1::digest::FixedOutput>::OutputSize::USIZE {
+                    if context_or_hash.len()
+                        != <sha3::Keccak256 as sha3::digest::OutputSizeUser>::OutputSize::USIZE
+                    {
                         return Err(Error::InvalidArgument);
                     }
                     // Use SHA-256 for RFC6979 even if Keccak256 was used for the message.
@@ -226,7 +228,7 @@ impl PublicKey {
                 }
                 SignatureType::Secp256k1_PrehashedSha256 => {
                     if context_or_hash.len()
-                        != <sha2::Sha256 as sha2::digest::FixedOutput>::OutputSize::USIZE
+                        != <sha2::Sha256 as sha2::digest::OutputSizeUser>::OutputSize::USIZE
                     {
                         return Err(Error::InvalidArgument);
                     }
@@ -240,7 +242,7 @@ impl PublicKey {
             Self::Secp256r1(pk) => match signature_type {
                 SignatureType::Secp256r1_PrehashedSha256 => {
                     if context_or_hash.len()
-                        != <sha2::Sha256 as sha2::digest::FixedOutput>::OutputSize::USIZE
+                        != <sha2::Sha256 as sha2::digest::OutputSizeUser>::OutputSize::USIZE
                     {
                         return Err(Error::InvalidArgument);
                     }
@@ -350,7 +352,7 @@ impl MemorySigner {
 
     /// Create a new signer for testing purposes.
     pub fn new_test(sig_type: SignatureType, name: &str) -> Self {
-        let mut digest = Sha512Trunc256::new();
+        let mut digest = Sha512_256::new();
         digest.update(name.as_bytes());
         let seed = digest.finalize();
         Self::new_from_seed(sig_type, &seed).unwrap()
@@ -418,7 +420,7 @@ impl MemorySigner {
                 SignatureType::Ed25519_Pure => signer.sign_raw(message),
                 SignatureType::Ed25519_PrehashedSha512 => {
                     if context_or_hash.len()
-                        != <Sha512 as sha2::digest::FixedOutput>::OutputSize::USIZE
+                        != <Sha512 as sha2::digest::OutputSizeUser>::OutputSize::USIZE
                     {
                         return Err(Error::InvalidArgument);
                     }
@@ -430,7 +432,9 @@ impl MemorySigner {
             Self::Secp256k1(signer) => match signature_type {
                 SignatureType::Secp256k1_Oasis => signer.sign(context_or_hash, message),
                 SignatureType::Secp256k1_PrehashedKeccak256 => {
-                    if context_or_hash.len() != <sha3_0_9_1::Keccak256 as sha3_0_9_1::digest::FixedOutput>::OutputSize::USIZE {
+                    if context_or_hash.len()
+                        != <sha3::Keccak256 as sha3::digest::OutputSizeUser>::OutputSize::USIZE
+                    {
                         return Err(Error::InvalidArgument);
                     }
                     // Use SHA-256 for RFC6979 even if Keccak256 was used for the message.
@@ -441,7 +445,7 @@ impl MemorySigner {
                 }
                 SignatureType::Secp256k1_PrehashedSha256 => {
                     if context_or_hash.len()
-                        != <sha2::Sha256 as sha2::digest::FixedOutput>::OutputSize::USIZE
+                        != <sha2::Sha256 as sha2::digest::OutputSizeUser>::OutputSize::USIZE
                     {
                         return Err(Error::InvalidArgument);
                     }
@@ -455,7 +459,7 @@ impl MemorySigner {
             Self::Secp256r1(signer) => match signature_type {
                 SignatureType::Secp256r1_PrehashedSha256 => {
                     if context_or_hash.len()
-                        != <sha2::Sha256 as sha2::digest::FixedOutput>::OutputSize::USIZE
+                        != <sha2::Sha256 as sha2::digest::OutputSizeUser>::OutputSize::USIZE
                     {
                         return Err(Error::InvalidArgument);
                     }
@@ -536,7 +540,7 @@ mod test {
             (
                 SignatureType::Secp256k1_PrehashedKeccak256,
                 Box::new(|message: &[u8]| -> Vec<u8> {
-                    let mut digest = sha3_0_9_1::Keccak256::new();
+                    let mut digest = sha3::Keccak256::new();
                     digest.update(message);
                     digest.finalize().to_vec()
                 }),

--- a/runtime-sdk/src/crypto/signature/sr25519.rs
+++ b/runtime-sdk/src/crypto/signature/sr25519.rs
@@ -1,6 +1,6 @@
 //! Sr25519 signatures.
 use schnorrkel;
-use sha2::{Digest, Sha512Trunc256};
+use sha2::{Digest, Sha512_256};
 
 use crate::crypto::signature::{Error, Signature};
 
@@ -48,9 +48,9 @@ impl PublicKey {
         // Generate a SigningTranscript from the context, and a pre-hash
         // of the message.
         //
-        // Note: This requires using Sha512Trunc256 instead of our hash,
+        // Note: This requires using Sha512_256 instead of our hash,
         // due to the need for FixedOutput.
-        let mut digest = Sha512Trunc256::new();
+        let mut digest = Sha512_256::new();
         digest.update(message);
         let transcript = context.hash256(digest);
 

--- a/runtime-sdk/src/storage/confidential.rs
+++ b/runtime-sdk/src/storage/confidential.rs
@@ -1,8 +1,8 @@
 use std::convert::TryInto as _;
 
 use anyhow;
-use hmac::{Hmac, Mac as _, NewMac as _};
-use sha2::Sha512Trunc256;
+use hmac::{Hmac, Mac as _};
+use sha2::Sha512_256;
 use slog::error;
 use thiserror::Error;
 use zeroize::{Zeroize, Zeroizing};
@@ -20,7 +20,7 @@ use crate::{
 };
 
 type Nonce = [u8; NONCE_SIZE];
-type Kdf = Hmac<Sha512Trunc256>;
+type Kdf = Hmac<Sha512_256>;
 
 /// Unpack the concatenation of (nonce || byte_slice) into (Nonce, &[u8]).
 fn unpack_nonce_slice<'a>(packed: &'a [u8]) -> Option<(&'a Nonce, &'a [u8])> {

--- a/tests/contracts/hello/Cargo.lock
+++ b/tests/contracts/hello/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
@@ -296,7 +296,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -308,12 +307,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
@@ -597,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -607,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher",
 ]
@@ -636,6 +629,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version 0.4.0",
@@ -652,19 +646,6 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 2.0.32",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -877,7 +858,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature 2.0.0",
  "spki 0.7.2",
 ]
 
@@ -891,16 +872,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "ed25519 2.2.2",
+ "serde",
+ "sha2 0.10.8",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -1386,8 +1391,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.7",
- "signature 2.1.0",
+ "sha2 0.10.8",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -1806,13 +1811,13 @@ dependencies = [
 name = "oasis-contract-sdk-crypto"
 version = "0.3.0"
 dependencies = [
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "k256",
  "oasis-cbor",
  "oasis-runtime-sdk",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
- "x25519-dalek",
+ "x25519-dalek 2.0.0",
 ]
 
 [[package]]
@@ -1874,7 +1879,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
@@ -1895,7 +1900,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "dcap-ql",
  "deoxysii",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "futures",
  "hmac 0.11.0",
  "honggfuzz",
@@ -1931,7 +1936,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 2.0.2",
  "tokio",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
  "x509-parser",
  "yasna 0.5.2",
  "zeroize",
@@ -1947,10 +1952,9 @@ dependencies = [
  "byteorder",
  "curve25519-dalek 3.2.0",
  "digest 0.10.7",
- "digest 0.9.0",
- "ed25519-dalek",
+ "ed25519-dalek 2.0.0",
  "hex",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "impl-trait-for-tuples",
  "io-context",
  "k256",
@@ -1965,9 +1969,8 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "schnorrkel",
- "sha2 0.9.9",
- "sha3 0.10.8",
- "sha3 0.9.1",
+ "sha2 0.10.8",
+ "sha3",
  "slog",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -2024,7 +2027,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2328,6 +2331,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -2541,18 +2545,19 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
+checksum = "6b3cebf217f367b9d6f2f27ca0ebd14c7d1dfb1ae3cdbf6f3fa1e5c3e4f67bb8"
 dependencies = [
  "arrayref",
  "arrayvec",
- "curve25519-dalek-ng",
+ "curve25519-dalek 4.1.0",
  "merlin",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.9.9",
- "subtle-ng",
+ "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
@@ -2682,25 +2687,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2736,9 +2729,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -2811,7 +2804,7 @@ dependencies = [
  "curve25519-dalek 4.1.0",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
 ]
 
@@ -2875,9 +2868,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subtle-encoding"
@@ -2887,12 +2880,6 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -2947,8 +2934,8 @@ checksum = "a8b18e007aee6b81b449e92ea6e8c2dceec5e26d340a8f244450caf40938c5d9"
 dependencies = [
  "async-trait",
  "bytes",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 1.5.3",
+ "ed25519-dalek 1.0.1",
  "flex-error",
  "futures",
  "num-traits",
@@ -3238,9 +3225,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle",
@@ -3549,6 +3536,18 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+dependencies = [
+ "curve25519-dalek 4.1.0",
+ "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 


### PR DESCRIPTION
I had some trouble getting `p384` working because `sha2`, `ed25519_dalek`, and a few other crypto deps were a version behind. Such is the state of Rust crypto. Anyway, this PR does not change any functionality, but I did remove one test for rejecting all-zero ed25519 private keys because `[0u8; 32]` is a valid private key, just not one you'd want to use.