### PR TITLE
client-sdk/go: Migrate ResolveAddress to Oasis CLI

### DIFF
--- a/examples/runtime-sdk/minimal-runtime/Cargo.toml
+++ b/examples/runtime-sdk/minimal-runtime/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.8.2" }
+oasis-runtime-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "runtime-sdk/v0.8.4" }

--- a/tools/gen_runtime_vectors/main.go
+++ b/tools/gen_runtime_vectors/main.go
@@ -105,7 +105,7 @@ func main() {
 						// Invalid Deposit: chain_context invalid
 						{testing.Dave.EthAddress.String(), testing.Dave.EthAddress, invalidChainContext, false},
 					} {
-						to, ethTo, _ := helpers.ResolveAddress(nil, t.to)
+						to, ethTo, _ := helpers.ResolveEthOrOasisAddress(t.to)
 						txBody := &consensusaccounts.Deposit{
 							To:     to,
 							Amount: types.NewBaseUnits(*quantity.NewFromUint64(amt), types.NativeDenomination),
@@ -139,7 +139,7 @@ func main() {
 						// Valid Withdraw: Frank -> Alice on consensus
 						{testing.Alice.Address.String(), testing.Frank, true},
 					} {
-						to, _, _ := helpers.ResolveAddress(nil, t.to)
+						to, _, _ := helpers.ResolveEthOrOasisAddress(t.to)
 						txBody := &consensusaccounts.Withdraw{
 							To:     to,
 							Amount: types.NewBaseUnits(*quantity.NewFromUint64(amt), types.NativeDenomination),
@@ -179,7 +179,7 @@ func main() {
 						// Invalid Transfer: orig_to doesn't match transaction's to
 						{testing.Dave.EthAddress.String(), &unknownEthAddr, testing.Alice, false},
 					} {
-						to, ethTo, _ := helpers.ResolveAddress(nil, t.to)
+						to, ethTo, _ := helpers.ResolveEthOrOasisAddress(t.to)
 						txBody := &accounts.Transfer{
 							To:     *to,
 							Amount: types.NewBaseUnits(*quantity.NewFromUint64(amt), types.NativeDenomination),
@@ -207,7 +207,7 @@ func main() {
 						// Invalid Delegate: chain_context invalid
 						{testing.Dave.EthAddress.String(), invalidChainContext, false},
 					} {
-						to, _, _ := helpers.ResolveAddress(nil, t.to)
+						to, _, _ := helpers.ResolveEthOrOasisAddress(t.to)
 						txBody := &consensusaccounts.Delegate{
 							To:     *to,
 							Amount: types.NewBaseUnits(*quantity.NewFromUint64(amt), types.NativeDenomination),
@@ -234,7 +234,7 @@ func main() {
 						// Invalid Undelegate: chain_context invalid
 						{testing.Dave.EthAddress.String(), invalidChainContext, false},
 					} {
-						from, _, _ := helpers.ResolveAddress(nil, t.from)
+						from, _, _ := helpers.ResolveEthOrOasisAddress(t.from)
 						txBody := &consensusaccounts.Undelegate{
 							From:   *from,
 							Shares: *quantity.NewFromUint64(amt),


### PR DESCRIPTION
This PR:
- Removes `ResolveAddress()` helper which was moved to Oasis CLI (https://github.com/oasisprotocol/cli/pull/134)
- Adds test for `ResolveEthOrOasisAddress()`
- deps: bumps minimal-runtime example runtime-sdk dependency to 0.8.4

Merge after https://github.com/oasisprotocol/cli/pull/134 and when the `runtime-sdk/v0.8.4` tag is pushed after https://github.com/oasisprotocol/oasis-sdk/pull/1507