### PR TITLE
runtime-sdk: remove compressed format requirement from ECDSA precompiles

### DIFF
--- a/runtime-sdk/src/crypto/signature/secp256k1.rs
+++ b/runtime-sdk/src/crypto/signature/secp256k1.rs
@@ -36,11 +36,9 @@ impl PublicKey {
 
     /// Construct a public key from a slice of bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let ep = k256::EncodedPoint::from_bytes(bytes).map_err(|_| Error::MalformedPublicKey)?;
-        if !ep.is_compressed() {
-            return Err(Error::MalformedPublicKey);
-        }
-        Ok(PublicKey(ep))
+        k256::EncodedPoint::from_bytes(bytes)
+            .map_err(|_| Error::MalformedPublicKey)
+            .map(PublicKey)
     }
 
     /// Verify a signature.

--- a/runtime-sdk/src/crypto/signature/secp256r1.rs
+++ b/runtime-sdk/src/crypto/signature/secp256r1.rs
@@ -23,11 +23,9 @@ impl PublicKey {
 
     /// Construct a public key from a slice of bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let ep = p256::EncodedPoint::from_bytes(bytes).map_err(|_| Error::MalformedPublicKey)?;
-        if !ep.is_compressed() {
-            return Err(Error::MalformedPublicKey);
-        }
-        Ok(PublicKey(ep))
+        p256::EncodedPoint::from_bytes(bytes)
+            .map_err(|_| Error::MalformedPublicKey)
+            .map(PublicKey)
     }
 
     /// Verify a signature.

--- a/runtime-sdk/src/crypto/signature/secp384r1.rs
+++ b/runtime-sdk/src/crypto/signature/secp384r1.rs
@@ -22,11 +22,9 @@ impl PublicKey {
 
     /// Construct a public key from a slice of bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let ep = p384::EncodedPoint::from_bytes(bytes).map_err(|_| Error::MalformedPublicKey)?;
-        if !ep.is_compressed() {
-            return Err(Error::MalformedPublicKey);
-        }
-        Ok(PublicKey(ep))
+        p384::EncodedPoint::from_bytes(bytes)
+            .map_err(|_| Error::MalformedPublicKey)
+            .map(PublicKey)
     }
 
     /// Verify a signature.


### PR DESCRIPTION
This PR removes the requirement that public keys provided to the ECDSA precompiles be in compressed format. Sometimes all the user has is an uncompressed one and the curve is not gas-efficient in Solidity. The restriction seems to be for no particular reason, so I removed it because it significantly limits the utility of the precompiles.