### PR TITLE
runtime-sdk: Implement message emission gas

### DIFF
--- a/client-sdk/ts-web/rt/playground/src/consensus.js
+++ b/client-sdk/ts-web/rt/playground/src/consensus.js
@@ -207,8 +207,7 @@ export const playground = (async function () {
             })
             .setSignerInfo([siAlice1])
             .setFeeAmount(FEE_FREE)
-            .setFeeGas(0n)
-            .setFeeConsensusMessages(1);
+            .setFeeGas(78n); // Enough to emit 1 consensus message (max_batch_gas / max_messages = 10_000 / 128).
         await twDeposit.sign([csAlice], consensusChainContext);
 
         const addrAliceBech32 = oasis.staking.addressToBech32(aliceAddr);
@@ -282,8 +281,7 @@ export const playground = (async function () {
             })
             .setSignerInfo([siDave2])
             .setFeeAmount(FEE_FREE)
-            .setFeeGas(0n)
-            .setFeeConsensusMessages(1);
+            .setFeeGas(78n); // Enough to emit 1 consensus message (max_batch_gas / max_messages = 10_000 / 128).
         await twWithdraw.sign([csDave], consensusChainContext);
 
         /** @type {oasisRT.types.ConsensusAccountsWithdrawEvent} */

--- a/runtime-sdk/modules/evm/src/raw_tx.rs
+++ b/runtime-sdk/modules/evm/src/raw_tx.rs
@@ -177,8 +177,7 @@ pub fn decode(
             fee: transaction::Fee {
                 amount: token::BaseUnits(resolved_fee_amount, token::Denomination::NATIVE),
                 gas: gas_limit,
-                // TODO: Allow customization, maybe through call data?
-                consensus_messages: 1,
+                consensus_messages: 0, // Dynamic number of consensus messages, limited by gas.
             },
             ..Default::default()
         },

--- a/runtime-sdk/src/types/transaction.rs
+++ b/runtime-sdk/src/types/transaction.rs
@@ -175,7 +175,8 @@ pub struct Fee {
     /// Maximum amount of gas paid for.
     #[cbor(optional)]
     pub gas: u64,
-    /// Maximum amount of emitted consensus messages paid for.
+    /// Maximum amount of emitted consensus messages paid for. Zero means that up to the maximum
+    /// number of per-batch messages can be emitted.
     #[cbor(optional)]
     pub consensus_messages: u32,
 }

--- a/tests/e2e/evmtest.go
+++ b/tests/e2e/evmtest.go
@@ -144,7 +144,6 @@ func evmCall(ctx context.Context, rtc client.RuntimeClient, e evm.V1, signer sig
 		}
 	}
 
-	txB.SetFeeConsensusMessages(1)
 	tx := txB.SetFeeAmount(types.NewBaseUnits(*quantity.NewFromUint64(gasPrice * gasLimit), types.NativeDenomination)).GetTransaction()
 	result, err := txgen.SignAndSubmitTxRaw(ctx, rtc, signer, *tx, gasLimit)
 	if err != nil {

--- a/tests/e2e/simple_consensus.go
+++ b/tests/e2e/simple_consensus.go
@@ -22,6 +22,9 @@ import (
 
 const (
 	timeout = 2 * time.Minute
+
+	// oneConsensusMessageGas is enough gas to emit 1 consensus message (max_batch_gas / max_messages = 10_000 / 256).
+	oneConsensusMessageGas = 39
 )
 
 func ensureStakingEvent(log *logging.Logger, ch <-chan *staking.Event, check func(*staking.Event) bool) error {
@@ -295,7 +298,7 @@ func ConsensusDepositWithdrawalTest(sc *RuntimeScenario, log *logging.Logger, co
 	amount := types.NewBaseUnits(*quantity.NewFromUint64(50_000), consDenomination)
 	consensusAmount := quantity.NewFromUint64(50)
 	tb := consAccounts.Deposit(&testing.Bob.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -328,7 +331,7 @@ func ConsensusDepositWithdrawalTest(sc *RuntimeScenario, log *logging.Logger, co
 	consensusAmount = quantity.NewFromUint64(40)
 	log.Info("bob depositing into runtime to alice")
 	tb = consAccounts.Deposit(&testing.Alice.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Bob.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Bob.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -360,7 +363,7 @@ func ConsensusDepositWithdrawalTest(sc *RuntimeScenario, log *logging.Logger, co
 	consensusAmount = quantity.NewFromUint64(25)
 	log.Info("alice withdrawing to bob")
 	tb = consAccounts.Withdraw(&testing.Bob.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, 1)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -380,7 +383,7 @@ func ConsensusDepositWithdrawalTest(sc *RuntimeScenario, log *logging.Logger, co
 	amount.Amount = *quantity.NewFromUint64(50_000)
 	log.Info("charlie withdrawing")
 	tb = consAccounts.Withdraw(&testing.Charlie.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Charlie.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Charlie.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -395,7 +398,7 @@ func ConsensusDepositWithdrawalTest(sc *RuntimeScenario, log *logging.Logger, co
 
 	log.Info("alice withdrawing with invalid nonce")
 	tb = consAccounts.Withdraw(&testing.Bob.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, 1)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -436,7 +439,7 @@ func ConsensusDepositWithdrawalTest(sc *RuntimeScenario, log *logging.Logger, co
 	log.Info("dave depositing (secp256k1)")
 	amount.Amount = *quantity.NewFromUint64(50_000)
 	tb = consAccounts.Deposit(&testing.Dave.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Dave.SigSpec, 0)
 	_ = tb.AppendSign(ctx, testing.Dave.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -496,7 +499,7 @@ func ConsensusDelegationTest(sc *RuntimeScenario, log *logging.Logger, conn *grp
 	amount := types.NewBaseUnits(*quantity.NewFromUint64(10_000), consDenomination)
 	consensusAmount := quantity.NewFromUint64(10)
 	tb := consAccounts.Delegate(testing.Bob.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, nonce)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -562,7 +565,7 @@ func ConsensusDelegationTest(sc *RuntimeScenario, log *logging.Logger, conn *grp
 	amount = types.NewBaseUnits(*quantity.NewFromUint64(3_000), consDenomination)
 	consensusAmount = quantity.NewFromUint64(3)
 	tb = consAccounts.Delegate(testing.Alice.Address, amount).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, nonce+1)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
@@ -590,14 +593,14 @@ func ConsensusDelegationTest(sc *RuntimeScenario, log *logging.Logger, conn *grp
 	sharesA := quantity.NewFromUint64(1)
 	consensusAmountA := quantity.NewFromUint64(1)
 	tb = consAccounts.Undelegate(testing.Bob.Address, *sharesB).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, nonce+2)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {
 		return err
 	}
 	tb = consAccounts.Undelegate(testing.Alice.Address, *sharesA).
-		SetFeeConsensusMessages(1).
+		SetFeeGas(oneConsensusMessageGas).
 		AppendAuthSignature(testing.Alice.SigSpec, nonce+3)
 	_ = tb.AppendSign(ctx, testing.Alice.Signer)
 	if err = tb.SubmitTx(ctx, nil); err != nil {


### PR DESCRIPTION
Previously one had to explicitly configure the maximum number of messages to consensus layer that can be emitted by a transaction. This posed a problem for Ethereum-compatible transactions which don't support this field.

This implementation adds message emission gas which is dynamically calculated based on MAX_BATCH_GAS and MAX_MESSAGES. Similar to storage gas, it is only charged in case other use is too small in order to limit the total number of messages that can be emitted in a batch.

All Ethereum-compatible transactions now use this dynamic limit for the maximum number of consensus messages to be emitted.