### PR TITLE
runtime-sdk/modules/rofl: Allow entity endorsement without runtime

### DIFF
--- a/client-sdk/go/modules/rofl/policy.go
+++ b/client-sdk/go/modules/rofl/policy.go
@@ -29,9 +29,9 @@ type AppAuthPolicy struct {
 type AllowedEndorsement struct {
 	// Any specifies that any node can endorse the enclave.
 	Any *struct{} `json:"any,omitempty" yaml:"any,omitempty"`
-	// ComputeRole specifies that a compute node can endorse the enclave.
+	// ComputeRole specifies that a compute node for the current runtime can endorse the enclave.
 	ComputeRole *struct{} `json:"role_compute,omitempty" yaml:"role_compute,omitempty"`
-	// ObserverRole specifies that an observer node can endorse the enclave.
+	// ObserverRole specifies that an observer node for the current runtime can endorse the enclave.
 	ObserverRole *struct{} `json:"role_observer,omitempty" yaml:"role_observer,omitempty"`
 	// Entity specifies that a registered node from a specific entity can endorse the enclave.
 	Entity *signature.PublicKey `json:"entity,omitempty" yaml:"entity,omitempty"`

--- a/runtime-sdk/src/modules/rofl/policy.rs
+++ b/runtime-sdk/src/modules/rofl/policy.rs
@@ -28,10 +28,10 @@ pub enum AllowedEndorsement {
     /// Any node can endorse the enclave.
     #[cbor(rename = "any", as_struct)]
     Any,
-    /// Compute node can endorse the enclave.
+    /// Compute node for the current runtime can endorse the enclave.
     #[cbor(rename = "role_compute", as_struct)]
     ComputeRole,
-    /// Observer node can endorse the enclave.
+    /// Observer node for the current runtime can endorse the enclave.
     #[cbor(rename = "role_observer", as_struct)]
     ObserverRole,
     /// Registered node from a specific entity can endorse the enclave.


### PR DESCRIPTION
When the policy specifies an entity can endorse enclaves, allow any nodes registered under that entity, even if they are not registered for the current runtime. This makes it more similar to the `AllowedEndorsement::Node` policy.