### PR TITLE
docs: Fix ROFL policy file

### DIFF
--- a/docs/rofl/deployment.md
+++ b/docs/rofl/deployment.md
@@ -196,7 +196,7 @@ successfully authenticate under our app ID. To do so, update the previously
 generated `policy.yml` as follows (using your own app identity):
 
 <!-- markdownlint-disable line-length -->
-![code yaml {11-12}](../../examples/runtime-sdk/rofl-oracle/policy2.yml "policy.yml")
+![code yaml {10-12}](../../examples/runtime-sdk/rofl-oracle/policy2.yml "policy.yml")
 <!-- markdownlint-enable line-length -->
 
 Then to update the on-chain policy, run (using _your own app identifier_ instead

--- a/examples/runtime-sdk/rofl-oracle/policy.yml
+++ b/examples/runtime-sdk/rofl-oracle/policy.yml
@@ -7,6 +7,8 @@ quotes:
     # Minimum acceptable TCB evaluation data number. This ensures that TCB information
     # provided by the TEE vendor is recent enough and includes relevant TCB recoveries.
     min_tcb_evaluation_data_number: 17
+# Acceptable enclave cryptographic identities.
+enclaves:
 # Acceptable nodes that can endorse the enclaves.
 endorsements:
   - any: {} # Any node can endorse.

--- a/examples/runtime-sdk/rofl-oracle/policy2.yml
+++ b/examples/runtime-sdk/rofl-oracle/policy2.yml
@@ -7,9 +7,12 @@ quotes:
     # Minimum acceptable TCB evaluation data number. This ensures that TCB information
     # provided by the TEE vendor is recent enough and includes relevant TCB recoveries.
     min_tcb_evaluation_data_number: 17
+# Acceptable enclave cryptographic identities.
+enclaves:
+  - "0+tTmlVjUvP0eIHXH7Dld3svPppCUdKDwYxnzplndLea/8+uR7hI7CyvHEm0soNTHhzEJfk1grNoBuUqQ9eNGg=="
 # Acceptable nodes that can endorse the enclaves.
 endorsements:
-  - "0+tTmlVjUvP0eIHXH7Dld3svPppCUdKDwYxnzplndLea/8+uR7hI7CyvHEm0soNTHhzEJfk1grNoBuUqQ9eNGg=="
+  - any: {} # Any node can endorse.
 # Who is paying the transaction fees on behalf of the enclaves.
 fees: endorsing_node # The endorsing node is paying via a fee proxy.
 # How often (in epochs) do the registrations need to be refreshed.


### PR DESCRIPTION
The enclaves and endorsements fields were mixed up. This PR properly fixes those.