### PR TITLE
docs: Fix broken anchors

### DIFF
--- a/docs/contract/confidential-smart-contract.md
+++ b/docs/contract/confidential-smart-contract.md
@@ -74,7 +74,7 @@ Since the smart contracts store is public, uploading the Wasm code is
 the same as for the non-confidential ones:
 
 ```shell
-oasis contracts upload hello_world.wasm
+oasis contract upload hello_world.wasm
 ```
 
 <!-- markdownlint-disable line-length -->
@@ -86,7 +86,7 @@ oasis contracts upload hello_world.wasm
 
 ## Confidential Instantiation and Calling
 
-To generate an encrypted transaction, the `oasis contracts` subcommand
+To generate an encrypted transaction, the `oasis contract` subcommand
 expects a `--encrypted` flag. The client (`oasis` command in our case) will
 generate and use an ephemeral keypair for encryption. If the original
 transaction was encrypted, the returned transaction result will also be
@@ -122,7 +122,7 @@ instantiate our smart contract above with a single write to the contract state,
 we need to raise the gas limit to `60000`:
 
 ```shell
-oasis contracts instantiate CODEID '{instantiate: {initial_counter: 42}}' --encrypted --gas-limit 60000
+oasis contract instantiate CODEID '{instantiate: {initial_counter: 42}}' --encrypted --gas-limit 400000
 ```
 
 :::danger
@@ -146,7 +146,7 @@ calls - in this case `300,000`.
 Finally, we make a confidential call:
 
 ```shell
-oasis contracts call INSTANCEID '{say_hello: {who: "me"}}' --encrypted --gas-limit 60000
+oasis contract call INSTANCEID '{say_hello: {who: "me"}}' --encrypted --gas-limit 400000
 ```
 
 :::tip Call Format

--- a/docs/contract/hello-world.md
+++ b/docs/contract/hello-world.md
@@ -133,7 +133,7 @@ The first deployment step that needs to be performed only once for the given
 binary is uploading the Wasm binary.
 
 ```
-oasis contracts upload hello_world.wasm
+oasis contract upload hello_world.wasm
 ```
 
 After successful execution it will show the code ID that you need to use for any
@@ -143,7 +143,7 @@ arguments. Note that the arguments depend on the contract that is being deployed
 and in our hello world case we are simply taking the initial counter value.
 
 ```
-oasis contracts instantiate CODEID '{instantiate: {initial_counter: 42}}'
+oasis contract instantiate CODEID '{instantiate: {initial_counter: 42}}'
 ```
 
 <!-- TODO: Mention how to send tokens and change the upgrade policy. -->
@@ -152,7 +152,7 @@ After successful execution it shows the instance ID that you need for calling
 the instantiated contract. Next, you can test calling the contract.
 
 ```
-oasis contracts call INSTANCEID '{say_hello: {who: "me"}}'
+oasis contract call INSTANCEID '{say_hello: {who: "me"}}'
 ```
 
 :::info Example

--- a/docs/contract/prerequisites.md
+++ b/docs/contract/prerequisites.md
@@ -10,7 +10,9 @@ described steps you will be able to start building your first smart contract
 on Oasis!
 
 If you already have everything set up, feel free to skip to the [next
-chapter](hello-world.md).
+chapter].
+
+[next chapter]: hello-world.md
 
 ## Environment Setup
 

--- a/docs/runtime/minimal-runtime.md
+++ b/docs/runtime/minimal-runtime.md
@@ -22,14 +22,16 @@ Since the Runtime SDK requires a nightly version of the Rust toolchain, you need
 to specify a version to use by creating a special file called
 `rust-toolchain.toml` containing the following information:
 
-![code](../../examples/runtime-sdk/minimal-runtime/rust-toolchain.toml)
+<!-- markdownlint-disable line-length -->
+![code toml](../../examples/runtime-sdk/minimal-runtime/rust-toolchain.toml "rust-toolchain.toml")
+<!-- markdownlint-enable line-length -->
 
 Additionally, due to the requirements of some upstream dependencies, you need to
 configure Cargo to always build with specific target CPU platform features
 (namely AES-NI and SSE3) by creating a `.cargo/config` file with the following
 content:
 
-```toml
+```toml title=".cargo/config"
 [build]
 rustflags = ["-C", "target-feature=+aes,+ssse3"]
 rustdocflags = ["-C", "target-feature=+aes,+ssse3"]
@@ -199,7 +201,7 @@ Now, let's see, if the local network was correctly initialized and the runtime
 is ready:
 
 ```bash
-oasis inspect node-status --network localhost
+oasis network status --network localhost
 ```
 
 If everything is working correctly, you should see the `"status": "ready"`
@@ -229,8 +231,11 @@ Now, let's add `minimal` runtime to the wallet. By default, `oasis-net-runner`
 assigns ID `8000000000000000000000000000000000000000000000000000000000000000`
 to the first provided runtime.
 
-```bash
+```shell
 oasis paratime add localhost minimal 8000000000000000000000000000000000000000000000000000000000000000
+```
+
+```
 ? Description: minimal
 ? Denomination symbol: TEST
 ? Denomination decimal places: 9
@@ -242,8 +247,11 @@ other test users (check the [oasis-sdk testing source] for a complete list).
 You can access the accounts by prepending `test:` literal in front of the test
 user's name, for example `test:alice`.
 
-```bash
-oasis accounts show test:alice --network localhost
+```shell
+oasis account show test:alice --network localhost
+```
+
+```
 Address: oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve
 Nonce: 0
 
@@ -261,8 +269,11 @@ Balances for all denominations:
 Sending some TEST in your runtime should also work. Let's send 0.1 TEST to
 Bob's address.
 
-```bash
-oasis accounts transfer 0.1 test:bob --network localhost --account test:alice 
+```shell
+oasis account transfer 0.1 test:bob --network localhost --account test:alice 
+```
+
+```
 Unlock your account.
 ? Passphrase: 
 You are about to sign the following transaction:
@@ -321,7 +332,7 @@ to submit some transactions and perform queries.
 
 First, create a `tests` directory and move into it, creating a Go module:
 
-```bash
+```shell
 go mod init example.com/oasisprotocol/minimal-runtime-client
 go mod tidy
 ```
@@ -334,13 +345,13 @@ Then create a `test.go` file with the following content:
 
 Fetch the dependencies:
 
-```bash
+```shell
 go get
 ```
 
 And build it:
 
-```bash
+```shell
 go build
 ```
 
@@ -352,7 +363,7 @@ end it will again query and display the final balances of both accounts.
 
 To run the built client do:
 
-```bash
+```shell
 ./minimal-runtime-client
 ```
 

--- a/docs/runtime/prerequisites.md
+++ b/docs/runtime/prerequisites.md
@@ -8,8 +8,9 @@ This chapter will show you how to install the software required for developing
 a runtime and client using the Oasis SDK. After successfully completing all the
 described steps you will be able to start building your first runtime!
 
-If you already have everything set up, feel free to skip to the [next
-chapter](minimal-runtime.md).
+If you already have everything set up, feel free to skip to the [next chapter].
+
+[next chapter]: minimal-runtime.md
 
 ## Environment Setup
 


### PR DESCRIPTION
Docusaurus 3.x markdown linter is more strict. This PR:
- fixes more strict linter errors
- refreshes docs/runtime/minimal-runtime.md looking more consistent with other parts of docs and updates the Oasis CLI commands