### PR TITLE
go/client-sdk/core: Add round parameter to MinGasPrice

### DIFF
--- a/client-sdk/go/modules/core/core.go
+++ b/client-sdk/go/modules/core/core.go
@@ -35,7 +35,7 @@ type V1 interface {
 	EstimateGasForCaller(ctx context.Context, round uint64, caller types.CallerAddress, tx *types.Transaction, propagateFailures bool) (uint64, error)
 
 	// MinGasPrice returns the minimum gas price.
-	MinGasPrice(ctx context.Context) (map[types.Denomination]types.Quantity, error)
+	MinGasPrice(ctx context.Context, round uint64) (map[types.Denomination]types.Quantity, error)
 
 	// GetEvents returns all core events emitted in a given block.
 	GetEvents(ctx context.Context, round uint64) ([]*Event, error)
@@ -90,9 +90,9 @@ func (a *v1) EstimateGasForCaller(ctx context.Context, round uint64, caller type
 }
 
 // Implements V1.
-func (a *v1) MinGasPrice(ctx context.Context) (map[types.Denomination]types.Quantity, error) {
+func (a *v1) MinGasPrice(ctx context.Context, round uint64) (map[types.Denomination]types.Quantity, error) {
 	var mgp map[types.Denomination]types.Quantity
-	err := a.rc.Query(ctx, client.RoundLatest, methodMinGasPrice, nil, &mgp)
+	err := a.rc.Query(ctx, round, methodMinGasPrice, nil, &mgp)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/evm/eth_tx.go
+++ b/tests/e2e/evm/eth_tx.go
@@ -26,7 +26,7 @@ func submitEthereumTx(ctx context.Context, rtc client.RuntimeClient, txData ethT
 	c := core.NewV1(rtc)
 	ac := accounts.NewV1(rtc)
 
-	mgp, err := c.MinGasPrice(ctx)
+	mgp, err := c.MinGasPrice(ctx, client.RoundLatest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get min gas price: %w", err)
 	}

--- a/tests/e2e/evm/tests.go
+++ b/tests/e2e/evm/tests.go
@@ -360,7 +360,7 @@ func evmTest(ctx context.Context, log *logging.Logger, rtc client.RuntimeClient,
 	gasPrice := uint64(1)
 
 	// Check min gas price.
-	mgp, err := c.MinGasPrice(ctx)
+	mgp, err := c.MinGasPrice(ctx, client.RoundLatest)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The Go client method `MinGasPrice` did not accept a round parameter and always queried the latest round.

Querying `MinGasPrice` for past rounds is necessary to calculate the charged fee for EVM EIP-1559 transactions, where the effective gas price depends on the base fee at the round of transaction (which corresponds to the min gas price in our case).