### PR TITLE
runtime-sdk/modules/rofl: Add rofl.AuthorizedOrigin{Node,Entity}

### DIFF
--- a/client-sdk/go/modules/rofl/rofl.go
+++ b/client-sdk/go/modules/rofl/rofl.go
@@ -19,6 +19,7 @@ var (
 
 	// Queries.
 	methodApp          = types.NewMethodName("rofl.App", AppQuery{})
+	methodAppInstance  = types.NewMethodName("rofl.AppInstance", AppInstanceQuery{})
 	methodAppInstances = types.NewMethodName("rofl.AppInstances", AppQuery{})
 	methodParameters   = types.NewMethodName("rofl.Parameters", nil)
 )
@@ -38,6 +39,9 @@ type V1 interface {
 
 	// App queries the given application configuration.
 	App(ctx context.Context, round uint64, id AppID) (*AppConfig, error)
+
+	// AppInstance queries a specific registered instance of the given application.
+	AppInstance(ctx context.Context, round uint64, id AppID, rak types.PublicKey) (*Registration, error)
 
 	// AppInstances queries the registered instances of the given application.
 	AppInstances(ctx context.Context, round uint64, id AppID) ([]*Registration, error)
@@ -84,6 +88,16 @@ func (a *v1) App(ctx context.Context, round uint64, id AppID) (*AppConfig, error
 		return nil, err
 	}
 	return &appCfg, nil
+}
+
+// Implements V1.
+func (a *v1) AppInstance(ctx context.Context, round uint64, id AppID, rak types.PublicKey) (*Registration, error) {
+	var instance Registration
+	err := a.rc.Query(ctx, round, methodAppInstance, AppInstanceQuery{App: id, RAK: rak}, &instance)
+	if err != nil {
+		return nil, err
+	}
+	return &instance, nil
 }
 
 // Implements V1.

--- a/client-sdk/go/modules/rofl/types.go
+++ b/client-sdk/go/modules/rofl/types.go
@@ -62,6 +62,14 @@ type AppQuery struct {
 	ID AppID `json:"id"`
 }
 
+// AppInstanceQuery is an application instance query.
+type AppInstanceQuery struct {
+	// App is the application identifier.
+	App AppID `json:"app"`
+	// RAK is the Runtime Attestation Key.
+	RAK types.PublicKey `json:"rak"`
+}
+
 // AppConfig is a ROFL application configuration.
 type AppConfig struct {
 	// ID is the application identifier.
@@ -80,6 +88,8 @@ type Registration struct {
 	App AppID `json:"app"`
 	// NodeID is the identifier of the endorsing node.
 	NodeID signature.PublicKey `json:"node_id"`
+	// EntityID is the optional identifier of the endorsing entity.
+	EntityID *signature.PublicKey `json:"entity_id,omitempty"`
 	// RAK is the Runtime Attestation Key.
 	RAK signature.PublicKey `json:"rak"`
 	// REK is the Runtime Encryption Key.

--- a/runtime-sdk/src/modules/rofl/config.rs
+++ b/runtime-sdk/src/modules/rofl/config.rs
@@ -12,6 +12,10 @@ pub trait Config: 'static {
     const GAS_COST_CALL_REGISTER: u64 = 100_000;
     /// Gas cost of rofl.IsAuthorizedOrigin call.
     const GAS_COST_CALL_IS_AUTHORIZED_ORIGIN: u64 = 1000;
+    /// Gas cost of rofl.AuthorizedOriginNode call.
+    const GAS_COST_CALL_AUTHORIZED_ORIGIN_NODE: u64 = 2000;
+    /// Gas cost of rofl.AuthorizedOriginEntity call.
+    const GAS_COST_CALL_AUTHORIZED_ORIGIN_ENTITY: u64 = 2000;
 
     /// Amount of stake required for maintaining an application.
     ///

--- a/runtime-sdk/src/modules/rofl/error.rs
+++ b/runtime-sdk/src/modules/rofl/error.rs
@@ -49,6 +49,10 @@ pub enum Error {
     #[sdk_error(code = 11)]
     Forbidden,
 
+    #[error("unknown instance")]
+    #[sdk_error(code = 12)]
+    UnknownInstance,
+
     #[error("core: {0}")]
     #[sdk_error(transparent)]
     Core(#[from] modules::core::Error),

--- a/runtime-sdk/src/modules/rofl/types.rs
+++ b/runtime-sdk/src/modules/rofl/types.rs
@@ -81,6 +81,8 @@ pub struct Registration {
     pub app: AppId,
     /// Identifier of the endorsing node.
     pub node_id: signature::PublicKey,
+    /// Optional identifier of the endorsing entity.
+    pub entity_id: Option<signature::PublicKey>,
     /// Runtime Attestation Key.
     pub rak: signature::PublicKey,
     /// Runtime Encryption Key.
@@ -96,4 +98,14 @@ pub struct Registration {
 pub struct AppQuery {
     /// ROFL application identifier.
     pub id: AppId,
+}
+
+/// Application instance query.
+#[derive(Clone, Debug, cbor::Encode, cbor::Decode)]
+#[cbor(no_default)]
+pub struct AppInstanceQuery {
+    /// ROFL application identifier.
+    pub app: AppId,
+    /// Runtime Attestation Key.
+    pub rak: PublicKey,
 }

--- a/tests/runtimes/components-ronl/src/oracle/mod.rs
+++ b/tests/runtimes/components-ronl/src/oracle/mod.rs
@@ -102,7 +102,7 @@ impl<Cfg: Config> Module<Cfg> {
         <C::Runtime as Runtime>::Core::use_tx_gas(Cfg::GAS_COST_CALL_OBSERVE)?;
 
         // Ensure that the observation was processed by the configured ROFL application.
-        if !Cfg::Rofl::is_authorized_origin(Cfg::rofl_app_id())? {
+        if !Cfg::Rofl::is_authorized_origin(Cfg::rofl_app_id()) {
             return Err(Error::NotAuthorized);
         }
 


### PR DESCRIPTION
Closes #1924 

This makes it possible to query the endorsing node and entity of the origin ROFL app instance.