### PR TITLE
CI: Bump upload-artifact action version to v4 in test-rust

### DIFF
--- a/.github/actions/test-rust/action.yml
+++ b/.github/actions/test-rust/action.yml
@@ -25,7 +25,8 @@ runs:
       uses: codecov/codecov-action@v2.1.0
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: cobertura.xml
+        overwrite: true


### PR DESCRIPTION
This one seems to have been left out when upgrading the `upload-artifact` versions (https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).