### PR TITLE
Update ROFL app docs

### DIFF
--- a/docs/rofl/app.md
+++ b/docs/rofl/app.md
@@ -131,7 +131,8 @@ The simplest way to test and debug your ROFL is with a local stack.
     }
    ```
 
-2. Compile ROFL in the _unsafe_ mode:
+2. Navigate to `examples/runtime-sdk/rofl-oracle` and compile
+ROFL in the _unsafe_ mode:
 
    ```shell
    oasis rofl build sgx --mode unsafe
@@ -141,7 +142,10 @@ The simplest way to test and debug your ROFL is with a local stack.
    folder to `/rofls` inside the docker image:
 
    ```shell
-   docker run -it -p8545:8545 -p8546:8546 -v rofl-oracle:/rofls ghcr.io/oasisprotocol/sapphire-localnet
+   # Make sure to use the latest Sapphire Localnet docker image
+   docker pull ghcr.io/oasisprotocol/sapphire-localnet:latest
+   # Assuming you are running this command from the `rofl-oracle` directory
+   docker run -it -p8544-8548:8544-8548 -v .:/rofls ghcr.io/oasisprotocol/sapphire-localnet:latest
    ```
 
 In a few moments, the Sapphire Localnet will spin up and automatically launch

--- a/docs/rofl/prerequisites.md
+++ b/docs/rofl/prerequisites.md
@@ -108,10 +108,20 @@ sudo apt install musl-tools gcc-multilib clang
 In order to generate binaries suitable for use with Intel SGX, you also need to
 install the relevant utilities. You can do so as follows:
 
+Start with adding OpenSSL development package and the Protobuf compiler:
+
+```shell
+sudo apt-get install pkg-config libssl-dev protobuf-compiler
+```
+
+You can find more details looking at [Fortanix docs].
+
 ```
 cargo install fortanix-sgx-tools
 cargo install sgxs-tools
 ```
+
+[Fortanix docs]: https://edp.fortanix.com/docs/installation/guide/#tab-3-1
 
 ## Oasis CLI Installation
 


### PR DESCRIPTION
Tweak docs to address potential `No ROFLs detected` while running localstack:

- Make sure sapphire-localnet container is not outdated 
- Commands where not clear or accurate (at least for me)
- Adjust ports so users can access local Nexus and Explorer 