### PR TITLE
rofl-utils: Get rid of ureq fork, bring mbedtls support locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -211,7 +211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
  "synstructure 0.13.1",
 ]
@@ -223,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -234,7 +234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -255,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -266,7 +266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -355,7 +355,7 @@ dependencies = [
  "peeking_take_while",
  "prettyplease",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
  "rustc-hash",
  "shlex",
@@ -378,7 +378,7 @@ dependencies = [
  "log",
  "prettyplease",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
  "rustc-hash",
  "shlex",
@@ -686,7 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -919,7 +919,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -933,7 +933,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.11.1",
  "syn 2.0.75",
 ]
@@ -945,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -956,7 +956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -1049,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -1060,7 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -1104,7 +1104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -1486,7 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -1838,7 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2073,7 +2073,7 @@ dependencies = [
  "cmake",
  "lazy_static",
  "libc",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2361,7 +2361,7 @@ dependencies = [
  "oasis-cbor-value",
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2408,7 +2408,7 @@ dependencies = [
  "difference",
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -2628,7 +2628,7 @@ dependencies = [
  "darling 0.20.10",
  "difference",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -2723,7 +2723,7 @@ checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2780,7 +2780,7 @@ checksum = "bdad6a1d9cf116a059582ce415d5f5566aabcd4008646779dab7fdc2a9a9d426"
 dependencies = [
  "peg-runtime",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
 ]
 
 [[package]]
@@ -2820,7 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -3023,7 +3023,7 @@ dependencies = [
  "anyhow",
  "itertools 0.12.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -3047,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2 1.0.86",
 ]
@@ -3209,16 +3209,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "rofl-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "der",
  "mockito",
+ "rustls",
+ "rustls-mbedcrypto-provider",
+ "rustls-mbedpki-provider",
+ "rustls-pki-types",
  "ureq",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -3353,16 +3359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
-dependencies = [
- "base64 0.22.1",
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,7 +3411,7 @@ checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -3515,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -3538,7 +3534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -3826,7 +3822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-ident",
 ]
 
@@ -3837,7 +3833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-ident",
 ]
 
@@ -3848,7 +3844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
  "unicode-xid 0.2.5",
 ]
@@ -3860,7 +3856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -4089,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -4192,7 +4188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -4380,7 +4376,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ureq"
 version = "3.0.0-beta1"
-source = "git+https://github.com/oasisprotocol/ureq?branch=mbedtls#3d4391221db5e90c2ddd28b5dccc3e34801aaf48"
+source = "git+https://github.com/algesten/ureq?rev=e4e7e4e51209d8a14c741ad46991cd83e1a18379#e4e7e4e51209d8a14c741ad46991cd83e1a18379"
 dependencies = [
  "base64 0.22.1",
  "brotli-decompressor",
@@ -4391,17 +4387,11 @@ dependencies = [
  "http",
  "log",
  "once_cell",
- "rustls",
- "rustls-mbedcrypto-provider",
- "rustls-mbedpki-provider",
- "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "smallvec",
  "thiserror",
  "utf-8",
- "webpki-root-certs",
 ]
 
 [[package]]
@@ -4467,7 +4457,7 @@ checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
 dependencies = [
  "heck",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -4498,7 +4488,7 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
@@ -4509,7 +4499,7 @@ version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4520,7 +4510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -4543,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
+checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
 dependencies = [
  "leb128",
 ]
@@ -4602,22 +4592,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "215.0.0"
+version = "216.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff1d00d893593249e60720be04a7c1f42f1c4dc3806a2869f4e66ab61eb54cb"
+checksum = "f7eb1f2eecd913fdde0dc6c3439d0f24530a98ac6db6cb3d14d92a5328554a08"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.215.0",
+ "wasm-encoder 0.216.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.215.0"
+version = "1.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670bf4d9c8cf76ae242d70ded47c546525b6dafaa6871f9bcb065344bf2b4e3d"
+checksum = "ac0409090fb5154f95fb5ba3235675fd9e579e731524d63b6a2f653e1280c82a"
 dependencies = [
  "wast",
 ]
@@ -4978,7 +4968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]
 
@@ -4998,6 +4988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 2.0.75",
 ]

--- a/rofl-utils/Cargo.toml
+++ b/rofl-utils/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
 name = "rofl-utils"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-# Need a custom version of ureq that uses mbedtls instead of ring since
-# builds of ring fail on the SGX target.
-#
-# Replace once https://github.com/algesten/ureq/pull/791 is merged.
-ureq = { git = "https://github.com/oasisprotocol/ureq", branch = "mbedtls", default-features = false, features = ["rustls-mbedtls", "gzip", "brotli", "charset", "json"] }
+der = { version = "0.7.9", default-features = false, features = ["pem", "std"] }
+rustls = { version = "0.23.11", default-features = false, features = ["logging", "std", "tls12"] }
+rustls-mbedcrypto-provider = { version = "0.1.0" }
+rustls-mbedpki-provider = { version = "0.1.0" }
+rustls-pki-types = { version = "1.7.0", default-features = false, features = ["std"] }
+# TODO: Change to released version once 3.x is published.
+ureq = { git = "https://github.com/algesten/ureq", rev = "e4e7e4e51209d8a14c741ad46991cd83e1a18379", default-features = false, features = ["gzip", "brotli", "charset", "json"] }
+webpki-root-certs = "0.26.4"
 
 [dev-dependencies]
 mockito = "0.31.0"

--- a/rofl-utils/src/https.rs
+++ b/rofl-utils/src/https.rs
@@ -6,15 +6,17 @@ use std::{
     fmt,
     io::{Read, Write},
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream},
+    sync::{Arc, OnceLock},
 };
 
+use rustls::{ClientConfig, ClientConnection, StreamOwned};
+use rustls_pki_types::ServerName;
 use ureq::{
     http::Uri,
     resolver::Resolver,
-    tls::RustlsConnector,
     transport::{
         time::NextTimeout, Buffers, ChainedConnector, ConnectionDetails, Connector, LazyBuffers,
-        Transport,
+        Transport, TransportAdapter,
     },
     Agent, AgentConfig,
 };
@@ -25,6 +27,7 @@ pub fn agent() -> Agent {
     #[cfg(not(test))]
     let cfg = AgentConfig {
         https_only: true, // Not using HTTPS is unsafe.
+        user_agent: "rofl-utils/0.1.0".to_string(),
         ..Default::default()
     };
 
@@ -32,6 +35,7 @@ pub fn agent() -> Agent {
     #[cfg(test)]
     let cfg = AgentConfig {
         https_only: false,
+        user_agent: "rofl-utils/0.1.0".to_string(),
         ..Default::default()
     };
 
@@ -136,6 +140,130 @@ impl Resolver for SgxResolver {
     }
 }
 
+#[derive(Default)]
+struct RustlsConnector {
+    config: OnceLock<Arc<ClientConfig>>,
+}
+
+impl Connector for RustlsConnector {
+    fn connect(
+        &self,
+        details: &ConnectionDetails,
+        chained: Option<Box<dyn Transport>>,
+    ) -> Result<Option<Box<dyn Transport>>, ureq::Error> {
+        let Some(transport) = chained else {
+            panic!("RustlsConnector requires a chained transport");
+        };
+
+        // Only add TLS if we are connecting via HTTPS and the transport isn't TLS
+        // already, otherwise use chained transport as is.
+        if !details.needs_tls() || transport.is_tls() {
+            return Ok(Some(transport));
+        }
+
+        // Initialize the config on first run.
+        let config_ref = self.config.get_or_init(|| build_config());
+        let config = config_ref.clone();
+
+        let name_borrowed: ServerName<'_> = details
+            .uri
+            .authority()
+            .ok_or(ureq::Error::HostNotFound)?
+            .host()
+            .try_into()
+            .map_err(|_| ureq::Error::HostNotFound)?;
+
+        let name = name_borrowed.to_owned();
+
+        let conn =
+            ClientConnection::new(config, name).map_err(|_| ureq::Error::ConnectionFailed)?;
+        let stream = StreamOwned {
+            conn,
+            sock: TransportAdapter::new(transport),
+        };
+
+        let buffers = LazyBuffers::new(
+            details.config.input_buffer_size,
+            details.config.output_buffer_size,
+        );
+
+        let transport = Box::new(RustlsTransport { buffers, stream });
+
+        Ok(Some(transport))
+    }
+}
+
+fn build_config() -> Arc<ClientConfig> {
+    let provider = Arc::new(rustls_mbedcrypto_provider::mbedtls_crypto_provider());
+
+    let builder = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .unwrap();
+
+    let builder = builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(
+            rustls_mbedpki_provider::MbedTlsServerCertVerifier::new(
+                webpki_root_certs::TLS_SERVER_ROOT_CERTS,
+            )
+            .unwrap(),
+        ));
+
+    let config = builder.with_no_client_auth();
+
+    Arc::new(config)
+}
+
+struct RustlsTransport {
+    buffers: LazyBuffers,
+    stream: StreamOwned<ClientConnection, TransportAdapter>,
+}
+
+impl Transport for RustlsTransport {
+    fn buffers(&mut self) -> &mut dyn Buffers {
+        &mut self.buffers
+    }
+
+    fn transmit_output(&mut self, amount: usize, _timeout: NextTimeout) -> Result<(), ureq::Error> {
+        let output = &self.buffers.output()[..amount];
+        self.stream.write_all(output)?;
+
+        Ok(())
+    }
+
+    fn await_input(&mut self, _timeout: NextTimeout) -> Result<bool, ureq::Error> {
+        if self.buffers.can_use_input() {
+            return Ok(true);
+        }
+
+        let input = self.buffers.input_mut();
+        let amount = self.stream.read(input)?;
+        self.buffers.add_filled(amount);
+
+        Ok(amount > 0)
+    }
+
+    fn is_open(&mut self) -> bool {
+        self.stream.get_mut().get_mut().is_open()
+    }
+
+    fn is_tls(&self) -> bool {
+        true
+    }
+}
+
+impl fmt::Debug for RustlsConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RustlsConnector").finish()
+    }
+}
+
+impl fmt::Debug for RustlsTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RustlsTransport").finish()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use mockito::{mock, server_url};
@@ -192,5 +320,23 @@ mod test {
             response.body_mut().read_to_string().unwrap(),
             r#"{"success":true}"#
         );
+    }
+
+    #[test]
+    fn test_get_remote_https() {
+        let response = agent().get("https://www.google.com/").call().unwrap();
+
+        // Verify the response
+        assert_eq!(
+            "text/html;charset=ISO-8859-1",
+            response
+                .headers()
+                .get("content-type")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace("; ", ";")
+        );
+        assert_eq!(response.body().mime_type(), Some("text/html"));
     }
 }


### PR DESCRIPTION
This removes the need to maintain an ureq fork and brings in mbedtls support into the `rofl-utils` crate (also see discussion in https://github.com/algesten/ureq/pull/791). There is some code duplication with `ureq` TLS, but on the other hand we have our own connectors/transports for SGX anyway.