### PR TITLE
rename pontusx_test to pontusx

### DIFF
--- a/client-sdk/go/config/default.go
+++ b/client-sdk/go/config/default.go
@@ -120,8 +120,8 @@ var DefaultNetworks = Networks{
 						ConsensusDenomination: "TEST",
 					},
 
-					// Pontus-X Testnet on Testnet.
-					"pontusx_test": {
+					// Pontus-X on Testnet.
+					"pontusx": {
 						Description: "Pontus-X Testnet",
 						ID:          "00000000000000000000000000000000000000000000000004a6f9071c007069",
 						Denominations: map[string]*DenominationInfo{


### PR DESCRIPTION
As discussed on slack, the `_test` is indicative of the paratime being on testnet, and `pontusx` alone might be preferable