### PR TITLE
client-sdk/modules: Fix missing client.EventDecoder

### DIFF
--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -22,6 +22,8 @@ var (
 
 // V1 is the v1 core module interface.
 type V1 interface {
+	client.EventDecoder
+
 	// Parameters queries the core module parameters.
 	Parameters(ctx context.Context, round uint64) (*Parameters, error)
 


### PR DESCRIPTION
Seems that V1 already integrated client.EventDecoder, the interface is just not complete. By adding client.EventDecoder we can pass it as a decoder in `func WatchEvents`

Without `client.EventDecoder` this will throw an error.

```go
decoders := []client.EventDecoder{
	core.NewV1(runtimeClient),
}
eventsCh, err := runtimeClient.WatchEvents(ctx, decoders, true)
```

Error:
```
cannot use core.NewV1(runtimeClient) (value of type "github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core".V1) as client.EventDecoder value in array or slice literal: "github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core".V1 does not implement client.EventDecoder (missing method DecodeEvent)
```


With fix applied you can properly decode `Events` from `core` module, e.g.:
```json
{"GasUsed":{"amount":22144}}
```