### PR TITLE
fix Unvalidated dynamic method call on connection() Improper Check for Unusual or Exceptional Conditions

### DIFF
--- a/client-sdk/ts-web/ext-utils/src/connection.ts
+++ b/client-sdk/ts-web/ext-utils/src/connection.ts
@@ -88,7 +88,11 @@ export function handleMessage(e: MessageEvent<unknown>) {
             const handlerKey = `${e.origin}/${m.event.type}`;
             if (!eventHandlers[handlerKey]) break;
             const handler = eventHandlers[handlerKey];
-            handler(m.event as never);
+            if (typeof handler === 'function') {
+                handler(m.event as never);
+            } else {
+                console.error(`Invalid handler for key: ${handlerKey}`);
+            }
             break;
         }
     }


### PR DESCRIPTION
https://github.com/oasisprotocol/oasis-sdk/blob/56fda77c2fec3c8d59f3e5e58dbb46e7ae6517ea/client-sdk/ts-web/ext-utils/src/connection.ts#L91-L91

To address the issue need to ensure that the value retrieved from `eventHandlers[handlerKey]` is a function before invoking it. This can be achieved by adding a `typeof` check to confirm that the handler is a function. If the check fails, the code should gracefully handle the situation (e.g., by logging an error or ignoring the event).

The fix involves:
1. Modifying the code on line 91 to include a `typeof` check for the handler.
2. Ensuring that the handler is only invoked if it is a valid function.


JavaScript makes it easy to look up object properties dynamically at runtime. In particular, methods can be looked up by name and then called. However, if the method name is user-controlled, an attacker could choose a name that makes the application invoke an unexpected method, which may cause a runtime exception. If this exception is not handled, it could be used to mount a denial-of-service attack.  there might not be a method of the given name, or the result of the lookup might not be a function. In either case the method call will throw a `TypeError` at runtime.

Another, more subtle is where the result of the lookup is a standard library method from `Object.prototype`, which most objects have on their prototype chain. Examples of such methods include `valueOf`, `hasOwnProperty` and `__defineSetter__`. If the method call passes the wrong number or kind of arguments to these methods, they will throw an exception.

## POC
an HTTP request parameter `action` property is used to dynamically look up a function in the `actions` map, which is then invoked with the `payload` parameter as its argument.
```ts
var express = require('express');
var app = express();

var actions = {
  play(data) {
    // ...
  },
  pause(data) {
    // ...
  }
}

app.get('/perform/:action/:payload', function(req, res) {
  let action = actions[req.params.action];
  // BAD: `action` may not be a function
  res.end(action(req.params.payload));
});
```
The intention is to allow clients to invoke the `play` or `pause` method, but there is no check that `action` is actually the name of a method stored in `actions`. action is `rewind`, `action` will be `undefined` and the call will result in a runtime error.

The easiest way to prevent this is to turn `actions` into a `Map` and using `Map.prototype.has` to check whether the method name is valid before looking it up.
```ts
var express = require('express');
var app = express();

var actions = new Map();
actions.set("play", function play(data) {
  // ...
});
actions.set("pause", function pause(data) {
  // ...
});

app.get('/perform/:action/:payload', function(req, res) {
  if (actions.has(req.params.action)) {
    if (typeof actions.get(req.params.action) === 'function'){
      let action = actions.get(req.params.action);
    }
    // GOOD: `action` is either the `play` or the `pause` function from above
    res.end(action(req.params.payload));
  } else {
    res.end("Unsupported action.");
  }
});
```
If `actions` cannot be turned into a `Map`, a `hasOwnProperty` check should be added to validate the method name:
```ts
var express = require('express');
var app = express();

var actions = {
  play(data) {
    // ...
  },
  pause(data) {
    // ...
  }
}

app.get('/perform/:action/:payload', function(req, res) {
  if (actions.hasOwnProperty(req.params.action)) {
    let action = actions[req.params.action];
    if (typeof action === 'function') {
      // GOOD: `action` is an own method of `actions`
      res.end(action(req.params.payload));
      return;
    }
  }
  res.end("Unsupported action.");
});
```
## References
[Denial of Service](https://www.owasp.org/index.php/Denial_of_Service)
[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
[Object.prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype)
[CWE-754](https://cwe.mitre.org/data/definitions/754.html)
