### PR TITLE
runtime-sdk/roflmarket: Add missing instance update events

### DIFF
--- a/runtime-sdk/modules/rofl-market/src/lib.rs
+++ b/runtime-sdk/modules/rofl-market/src/lib.rs
@@ -836,6 +836,13 @@ impl<Cfg: Config> Module<Cfg> {
                 .claim(ctx, &provider, &mut instance)?;
             instance.updated_at = ctx.now();
             state::set_instance(instance);
+
+            CurrentState::with(|state| {
+                state.emit_event(Event::InstanceUpdated {
+                    provider: body.provider,
+                    id,
+                })
+            });
         }
 
         Ok(())

--- a/runtime-sdk/modules/rofl-market/src/lib.rs
+++ b/runtime-sdk/modules/rofl-market/src/lib.rs
@@ -793,6 +793,13 @@ impl<Cfg: Config> Module<Cfg> {
         instance.updated_at = ctx.now();
         state::set_instance(instance);
 
+        CurrentState::with(|state| {
+            state.emit_event(Event::InstanceUpdated {
+                provider: body.provider,
+                id: body.id,
+            })
+        });
+
         Ok(())
     }
 


### PR DESCRIPTION
In these two places, the instance was updated, but no `InstanceUpdated` event was emitted.