### PR TITLE
runtime-sdk: Support storage update gas costs

### DIFF
--- a/runtime-sdk/modules/contracts/src/abi/oasis/test.rs
+++ b/runtime-sdk/modules/contracts/src/abi/oasis/test.rs
@@ -5,7 +5,6 @@ use oasis_runtime_sdk::{
     error::Error as _,
     modules,
     modules::core,
-    state::CurrentState,
     testing::mock,
     types::{address::Address, transaction::CallFormat},
 };

--- a/runtime-sdk/src/dispatcher.rs
+++ b/runtime-sdk/src/dispatcher.rs
@@ -1003,12 +1003,7 @@ mod test {
                         max_tx_size: 32 * 1024,
                         max_tx_signers: 1,
                         max_multisig_signers: 8,
-                        gas_costs: core::GasCosts {
-                            tx_byte: 0,
-                            auth_signature: 0,
-                            auth_multisig_signer: 0,
-                            callformat_x25519_deoxysii: 0,
-                        },
+                        gas_costs: Default::default(),
                         min_gas_price: BTreeMap::from([(token::Denomination::NATIVE, 0)]),
                         dynamic_min_gas_price: Default::default(),
                     },

--- a/runtime-sdk/src/state.rs
+++ b/runtime-sdk/src/state.rs
@@ -584,6 +584,14 @@ impl State {
             .unwrap_or_default()
     }
 
+    /// Size (in bytes) of any pending updates in the associated store.
+    pub fn pending_store_update_byte_size(&self) -> usize {
+        self.store
+            .as_ref()
+            .map(|store| store.pending_update_byte_size())
+            .unwrap_or_default()
+    }
+
     /// Random number generator.
     pub fn rng(&mut self) -> &mut RootRng {
         self.rng.as_mut().unwrap()

--- a/runtime-sdk/src/storage/mkvs.rs
+++ b/runtime-sdk/src/storage/mkvs.rs
@@ -50,4 +50,8 @@ impl<M: mkvs::MKVS> NestedStore for MKVSStore<M> {
     fn has_pending_updates(&self) -> bool {
         true
     }
+
+    fn pending_update_byte_size(&self) -> usize {
+        0
+    }
 }

--- a/runtime-sdk/src/storage/mod.rs
+++ b/runtime-sdk/src/storage/mod.rs
@@ -41,6 +41,9 @@ pub trait NestedStore: Store {
 
     /// Whether there are any store updates pending to be committed.
     fn has_pending_updates(&self) -> bool;
+
+    /// Size (in bytes) of any pending updates.
+    fn pending_update_byte_size(&self) -> usize;
 }
 
 impl<S: Store + ?Sized> Store for &mut S {

--- a/runtime-sdk/src/storage/overlay.rs
+++ b/runtime-sdk/src/storage/overlay.rs
@@ -50,6 +50,25 @@ impl<S: Store> NestedStore for OverlayStore<S> {
     fn has_pending_updates(&self) -> bool {
         !self.dirty.is_empty()
     }
+
+    fn pending_update_byte_size(&self) -> usize {
+        let updated_size = self
+            .overlay
+            .iter()
+            .map(|(key, value)| key.len() + value.len())
+            .reduce(|acc, bytes| acc + bytes)
+            .unwrap_or_default();
+
+        let removed_size = self
+            .dirty
+            .iter()
+            .filter(|key| !self.overlay.contains_key(key.as_slice()))
+            .map(|key| key.len())
+            .reduce(|acc, bytes| acc + bytes)
+            .unwrap_or_default();
+
+        updated_size.saturating_add(removed_size)
+    }
 }
 
 impl<S: Store> Store for OverlayStore<S> {

--- a/tests/runtimes/simple-keyvalue/src/lib.rs
+++ b/tests/runtimes/simple-keyvalue/src/lib.rs
@@ -131,6 +131,7 @@ impl sdk::Runtime for Runtime {
                     max_multisig_signers: 8,
                     gas_costs: modules::core::GasCosts {
                         tx_byte: 1,
+                        storage_byte: 1,
                         auth_signature: 10,
                         auth_multisig_signer: 10,
                         callformat_x25519_deoxysii: 50,


### PR DESCRIPTION
Introduce the notion of storage gas which is charged for each byte of a key/value pair that is updated in storage. For removals only the size of the key is charged. The reason for this is to reflect actual costs that storage updates have (as any state update increases the size of the write log).

Storage gas is handled in a somewhat special way where any gas already used by transaction execution is taken into account. This means that storage gas is only charged in case a transaction would use more storage gas than execution gas in order to limit storage growth.