### PR TITLE
docs: Fix typo in /sign-submit param name

### DIFF
--- a/docs/rofl/features/rest.md
+++ b/docs/rofl/features/rest.md
@@ -128,7 +128,7 @@ Subcall.roflEnsureAuthorizedOrigin(roflAppID);
   - Oasis SDK calls (`std`) support CBOR-serialized hex-encoded `Transaction`s
     to be specified.
 
-- `encrypted` is a boolean flag specifying whether the transaction should be
+- `encrypt` is a boolean flag specifying whether the transaction should be
   encrypted. By default this is `true`. Note that encryption is handled
   transparently for the caller using an ephemeral key and any response is first
   decrypted before being passed on.


### PR DESCRIPTION
https://github.com/oasisprotocol/oasis-sdk/blob/840e66d0c42ad9591be2c34a5c9fa97d378b6a90/rofl-appd/src/routes/tx.rs#L73

https://github.com/oasisprotocol/oasis-sdk/blob/840e66d0c42ad9591be2c34a5c9fa97d378b6a90/rofl-appd/src/routes/tx.rs#L102
