### PR TITLE
ts-web: removed unnecessary async from hash function

### DIFF
--- a/client-sdk/ts-web/core/src/address.ts
+++ b/client-sdk/ts-web/core/src/address.ts
@@ -3,18 +3,11 @@ import {bech32} from 'bech32';
 import * as hash from './hash';
 import * as misc from './misc';
 
-export async function fromData(
-    contextIdentifier: string,
-    contextVersion: number,
-    data: Uint8Array,
-) {
+export function fromData(contextIdentifier: string, contextVersion: number, data: Uint8Array) {
     const versionU8 = new Uint8Array([contextVersion]);
     return misc.concat(
         versionU8,
-        (await hash.hash(misc.concat(misc.fromString(contextIdentifier), versionU8, data))).slice(
-            0,
-            20,
-        ),
+        hash.hash(misc.concat(misc.fromString(contextIdentifier), versionU8, data)).slice(0, 20),
     );
 }
 

--- a/client-sdk/ts-web/core/src/common.ts
+++ b/client-sdk/ts-web/core/src/common.ts
@@ -72,8 +72,8 @@ export const IDENTITY_MODULE_NAME = 'identity';
  */
 export const IDENTITY_ERR_CERTIFICATE_ROTATION_FORBIDDEN_CODE = 1;
 
-export async function openSignedEntity(context: string, signed: types.SignatureSigned) {
-    return misc.fromCBOR(await signature.openSigned(context, signed)) as types.Entity;
+export function openSignedEntity(context: string, signed: types.SignatureSigned) {
+    return misc.fromCBOR(signature.openSigned(context, signed)) as types.Entity;
 }
 
 export async function signSignedEntity(
@@ -84,11 +84,8 @@ export async function signSignedEntity(
     return await signature.signSigned(signer, context, misc.toCBOR(entity));
 }
 
-export async function openMultiSignedNode(
-    context: string,
-    multiSigned: types.SignatureMultiSigned,
-) {
-    return misc.fromCBOR(await signature.openMultiSigned(context, multiSigned)) as types.Node;
+export function openMultiSignedNode(context: string, multiSigned: types.SignatureMultiSigned) {
+    return misc.fromCBOR(signature.openMultiSigned(context, multiSigned)) as types.Node;
 }
 
 export async function signMultiSignedNode(

--- a/client-sdk/ts-web/core/src/consensus.ts
+++ b/client-sdk/ts-web/core/src/consensus.ts
@@ -91,9 +91,9 @@ export const TRANSACTION_ERR_GAS_PRICE_TOO_LOW_CODE = 3;
  */
 export const TRANSACTION_ERR_UPGRADE_PENDING = 4;
 
-export async function openSignedTransaction(chainContext: string, signed: types.SignatureSigned) {
+export function openSignedTransaction(chainContext: string, signed: types.SignatureSigned) {
     const context = signature.combineChainContext(TRANSACTION_SIGNATURE_CONTEXT, chainContext);
-    return misc.fromCBOR(await signature.openSigned(context, signed)) as types.ConsensusTransaction;
+    return misc.fromCBOR(signature.openSigned(context, signed)) as types.ConsensusTransaction;
 }
 
 export async function signSignedTransaction(
@@ -109,8 +109,8 @@ export async function signSignedTransaction(
  * This special hex-hash-of-the-CBOR-encoded signed transaction is useful for interoperability
  * with block explorers, so here's a special function for doing it.
  */
-export async function hashSignedTransaction(signed: types.SignatureSigned) {
-    return misc.toHex(await hash.hash(misc.toCBOR(signed)));
+export function hashSignedTransaction(signed: types.SignatureSigned) {
+    return misc.toHex(hash.hash(misc.toCBOR(signed)));
 }
 
 export class TransactionWrapper<BODY> {
@@ -164,8 +164,8 @@ export class TransactionWrapper<BODY> {
         );
     }
 
-    async hash() {
-        return await hashSignedTransaction(this.signedTransaction);
+    hash() {
+        return hashSignedTransaction(this.signedTransaction);
     }
 
     async submit(nic: client.NodeInternal) {

--- a/client-sdk/ts-web/core/src/genesis.ts
+++ b/client-sdk/ts-web/core/src/genesis.ts
@@ -2,6 +2,6 @@ import * as hash from './hash';
 import * as misc from './misc';
 import * as types from './types';
 
-export async function chainContext(doc: types.GenesisDocument) {
-    return misc.toHex(await hash.hash(misc.toCBOR(doc)));
+export function chainContext(doc: types.GenesisDocument) {
+    return misc.toHex(hash.hash(misc.toCBOR(doc)));
 }

--- a/client-sdk/ts-web/core/src/hash.ts
+++ b/client-sdk/ts-web/core/src/hash.ts
@@ -1,5 +1,5 @@
 import {sha512_256} from '@noble/hashes/sha512';
 
-export async function hash(data: Uint8Array) {
+export function hash(data: Uint8Array) {
     return sha512_256(data);
 }

--- a/client-sdk/ts-web/core/src/signature.ts
+++ b/client-sdk/ts-web/core/src/signature.ts
@@ -10,8 +10,8 @@ export function combineChainContext(context: string, chainContext: string) {
     return `${context}${CHAIN_CONTEXT_SEPARATOR}${chainContext}`;
 }
 
-export async function prepareSignerMessage(context: string, message: Uint8Array) {
-    return await hash.hash(misc.concat(misc.fromString(context), message));
+export function prepareSignerMessage(context: string, message: Uint8Array) {
+    return hash.hash(misc.concat(misc.fromString(context), message));
 }
 
 export interface Signer {
@@ -24,20 +24,20 @@ export interface ContextSigner {
     sign(context: string, message: Uint8Array): Promise<Uint8Array>;
 }
 
-export async function verify(
+export function verify(
     publicKey: Uint8Array,
     context: string,
     message: Uint8Array,
     signature: Uint8Array,
 ) {
-    const signerMessage = await prepareSignerMessage(context, message);
+    const signerMessage = prepareSignerMessage(context, message);
     const sigOk = nacl.sign.detached.verify(signerMessage, signature, publicKey);
 
     return sigOk;
 }
 
-export async function openSigned(context: string, signed: types.SignatureSigned) {
-    const sigOk = await verify(
+export function openSigned(context: string, signed: types.SignatureSigned) {
+    const sigOk = verify(
         signed.signature.public_key,
         context,
         signed.untrusted_raw_value,
@@ -57,8 +57,8 @@ export async function signSigned(signer: ContextSigner, context: string, rawValu
     } as types.SignatureSigned;
 }
 
-export async function openMultiSigned(context: string, multiSigned: types.SignatureMultiSigned) {
-    const signerMessage = await prepareSignerMessage(context, multiSigned.untrusted_raw_value);
+export function openMultiSigned(context: string, multiSigned: types.SignatureMultiSigned) {
+    const signerMessage = prepareSignerMessage(context, multiSigned.untrusted_raw_value);
     for (const signature of multiSigned.signatures) {
         const sigOk = nacl.sign.detached.verify(
             signerMessage,
@@ -100,7 +100,7 @@ export class BlindContextSigner implements ContextSigner {
     }
 
     async sign(context: string, message: Uint8Array): Promise<Uint8Array> {
-        const signerMessage = await prepareSignerMessage(context, message);
+        const signerMessage = prepareSignerMessage(context, message);
         return await this.signer.sign(signerMessage);
     }
 }

--- a/client-sdk/ts-web/core/src/staking.ts
+++ b/client-sdk/ts-web/core/src/staking.ts
@@ -195,12 +195,12 @@ export const TOKEN_MODULE_NAME = 'staking/token';
  */
 export const TOKEN_ERR_INVALID_TOKEN_VALUE_EXPONENT_CODE = 1;
 
-export async function addressFromPublicKey(pk: Uint8Array) {
-    return await address.fromData(ADDRESS_V0_CONTEXT_IDENTIFIER, ADDRESS_V0_CONTEXT_VERSION, pk);
+export function addressFromPublicKey(pk: Uint8Array) {
+    return address.fromData(ADDRESS_V0_CONTEXT_IDENTIFIER, ADDRESS_V0_CONTEXT_VERSION, pk);
 }
 
-export async function addressFromRuntimeID(id: Uint8Array) {
-    return await address.fromData(
+export function addressFromRuntimeID(id: Uint8Array) {
+    return address.fromData(
         ADDRESS_RUNTIME_V0_CONTEXT_IDENTIFIER,
         ADDRESS_RUNTIME_V0_CONTEXT_VERSION,
         id,
@@ -219,8 +219,8 @@ export function addressFromBech32(str: string) {
  * CommonPoolAddress is the common pool address.
  * The address is reserved to prevent it being accidentally used in the actual ledger.
  */
-export async function commonPoolAddress() {
-    return await addressFromPublicKey(
+export function commonPoolAddress() {
+    return addressFromPublicKey(
         misc.fromHex('1abe11edc001ffffffffffffffffffffffffffffffffffffffffffffffffffff'),
     );
 }
@@ -230,8 +230,8 @@ export async function commonPoolAddress() {
  * It holds all fees from txs in a block which are later disbursed to validators appropriately.
  * The address is reserved to prevent it being accidentally used in the actual ledger.
  */
-export async function feeAccumulatorAddress() {
-    return await addressFromPublicKey(
+export function feeAccumulatorAddress() {
+    return addressFromPublicKey(
         misc.fromHex('1abe11edfeeaccffffffffffffffffffffffffffffffffffffffffffffffffff'),
     );
 }
@@ -240,8 +240,8 @@ export async function feeAccumulatorAddress() {
  * GovernanceDepositsAddress is the governance deposits address.
  * This address is reserved to prevent it from being accidentally used in the actual ledger.
  */
-export async function governanceDepositsAddress() {
-    return await addressFromPublicKey(
+export function governanceDepositsAddress() {
+    return addressFromPublicKey(
         misc.fromHex('1abe11eddeaccfffffffffffffffffffffffffffffffffffffffffffffffffff'),
     );
 }

--- a/client-sdk/ts-web/rt/playground/src/consensus.js
+++ b/client-sdk/ts-web/rt/playground/src/consensus.js
@@ -120,11 +120,11 @@ export const playground = (async function () {
         });
 
         const alice = oasis.signature.NaclSigner.fromSeed(
-            await oasis.hash.hash(oasis.misc.fromString('oasis-runtime-sdk/test-keys: alice')),
+            oasis.hash.hash(oasis.misc.fromString('oasis-runtime-sdk/test-keys: alice')),
             'this key is not important',
         );
         const csAlice = new oasis.signature.BlindContextSigner(alice);
-        const aliceAddr = await oasis.staking.addressFromPublicKey(alice.public());
+        const aliceAddr = oasis.staking.addressFromPublicKey(alice.public());
 
         // Suppose this were the private key pasted in from a Metamask export.
         // (This is the "dave" test account.)
@@ -132,7 +132,7 @@ export const playground = (async function () {
         const davePriv = oasis.misc.fromHex(davePrivHex);
 
         // Make sure this private key is in sync with the Rust and Go codebases.
-        const davePrivExpected = await oasis.hash.hash(
+        const davePrivExpected = oasis.hash.hash(
             oasis.misc.fromString('oasis-runtime-sdk/test-keys: dave'),
         );
         if (davePrivHex !== oasis.misc.toHex(davePrivExpected)) {
@@ -149,7 +149,7 @@ export const playground = (async function () {
         // Check address derivation from Ethereum address.
         const daveEthAddr = '0xDce075E1C39b1ae0b75D554558b6451A226ffe00';
         const daveEthAddrU8 = oasis.misc.fromHex(daveEthAddr.slice(2));
-        const daveAddr = await oasis.address.fromData(
+        const daveAddr = oasis.address.fromData(
             oasisRT.address.V0_SECP256K1ETH_CONTEXT_IDENTIFIER,
             oasisRT.address.V0_SECP256K1ETH_CONTEXT_VERSION,
             daveEthAddrU8,
@@ -160,7 +160,7 @@ export const playground = (async function () {
         }
 
         // Make sure derivation from sigspec is consistent.
-        const daveAddrFromSigspec = await oasisRT.address.fromSigspec({
+        const daveAddrFromSigspec = oasisRT.address.fromSigspec({
             secp256k1eth: csDave.public(),
         });
         if (oasis.staking.addressToBech32(daveAddrFromSigspec) !== addrDaveBech32) {

--- a/client-sdk/ts-web/rt/src/address.ts
+++ b/client-sdk/ts-web/rt/src/address.ts
@@ -9,9 +9,9 @@ export const V0_SECP256K1ETH_CONTEXT_VERSION = 0;
 export const V0_MULTISIG_CONTEXT_IDENTIFIER = 'oasis-runtime-sdk/address: multisig';
 export const V0_MULTISIG_CONTEXT_VERSION = 0;
 
-export async function fromSigspec(spec: types.SignatureAddressSpec) {
+export function fromSigspec(spec: types.SignatureAddressSpec) {
     if (spec.ed25519) {
-        return await oasis.staking.addressFromPublicKey(spec.ed25519);
+        return oasis.staking.addressFromPublicKey(spec.ed25519);
     } else if (spec.secp256k1eth) {
         // Use a scheme such that we can compute Secp256k1 addresses from Ethereum
         // addresses as this makes things more interoperable.
@@ -19,7 +19,7 @@ export async function fromSigspec(spec: types.SignatureAddressSpec) {
             .toRawBytes(false)
             .slice(1);
         const pkData = keccak_256(new Uint8Array(untaggedPk)).slice(32 - 20);
-        return await oasis.address.fromData(
+        return oasis.address.fromData(
             V0_SECP256K1ETH_CONTEXT_IDENTIFIER,
             V0_SECP256K1ETH_CONTEXT_VERSION,
             pkData,
@@ -29,9 +29,9 @@ export async function fromSigspec(spec: types.SignatureAddressSpec) {
     }
 }
 
-export async function fromMultisigConfig(config: types.MultisigConfig) {
+export function fromMultisigConfig(config: types.MultisigConfig) {
     const configU8 = oasis.misc.toCBOR(config);
-    return await oasis.address.fromData(
+    return oasis.address.fromData(
         V0_MULTISIG_CONTEXT_IDENTIFIER,
         V0_MULTISIG_CONTEXT_VERSION,
         configU8,

--- a/client-sdk/ts-web/rt/src/callformat.ts
+++ b/client-sdk/ts-web/rt/src/callformat.ts
@@ -32,14 +32,14 @@ export interface MetaEncryptedX25519DeoxysII {
  * encodeCallWithNonceAndKeys encodes a call based on its configured call format.
  * It returns the encoded call and any metadata needed to successfully decode the result.
  */
-export async function encodeCallWithNonceAndKeys(
+export function encodeCallWithNonceAndKeys(
     nonce: Uint8Array,
     sk: Uint8Array,
     pk: Uint8Array,
     call: types.Call,
     format: types.CallFormat,
     config?: EncodeConfig,
-): Promise<[types.Call, unknown]> {
+): [types.Call, unknown] {
     switch (format) {
         case transaction.CALLFORMAT_PLAIN:
             return [call, undefined];
@@ -80,15 +80,15 @@ export async function encodeCallWithNonceAndKeys(
  * encodeCall randomly generates nonce and keyPair and then call encodeCallWithNonceAndKeys
  * It returns the encoded call and any metadata needed to successfully decode the result.
  */
-export async function encodeCall(
+export function encodeCall(
     call: types.Call,
     format: types.CallFormat,
     config?: EncodeConfig,
-): Promise<[types.Call, unknown]> {
+): [types.Call, unknown] {
     const nonce = new Uint8Array(deoxysii.NonceSize);
     crypto.getRandomValues(nonce);
     const keyPair = nacl.box.keyPair();
-    return await encodeCallWithNonceAndKeys(
+    return encodeCallWithNonceAndKeys(
         nonce,
         keyPair.secretKey,
         keyPair.publicKey,
@@ -101,11 +101,11 @@ export async function encodeCall(
 /**
  * decodeResult performs result decoding based on the specified call format metadata.
  */
-export async function decodeResult(
+export function decodeResult(
     result: types.CallResult,
     format: types.CallFormat,
     meta?: MetaEncryptedX25519DeoxysII,
-): Promise<types.CallResult> {
+): types.CallResult {
     switch (format) {
         case transaction.CALLFORMAT_PLAIN:
             // In case of plain-text data format, we simply pass on the result unchanged.

--- a/client-sdk/ts-web/rt/src/signature_secp256k1.ts
+++ b/client-sdk/ts-web/rt/src/signature_secp256k1.ts
@@ -11,13 +11,13 @@ export interface ContextSigner {
     sign(context: string, message: Uint8Array): Promise<Uint8Array>;
 }
 
-export async function verify(
+export function verify(
     context: string,
     message: Uint8Array,
     signature: Uint8Array,
     publicKey: Uint8Array,
 ) {
-    const signerMessage = await oasis.signature.prepareSignerMessage(context, message);
+    const signerMessage = oasis.signature.prepareSignerMessage(context, message);
     return secp256k1.verify(signature, signerMessage, publicKey);
 }
 
@@ -33,7 +33,7 @@ export class BlindContextSigner implements ContextSigner {
     }
 
     async sign(context: string, message: Uint8Array): Promise<Uint8Array> {
-        const signerMessage = await oasis.signature.prepareSignerMessage(context, message);
+        const signerMessage = oasis.signature.prepareSignerMessage(context, message);
         return await this.signer.sign(signerMessage);
     }
 }

--- a/client-sdk/ts-web/rt/src/transaction.ts
+++ b/client-sdk/ts-web/rt/src/transaction.ts
@@ -45,11 +45,9 @@ export type MultisigSignerSet = AnySigner[];
  */
 export type ProofProvider = AnySigner | MultisigSignerSet;
 
-export async function deriveChainContext(runtimeID: Uint8Array, consensusChainContext: string) {
+export function deriveChainContext(runtimeID: Uint8Array, consensusChainContext: string) {
     return oasis.misc.toHex(
-        await oasis.hash.hash(
-            oasis.misc.concat(runtimeID, oasis.misc.fromString(consensusChainContext)),
-        ),
+        oasis.hash.hash(oasis.misc.concat(runtimeID, oasis.misc.fromString(consensusChainContext))),
     );
 }
 
@@ -140,7 +138,7 @@ export async function signUnverifiedTransaction(
     consensusChainContext: string,
     transaction: types.Transaction,
 ) {
-    const chainContext = await deriveChainContext(runtimeID, consensusChainContext);
+    const chainContext = deriveChainContext(runtimeID, consensusChainContext);
     const context = oasis.signature.combineChainContext(SIGNATURE_CONTEXT_BASE, chainContext);
     const body = oasis.misc.toCBOR(transaction);
     const authProofs = new Array(transaction.ai.si.length) as types.AuthProof[];


### PR DESCRIPTION
The `hash.ts:hash` function is unnecessarily async, this has a knock-on effect making many simple functions also async where really they're deterministic.

This change means I can derive addresses in a `constructor`, such as:

```typescript
export class OasisSigner {
  public readonly signer: oasis.signature.Signer;
  public readonly address: Uint8Array;
  public readonly addressBech32: string;

  constructor(public readonly client: OasisClient, public readonly secret: Uint8Array) {
    this.signer = oasis.signature.NaclSigner.fromSecret(secret, 'this key is not important');
    this.address = oasis.staking.addressFromPublicKey(this.signer.public())
    this.addressBech32 = oasis.staking.addressToBech32(this.address);
  }
...
}
```

You can't have async code in constructors, so the alternative would be an async factory that passes the pre-calculated addresses as args to the constructor which is annoying.

The following functions can have their async nature removed due to this change:

* address.fromData
* common.openSignedEntity
* common.openMultiSignedNode
* consensus.openSignedTransaction
* consensus.hashSignedTransaction
* genesis.chainContext
* signature.prepareSignerMessage
* signature.verify
* signature.openSigned
* signature.openMultiSigned
* staking.addressFromPublicKey
* staking.addressFromRuntimeID
* staking.commonPoolAddress
* staking.feeAccumulatorAddress
* staking.governanceDepositsAddress