### PR TITLE
.github/actions/hash-rust: Add features parameter

### DIFF
--- a/.github/actions/hash-rust/action.yml
+++ b/.github/actions/hash-rust/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Code to run before building
     default: ""
     required: false
+  features:
+    description: Extra cargo features passed during compilation
+    default: ""
+    required: false
 outputs:
   hashes:
     description: Comma-separated list of binary hashes
@@ -60,7 +64,7 @@ runs:
 
             for pkg in $PKG_DIRS; do
               pushd "${pkg}"
-              cargo build --release --locked --target "$TARGET"
+              cargo build --release --locked --features "${{ inputs.features }}" --target "$TARGET"
               cargo elf2sgxs --release
               popd
             done
@@ -69,7 +73,7 @@ runs:
 
             for pkg in $PKG_DIRS; do
               pushd "${pkg}"
-              cargo build --release --locked
+              cargo build --release --locked --features "${{ inputs.features }}"
               popd
             done
           fi


### PR DESCRIPTION
Straight forward implementation of #1947. Passing empty features, e.g. `--features ""` works perfectly fine.