### PR TITLE
ts-web: 1.0 releases

### DIFF
--- a/client-sdk/ts-web/core/docs/changelog.md
+++ b/client-sdk/ts-web/core/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased changes
+## v1.0.0
+
+Spotlight change:
+
+- Bumped protobufjs to 7.2.x.
+  Due to the versioning scheme they use, this is a "major" version, so
+  downstream packages can now upgrade to that too.
 
 Little things:
 
@@ -8,8 +14,14 @@ Little things:
   return falsy values (e.g. 0) instead of `undefined`.
   Our thanks to the grpc-web team that helped us add support for this in their
   library!
-- Compatibility with oasis-core is updated to 22.2.2.
-  They told me to keep pressing 2 until it auto completed a Git tag.
+- Compatibility with oasis-core is updated to 23.0.
+  How neat was that, that nobody complained about incompatibility for so long?
+
+Extra note:
+
+- Happy v1!
+  We'll be publishing this to the `latest` tag on npm, so you won't need to
+  specify the `@alpha` tag anymore.
 
 ## v0.1.1-alpha.2
 

--- a/client-sdk/ts-web/core/docs/getting-started.md
+++ b/client-sdk/ts-web/core/docs/getting-started.md
@@ -8,16 +8,8 @@
 ## Getting this SDK and building
 
 ```sh
-npm install @oasisprotocol/client@alpha
+npm install @oasisprotocol/client
 ```
-
-Install this package [from
-npm](https://www.npmjs.com/package/@oasisprotocol/client?activeTab=versions).
-The `@alpha` is needed because we are publishing to the `alpha` tag.
-Due to technical limitations, npm has also created a `latest` tag which is
-stuck at a very old alpha verison.
-
-**TODO: Update this command when this library gets out of alpha.**
 
 You'll need a bundler.
 We have [a sample that uses webpack](../playground/webpack.config.js).

--- a/client-sdk/ts-web/core/package.json
+++ b/client-sdk/ts-web/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client",
-    "version": "0.1.1-alpha.2",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "homepage": "https://github.com/oasisprotocol/oasis-sdk/tree/main/client-sdk/ts-web/core",
     "repository": {

--- a/client-sdk/ts-web/core/tsconfig.json
+++ b/client-sdk/ts-web/core/tsconfig.json
@@ -12,9 +12,9 @@
         "src/**/*"
     ],
     "typedocOptions": {
-      "entryPoints": ["src/index.ts"],
-      "out": "docs/api",
-      "excludeInternal": true,
-      "excludePrivate": true
+        "entryPoints": ["src/index.ts"],
+        "out": "docs/api",
+        "excludeInternal": true,
+        "excludePrivate": true
     }
 }

--- a/client-sdk/ts-web/ext-utils/docs/changelog.md
+++ b/client-sdk/ts-web/ext-utils/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.0
+
+Spotlight change:
+
+- Our dependencies on `@oasisprotocol/client` and `@oasisprotocol/client-rt`
+  are bumped to v1.0.0.
+  Happy v1!
+
 ## v0.1.1-alpha.1
 
 Spotlight change:

--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -24,7 +24,7 @@
         "test-e2e-cy": "cypress run"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.1-alpha.2"
+        "@oasisprotocol/client": "^1.0.0"
     },
     "devDependencies": {
         "@oasisprotocol/client-rt": "^0.2.1-alpha.2",

--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-ext-utils",
-    "version": "0.1.1-alpha.1",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "homepage": "https://github.com/oasisprotocol/oasis-sdk/tree/main/client-sdk/ts-web/ext-utils",
     "repository": {

--- a/client-sdk/ts-web/ext-utils/package.json
+++ b/client-sdk/ts-web/ext-utils/package.json
@@ -27,7 +27,7 @@
         "@oasisprotocol/client": "^1.0.0"
     },
     "devDependencies": {
-        "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
+        "@oasisprotocol/client-rt": "^1.0.0",
         "buffer": "^6.0.3",
         "cypress": "^13.6.1",
         "prettier": "^3.1.0",

--- a/client-sdk/ts-web/ext-utils/tsconfig.json
+++ b/client-sdk/ts-web/ext-utils/tsconfig.json
@@ -12,9 +12,9 @@
         "src/**/*"
     ],
     "typedocOptions": {
-      "entryPoints": ["src/index.ts"],
-      "out": "docs/api",
-      "excludeInternal": true,
-      "excludePrivate": true
+        "entryPoints": ["src/index.ts"],
+        "out": "docs/api",
+        "excludeInternal": true,
+        "excludePrivate": true
     }
 }

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -8664,7 +8664,7 @@
         },
         "signer-ledger": {
             "name": "@oasisprotocol/client-signer-ledger",
-            "version": "0.1.1-alpha.1",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^6.28.0",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -50,7 +50,7 @@
                 "@oasisprotocol/client": "^1.0.0"
             },
             "devDependencies": {
-                "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
+                "@oasisprotocol/client-rt": "^1.0.0",
                 "buffer": "^6.0.3",
                 "cypress": "^13.6.1",
                 "prettier": "^3.1.0",
@@ -8633,7 +8633,7 @@
         },
         "rt": {
             "name": "@oasisprotocol/client-rt",
-            "version": "0.2.1-alpha.2",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@oasisprotocol/client": "^1.0.0",
@@ -9683,7 +9683,7 @@
             "version": "file:ext-utils",
             "requires": {
                 "@oasisprotocol/client": "^1.0.0",
-                "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
+                "@oasisprotocol/client-rt": "^1.0.0",
                 "buffer": "^6.0.3",
                 "cypress": "^13.6.1",
                 "prettier": "^3.1.0",

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -44,7 +44,7 @@
         },
         "ext-utils": {
             "name": "@oasisprotocol/client-ext-utils",
-            "version": "0.1.1-alpha.1",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@oasisprotocol/client": "^1.0.0"

--- a/client-sdk/ts-web/package-lock.json
+++ b/client-sdk/ts-web/package-lock.json
@@ -13,7 +13,7 @@
         },
         "core": {
             "name": "@oasisprotocol/client",
-            "version": "0.1.1-alpha.2",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^2.0.0",
@@ -47,7 +47,7 @@
             "version": "0.1.1-alpha.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.1-alpha.2"
+                "@oasisprotocol/client": "^1.0.0"
             },
             "devDependencies": {
                 "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
@@ -8636,7 +8636,7 @@
             "version": "0.2.1-alpha.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@oasisprotocol/client": "^0.1.1-alpha.2",
+                "@oasisprotocol/client": "^1.0.0",
                 "@oasisprotocol/deoxysii": "^0.0.5",
                 "elliptic": "^6.5.3",
                 "js-sha512": "^0.8.0",
@@ -8668,7 +8668,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ledgerhq/hw-transport-webusb": "^6.28.0",
-                "@oasisprotocol/client": "^0.1.1-alpha.2",
+                "@oasisprotocol/client": "^1.0.0",
                 "@oasisprotocol/ledger": "^1.0.0"
             },
             "devDependencies": {
@@ -9682,7 +9682,7 @@
         "@oasisprotocol/client-ext-utils": {
             "version": "file:ext-utils",
             "requires": {
-                "@oasisprotocol/client": "^0.1.1-alpha.2",
+                "@oasisprotocol/client": "^1.0.0",
                 "@oasisprotocol/client-rt": "^0.2.1-alpha.2",
                 "buffer": "^6.0.3",
                 "cypress": "^13.6.1",
@@ -9699,7 +9699,7 @@
         "@oasisprotocol/client-rt": {
             "version": "file:rt",
             "requires": {
-                "@oasisprotocol/client": "^0.1.1-alpha.2",
+                "@oasisprotocol/client": "^1.0.0",
                 "@oasisprotocol/deoxysii": "^0.0.5",
                 "@types/elliptic": "^6.4.18",
                 "@types/jest": "^29.5.11",
@@ -9727,7 +9727,7 @@
             "version": "file:signer-ledger",
             "requires": {
                 "@ledgerhq/hw-transport-webusb": "^6.28.0",
-                "@oasisprotocol/client": "^0.1.1-alpha.2",
+                "@oasisprotocol/client": "^1.0.0",
                 "@oasisprotocol/ledger": "^1.0.0",
                 "@types/w3c-web-usb": "^1.0.10",
                 "buffer": "^6.0.3",

--- a/client-sdk/ts-web/rt/docs/changelog.md
+++ b/client-sdk/ts-web/rt/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.0
+
+Spotlight change:
+
+- Our dependency on `@oasisprotocol/client` is bumped to v1.0.0.
+  Happy v1!
+
 ## v0.2.1-alpha.2
 
 Spotlight change:

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -22,7 +22,7 @@
         "test-e2e-cy": "cypress run"
     },
     "dependencies": {
-        "@oasisprotocol/client": "^0.1.1-alpha.2",
+        "@oasisprotocol/client": "^1.0.0",
         "@oasisprotocol/deoxysii": "^0.0.5",
         "elliptic": "^6.5.3",
         "js-sha512": "^0.8.0",

--- a/client-sdk/ts-web/rt/package.json
+++ b/client-sdk/ts-web/rt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-rt",
-    "version": "0.2.1-alpha.2",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "homepage": "https://github.com/oasisprotocol/oasis-sdk/tree/main/client-sdk/ts-web/rt",
     "repository": {

--- a/client-sdk/ts-web/rt/tsconfig.json
+++ b/client-sdk/ts-web/rt/tsconfig.json
@@ -11,9 +11,9 @@
         "src/**/*"
     ],
     "typedocOptions": {
-      "entryPoints": ["src/index.ts"],
-      "out": "docs/api",
-      "excludeInternal": true,
-      "excludePrivate": true
+        "entryPoints": ["src/index.ts"],
+        "out": "docs/api",
+        "excludeInternal": true,
+        "excludePrivate": true
     }
 }

--- a/client-sdk/ts-web/signer-ledger/docs/changelog.md
+++ b/client-sdk/ts-web/signer-ledger/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.0
+
+Spotlight change:
+
+- Our dependency on `@oasisprotocol/client` is bumped to v1.0.0.
+  Happy v1!
+
 ## v0.1.1-alpha.1
 
 Spotlight change:

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oasisprotocol/client-signer-ledger",
-    "version": "0.1.1-alpha.1",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "homepage": "https://github.com/oasisprotocol/oasis-sdk/tree/main/client-sdk/ts-web/signer-ledger",
     "repository": {

--- a/client-sdk/ts-web/signer-ledger/package.json
+++ b/client-sdk/ts-web/signer-ledger/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@ledgerhq/hw-transport-webusb": "^6.28.0",
-        "@oasisprotocol/client": "^0.1.1-alpha.2",
+        "@oasisprotocol/client": "^1.0.0",
         "@oasisprotocol/ledger": "^1.0.0"
     },
     "devDependencies": {

--- a/client-sdk/ts-web/signer-ledger/tsconfig.json
+++ b/client-sdk/ts-web/signer-ledger/tsconfig.json
@@ -12,9 +12,9 @@
         "src/**/*"
     ],
     "typedocOptions": {
-      "entryPoints": ["src/index.ts"],
-      "out": "docs/api",
-      "excludeInternal": true,
-      "excludePrivate": true
+        "entryPoints": ["src/index.ts"],
+        "out": "docs/api",
+        "excludeInternal": true,
+        "excludePrivate": true
     }
 }


### PR DESCRIPTION
so downstream users can get rid of that nagging about protobufjs 7.1.x having a vulnerability