### PR TITLE
deps: Bump rust toolchain for minimal-runtime to 2023-09-12

### DIFF
--- a/examples/contract-sdk/c10l-hello-world/rust-toolchain.toml
+++ b/examples/contract-sdk/c10l-hello-world/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-16"
+channel = "nightly-2023-09-12"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-fortanix-unknown-sgx", "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/examples/contract-sdk/hello-world/rust-toolchain.toml
+++ b/examples/contract-sdk/hello-world/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-16"
+channel = "nightly-2023-09-12"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-fortanix-unknown-sgx", "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/examples/runtime-sdk/minimal-runtime/Cargo.toml
+++ b/examples/runtime-sdk/minimal-runtime/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.4.0" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.8.2" }

--- a/examples/runtime-sdk/minimal-runtime/rust-toolchain.toml
+++ b/examples/runtime-sdk/minimal-runtime/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-16"
+channel = "nightly-2023-09-12"
 components = [ "rustfmt", "clippy" ]
 targets = [ "x86_64-fortanix-unknown-sgx", "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
Unblocks https://github.com/oasisprotocol/oasis-sdk/pull/1600