### PR TITLE
runtime-sdk/modules/rofl: Add watchdog task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "rofl-containers"
-version = "0.3.3"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/rofl-containers/Cargo.toml
+++ b/rofl-containers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rofl-containers"
-version = "0.3.3"
+version = "0.3.5"
 edition = "2021"
 
 [dependencies]

--- a/runtime-sdk/src/modules/rofl/app/mod.rs
+++ b/runtime-sdk/src/modules/rofl/app/mod.rs
@@ -26,6 +26,7 @@ mod notifier;
 pub mod prelude;
 mod processor;
 mod registration;
+mod watchdog;
 
 pub use crate::modules::rofl::app_id::AppId;
 pub use client::Client;

--- a/runtime-sdk/src/modules/rofl/app/registration.rs
+++ b/runtime-sdk/src/modules/rofl/app/registration.rs
@@ -156,6 +156,11 @@ where
         }
         self.last_registration_epoch = Some(epoch);
 
+        // Notify about registration refresh.
+        self.env
+            .send_command(processor::Command::RegistrationRefreshed)
+            .await?;
+
         Ok(())
     }
 }

--- a/runtime-sdk/src/modules/rofl/app/watchdog.rs
+++ b/runtime-sdk/src/modules/rofl/app/watchdog.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use tokio::{sync::mpsc, time};
+
+use crate::core::common::{logger::get_logger, process};
+
+/// Interval in which at least one keep-alive must be delivered to avoid the watchdog from
+/// terminating the application.
+const WATCHDOG_TRIGGER_INTERVAL: u64 = 6 * 3600; // 6 hours
+
+/// Application watchdog task.
+pub(super) struct Task {
+    imp: Option<Impl>,
+    tx: mpsc::Sender<()>,
+}
+
+impl Task {
+    /// Create an application watchdog task.
+    pub(super) fn new() -> Self {
+        let (tx, rx) = mpsc::channel(16);
+
+        let imp = Impl {
+            logger: get_logger("modules/rofl/app/watchdog"),
+            notify: rx,
+        };
+
+        Self { imp: Some(imp), tx }
+    }
+
+    /// Start the application watchdog task.
+    pub(super) fn start(&mut self) {
+        if let Some(imp) = self.imp.take() {
+            imp.start();
+        }
+    }
+
+    /// Notify the watchdog that we are still alive.
+    pub(super) async fn keep_alive(&self) -> Result<()> {
+        self.tx.send(()).await?;
+        Ok(())
+    }
+}
+
+struct Impl {
+    logger: slog::Logger,
+
+    notify: mpsc::Receiver<()>,
+}
+
+impl Impl {
+    /// Start the application watchdog task.
+    pub(super) fn start(self) {
+        tokio::task::spawn(self.run());
+    }
+
+    /// Run the application watchdog task.
+    async fn run(mut self) {
+        slog::info!(self.logger, "starting watchdog task");
+
+        loop {
+            tokio::select! {
+                Some(()) = self.notify.recv() => {
+                    // Keep-alive received, reset watchdog.
+                },
+
+                _ = time::sleep(time::Duration::from_secs(WATCHDOG_TRIGGER_INTERVAL)) => {
+                    // Watchdog triggered, kill the process.
+                    slog::error!(self.logger, "keep-alive not received, terminating application");
+                    process::abort();
+                },
+
+                else => break,
+            }
+        }
+
+        slog::info!(self.logger, "watchdog task stopped");
+    }
+}


### PR DESCRIPTION
Fixes #2143 

The watchdog task ensures that the app is successfully re-registering and terminates it if this is not the case.