### PR TITLE
.github/dependabot: group all updates across all projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,17 +44,38 @@ updates:
 
   # Manage Rust package versions.
   - package-ecosystem: cargo
-    directory: /
+    directories:
+      - /
+      # Contract SDK specs.
+      - contract-sdk/specs/token/oas20/
+      - contract-sdk/specs/access/oas173/
+      # Test contracts.
+      - tests/contracts/hello/
+      - tests/contracts/bench/
     schedule:
       interval: daily
     commit-message:
       prefix: "runtime-sdk:"
+    groups:
+      # Update all other dependencies in a single PR.
+      rust:
+        # Update all dependencies, unless explicitly ignored.
+        patterns:
+          - "*"
+        # Excluded dependencies are updated in separate PRs.
+        # Commented out because it requires at least one entry to be valid.
+        # exclude-patterns: []
+    # Ignored depenednecies are ignored by dependabot.
+    ignore:
+      # oasis-core dependencies are manually kept up to date.
+      - dependency-name: oasis-core-runtime
+      - dependency-name: oasis-core-keymanager
+    labels:
+      - c:deps
+      - rust
     labels:
       - c:deps
       - c:runtime-sdk
-    ignore:
-      # oasis-core-runtime is manually kept up to date.
-      - dependency-name: oasis-core-runtime
 
   # Manage npm package versions.
   - package-ecosystem: npm


### PR DESCRIPTION
Create a rust group to update all rust dependencies in a single PR. This works nicely in oasis-core:  https://github.com/oasisprotocol/oasis-core/pull/5656

Also use the [multi-directory-beta-feature](https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/) to (hopefully) update all cargo projects within a single PR - this is the main issue currently preventing dependabot for rust to be useful in this repo, since updating dependency only in a single project causes dependent projects to fail CI. 
If this works nice, we should also enable it for go, instead of the hacky workaround currently used.