### PR TITLE
docs: Add gcc-multilib dependency in order to compile rofl

### DIFF
--- a/docs/rofl/prerequisites.md
+++ b/docs/rofl/prerequisites.md
@@ -85,11 +85,11 @@ rust environment:
 rustup target add x86_64-unknown-linux-musl
 ```
 
-Additionally, you will need the MUSL wrapper for gcc. On Ubuntu/Debian systems,
-you can install it by running:
+Additionally, you will need the MUSL wrapper for gcc and the multilib package.
+On Ubuntu/Debian systems, you can install it by running:
 
 ```shell
-sudo apt install musl-tools
+sudo apt install musl-tools gcc-multilib
 ```
 
 <!-- markdownlint-disable line-length -->


### PR DESCRIPTION
`oasis rofl build sgx --mode unsafe` fails following current instructions on plain ubuntu during the SGXS compilation. You need to install `gcc-multilib`.