### PR TITLE
docs: rofl/quickstart - changed brackets from [] to ()

### DIFF
--- a/docs/rofl/quickstart.mdx
+++ b/docs/rofl/quickstart.mdx
@@ -34,7 +34,7 @@ async def hello(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(f'Hello {update.effective_user.first_name}')
 
 
-app = ApplicationBuilder().token(os.getenv["TOKEN"]).build()
+app = ApplicationBuilder().token(os.getenv("TOKEN")).build()
 
 app.add_handler(CommandHandler("hello", hello))
 


### PR DESCRIPTION
for MAC users - we get this error  when running
TOKEN=$TOKEN python bot.py 

the fix is changing the square brackets to ()

Traceback (most recent call last):
  File "/Users/jordan/Desktop/testing/demo/bot.py", line 10, in <module>
    app = ApplicationBuilder().token(os.getenv["TOKEN"]).build()
TypeError: 'function' object is not subscriptable