### PR TITLE
client-sdk: allow insecure connections to localhost address

### DIFF
--- a/client-sdk/go/config/network.go
+++ b/client-sdk/go/config/network.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 )
@@ -135,9 +134,4 @@ func (n *Network) Validate() error {
 	}
 
 	return nil
-}
-
-// IsLocalRPC checks whether the RPC endpoint points to a local UNIX socket.
-func (n *Network) IsLocalRPC() bool {
-	return strings.HasPrefix(n.RPC, "unix:")
 }

--- a/client-sdk/go/connection/connection.go
+++ b/client-sdk/go/connection/connection.go
@@ -105,7 +105,7 @@ func Connect(ctx context.Context, net *config.Network) (Connection, error) {
 // omitting the chain context check.
 func ConnectNoVerify(_ context.Context, net *config.Network) (Connection, error) {
 	var dialOpts []grpc.DialOption
-	switch net.IsLocalRPC() {
+	switch cmnGrpc.IsLocalAddress(net.RPC) {
 	case true:
 		// No TLS needed for local nodes.
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))


### PR DESCRIPTION
This usecase came up in https://github.com/oasisprotocol/oasis-web3-gateway/pull/626 since we want to expose the node from docker via a port (since this works better cross-platform than exposing the socket via a volume).

The alternative possible solution would be to provide a flag that allows insecure connections or connections with self-signed certs (something like --insecure in curl).

BTW we might want to do the same in oasis-core: https://github.com/oasisprotocol/oasis-core/blob/280d2ef1947bc9baaeb390c3131a08b87824c9ef/go/oasis-node/cmd/common/grpc/grpc.go#L83-L89
since ideally, both `oasis-node` and `oasis-cli` would work with local-net without much hassle.

cc @matevz 


TODO: 
- [x] use the method from oasis-core: https://github.com/oasisprotocol/oasis-core/compare/ptrus/feature/grpc-loopback-insecure?expand=1