### PR TITLE
runtime-sdk/modules/rofl: Reduce coupling between ROFL and RONL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime-components-rofl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tests/runtimes/components-rofl/Cargo.toml
+++ b/tests/runtimes/components-rofl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-runtime-components-rofl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tests/runtimes/components-rofl/src/main.rs
+++ b/tests/runtimes/components-rofl/src/main.rs
@@ -3,14 +3,18 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use oasis_runtime_sdk::modules::rofl::app::{App, AppId, Environment};
+use oasis_runtime_sdk::{
+    self as sdk,
+    modules::rofl::app::{App, AppId, Environment},
+    Version,
+};
 
 struct TestApp;
 
 #[async_trait]
 impl App for TestApp {
-    /// Runtime to attach the application to.
-    type AttachTo = components_ronl::Runtime;
+    /// Application version.
+    const VERSION: Version = sdk::version_from_cargo!();
 
     /// Identifier of the application (used for registrations).
     ///


### PR DESCRIPTION
The previous solution required the same SDK versions for ROFL and RONL which seems like an artificial constraint that could get annoying in practice. This should reduce developer friction.