### PR TITLE
rofl-client-py: Prepare 0.1.0 release

### DIFF
--- a/rofl-client/py/CHANGELOG.md
+++ b/rofl-client/py/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## 0.1.0 - 2025-09-17
+
+### Added
+- Initial public release
+- Core ROFL client functionality for Python
+- Documentation and usage examples


### PR DESCRIPTION
Initial Release

Needs tag for pypi publish workflow
```
rofl-client/py/v0.1.0
```