### PR TITLE
Bump wasm3-rs to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "quote 1.0.33",
  "regex",
  "rustc-hash",
- "shlex 1.3.0",
+ "shlex",
  "which 3.1.1",
 ]
 
@@ -331,7 +331,7 @@ dependencies = [
  "quote 1.0.33",
  "regex",
  "rustc-hash",
- "shlex 1.3.0",
+ "shlex",
  "syn 2.0.41",
  "which 4.4.2",
 ]
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "oasis-runtime-sdk"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "oasis-runtime-sdk-contracts"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3514,12 +3514,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-
-[[package]]
-name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
@@ -4347,8 +4341,8 @@ dependencies = [
 
 [[package]]
 name = "wasm3"
-version = "0.3.1"
-source = "git+https://github.com/oasisprotocol/wasm3-rs?tag=v0.3.1#ec3a16c2beff2d41efbd9fa20412c71b18c65869"
+version = "0.3.2"
+source = "git+https://github.com/oasisprotocol/wasm3-rs?tag=v0.3.2#4c888af4209244d0c7652ee7a8d2c7fe0b5752b3"
 dependencies = [
  "cty",
  "impl-trait-for-tuples",
@@ -4360,12 +4354,12 @@ dependencies = [
 [[package]]
 name = "wasm3-sys"
 version = "0.3.1"
-source = "git+https://github.com/oasisprotocol/wasm3-rs?tag=v0.3.1#ec3a16c2beff2d41efbd9fa20412c71b18c65869"
+source = "git+https://github.com/oasisprotocol/wasm3-rs?tag=v0.3.2#4c888af4209244d0c7652ee7a8d2c7fe0b5752b3"
 dependencies = [
  "bindgen 0.58.1",
  "cc",
  "cty",
- "shlex 0.1.1",
+ "shlex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "quote 1.0.33",
  "regex",
  "rustc-hash",
- "shlex 1.2.0",
+ "shlex 1.3.0",
  "which 3.1.1",
 ]
 
@@ -331,7 +331,7 @@ dependencies = [
  "quote 1.0.33",
  "regex",
  "rustc-hash",
- "shlex 1.2.0",
+ "shlex 1.3.0",
  "syn 2.0.41",
  "which 4.4.2",
 ]
@@ -3520,9 +3520,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/contract-sdk/specs/access/oas173/Cargo.lock
+++ b/contract-sdk/specs/access/oas173/Cargo.lock
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "oasis-runtime-sdk"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/contract-sdk/specs/token/oas20/Cargo.lock
+++ b/contract-sdk/specs/token/oas20/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "oasis-runtime-sdk"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/runtime-sdk/Cargo.toml
+++ b/runtime-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oasis-runtime-sdk"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/runtime-sdk/modules/contracts/Cargo.toml
+++ b/runtime-sdk/modules/contracts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oasis-runtime-sdk-contracts"
 description = "Smart contracts module for the Oasis Runtime SDK."
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ oasis-contract-sdk-types = { path = "../../../contract-sdk/types", features = ["
 oasis-runtime-sdk = { path = "../.." }
 
 # Internal Wasm3 bindings.
-wasm3 = { git = "https://github.com/oasisprotocol/wasm3-rs", tag = "v0.3.1" }
+wasm3 = { git = "https://github.com/oasisprotocol/wasm3-rs", tag = "v0.3.2" }
 
 # Third party.
 anyhow = "1.0"

--- a/tests/contracts/hello/Cargo.lock
+++ b/tests/contracts/hello/Cargo.lock
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "oasis-runtime-sdk"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/tests/contracts/hello/Cargo.lock
+++ b/tests/contracts/hello/Cargo.lock
@@ -2683,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"


### PR DESCRIPTION
This PR:
- Bumps shlex to 1.3.0
- oasis-runtime-sdk-contracts: Bumps wasm3 to 0.3.2 (which bumps shlex to 1.3.0)