### PR TITLE
rofl-client-py: Prepare release 0.1.1

### DIFF
--- a/.github/workflows/release-rofl-client-py.yml
+++ b/.github/workflows/release-rofl-client-py.yml
@@ -33,10 +33,12 @@ jobs:
       run: uv python install 3.12
     
     - name: Build package
+      working-directory: rofl-client/py
       run: uv build
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
+      working-directory: rofl-client/py
       with:
         name: python-package-distributions
         path: dist/
@@ -51,6 +53,7 @@ jobs:
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4
+      working-directory: rofl-client/py
       with:
         name: python-package-distributions
         path: dist/
@@ -59,5 +62,6 @@ jobs:
       uses: astral-sh/setup-uv@v4
     
     - name: Publish to PyPI
+      working-directory: rofl-client/py
       run: |
         uv publish dist/*

--- a/rofl-client/py/CHANGELOG.md
+++ b/rofl-client/py/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 - 2025-09-18
+
+### Fixed 
+- Missing working directory in github workflow
+
 
 ## 0.1.0 - 2025-09-17
 


### PR DESCRIPTION
There were some missing workdirs in the publish workflow.