### PR TITLE
ts-web/core: throw on quantity from negative bigint

### DIFF
--- a/client-sdk/ts-web/core/src/quantity.ts
+++ b/client-sdk/ts-web/core/src/quantity.ts
@@ -7,6 +7,7 @@ export function toBigInt(q: Uint8Array) {
 
 export function fromBigInt(bi: bigint) {
     if (bi === 0n) return new Uint8Array();
+    if (bi < 0n) throw new RangeError(`Cannot convert ${bi} to quantity`);
     let hex = bi.toString(16);
     if (hex.length % 2) {
         hex = '0' + hex;


### PR DESCRIPTION
the library is still very much "only help when you already know what you're doing" but look at this badness

```ts
import * as oasis from '@oasisprotocol/client';
console.log(oasis.quantity.toBigInt(oasis.quantity.fromBigInt(-10n)));
// 246n
```

