### PR TITLE
.github/dependabot: group all go dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,14 +30,23 @@ updates:
       interval: daily
     commit-message:
       prefix: "go:"
-    labels:
-      - c:deps
-      - golang
+    groups:
+      # Update all dependencies in a single PR.
+      go:
+        # Update all dependencies, unless explicitly ignored.
+        patterns:
+          - "*"
+        # Excluded dependencies are updated in separate PRs.
+        # Commented out because it requires at least one entry to be valid.
+        # exclude-patterns: []
     ignore:
       # oasis-core is manually kept up to date.
       - dependency-name: github.com/oasisprotocol/oasis-core/go
       # client-sdk is replaced with the local up-to-date version.
       - dependency-name: github.com/oasisprotocol/oasis-sdk/client-sdk/go
+    labels:
+      - c:deps
+      - golang
 
   # Manage Rust package versions.
   - package-ecosystem: cargo


### PR DESCRIPTION
Let's also group all go dependency updates in a single PR. 