### PR TITLE
Harden github workflow against injection

### DIFF
--- a/.github/actions/hash-rust/action.yml
+++ b/.github/actions/hash-rust/action.yml
@@ -40,9 +40,12 @@ runs:
   steps:
     - shell: bash
       id: build
+      env:
+        INPUTS_DIR: ${{ inputs.dir }}
+        INPUTS_IMAGE: ${{ inputs.image }}
       run: |
         GITHUB_TEMP_DIR=$(dirname "$GITHUB_OUTPUT")
-        docker run --rm -i -e GITHUB_OUTPUT -v ${GITHUB_TEMP_DIR}:${GITHUB_TEMP_DIR} -v ${{ inputs.dir }}:/src ${{ inputs.image }} /bin/bash <<-'EOF'
+        docker run --rm -i -e GITHUB_OUTPUT -v "${GITHUB_TEMP_DIR}:${GITHUB_TEMP_DIR}" -v "$INPUTS_DIR:/src" "$INPUTS_IMAGE" /bin/bash <<-'EOF'
           set -e
           ${{ inputs.setup }}
           cd /src

--- a/.github/actions/lint-rust/action.yml
+++ b/.github/actions/lint-rust/action.yml
@@ -13,11 +13,13 @@ runs:
   steps:
     - name: Clippy check
       shell: bash
+      env:
+        MANIFEST_PATH: ${{ inputs.manifest_path }}
       run: |
         cargo clippy \
           --all-features \
           --locked \
-          --manifest-path ${{ inputs.manifest_path }} \
+          --manifest-path "$MANIFEST_PATH" \
           -- \
           -D warnings \
           -D clippy::dbg_macro \
@@ -25,4 +27,6 @@ runs:
 
     - name: Formatting check
       shell: bash
-      run: cargo fmt --all --manifest-path ${{ inputs.manifest_path }} -- --check
+      env:
+        MANIFEST_PATH: ${{ inputs.manifest_path }}
+      run: cargo fmt --all --manifest-path "$MANIFEST_PATH" -- --check

--- a/.github/actions/test-rust/action.yml
+++ b/.github/actions/test-rust/action.yml
@@ -15,10 +15,11 @@ runs:
 
     - name: Unit tests with coverage
       shell: bash
-      run: cargo tarpaulin --out Xml --avoid-cfg-tarpaulin --manifest-path ${{ inputs.manifest_path }} -- --test-threads 1
+      run: cargo tarpaulin --out Xml --avoid-cfg-tarpaulin --manifest-path "$MANIFEST_PATH" -- --test-threads 1
       env:
         # Required as tarpaulin doesn't honor .cargo/config.
         RUSTFLAGS: -C target-feature=+aes,+ssse3
+        MANIFEST_PATH: ${{ inputs.manifest_path }}
 
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
Prevents theoretical `image: ghcr.io/oasisprotocol/runtime-builder:main; echo injected` in
https://github.com/oasisprotocol/oasis-sdk/blob/2057e22fac35f61159e6ae2871b99e047bb5f500/.github/workflows/ci-reproducibility.yml#L45-L48
