### PR TITLE
docs: rofl app terms replace

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,19 +24,19 @@ The Runtime SDK handles the _backend_ part, namely the runtime itself. It
 allows you to build the logic that will be replicated when running alongside an
 Oasis Core node in Rust.
 
-#### ROFL Applications
+#### ROFL-Powered Applications
 
-Runtime OFf-chain Logic (ROFL) applications are a mechanism to augment the
-deterministic on-chain backend with verifiable off-chain applications. These
+Runtime OFf-chain Logic (ROFL)-powered applications are a mechanism to augment
+the deterministic on-chain backend with verifiable off-chain applications. These
 applications are stateless, have access to the network and can perform expensive
 and/or non-deterministic computation. Consider them the _off-chain backend_
 part.
 
-ROFL applications run in Trusted Execution Environments (TEEs), similar to the
-on-chain confidential runtimes. This enables them to securely authenticate to
-the on-chain backend which is handled transparently by the framework. Together
-they allow one to implement secure decentralized oracles, bridges, AI agents and
-more.
+ROFL-powered applications run in Trusted Execution Environments (TEEs), similar
+to the on-chain confidential runtimes. This enables them to securely
+authenticate to the on-chain backend which is handled transparently by the
+framework. Together, they allow one to implement secure decentralized oracles,
+bridges, AI agents and more.
 
 ### Contract SDK
 
@@ -55,7 +55,7 @@ transactions, look up emitted events and query the runtime.
 
 * [Build a Smart Contract](contract/prerequisites.md)
 * [Build a Runtime](runtime/prerequisites.md)
-* [Build a ROFL Application](rofl/prerequisites.md)
+* [Build a ROFL-Powered App](rofl/prerequisites.md)
 
 <!-- markdownlint-disable line-length -->
 [Oasis Core Runtime Layer]:

--- a/docs/rofl/README.mdx
+++ b/docs/rofl/README.mdx
@@ -1,27 +1,28 @@
 ---
-description: Build your own ROFL app
+description: Build your own ROFL-Powered App
 ---
 
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Build ROFL App
+# Build ROFL-Powered Apps
 
 ![ROFL diagram](images/rofl.svg)
 
-*Runtime OFf-chain Logic (ROFL)* apps are a mechanism to augment the deterministic
-on-chain backend with verifiable off-chain applications. These applications are
-stateless (with support for encrypted persistent local volumes), have access to
-the network and can perform expensive and/or non-deterministic computation.
+*Runtime OFf-chain Logic (ROFL)* is a mechanism to augment the
+deterministic on-chain backend with verifiable off-chain applications.
+Applications in ROFL are stateless (with support for encrypted persistent local
+volumes), have access to the network and can perform expensive and/or
+non-deterministic computation.
 
-ROFL apps run in *Trusted Execution Environments (TEEs)*, similar to the
+These apps run in *Trusted Execution Environments (TEEs)*, similar to the
 on-chain confidential runtimes. This enables them to securely authenticate to
 the on-chain backend which is handled transparently by the framework. Together
 they allow one to implement secure decentralized oracles, bridges, AI agents and
 more.
 
-The following chapters will teach you how to build your own ROFL app with the
-help of the [Oasis Runtime SDK].
+The following chapters will teach you how to build your own app with the help of
+the [Oasis Runtime SDK].
 
 ## See also
 

--- a/docs/rofl/app.mdx
+++ b/docs/rofl/app.mdx
@@ -3,8 +3,8 @@ import TabItem from '@theme/TabItem';
 
 # Application
 
-ROFL apps come in different flavors and the right choice is a tradeoff between
-the Trusted Computing Base (TCB) size and ease of use:
+Apps running in ROFL come in different flavors and the right choice is a
+tradeoff between the Trusted Computing Base (TCB) size and ease of use:
 
 - **TDX containers ROFL (default)**: A Docker compose-based container services
   packed in a secure virtual machine.
@@ -14,34 +14,33 @@ the Trusted Computing Base (TCB) size and ease of use:
   a single secure binary.
 
 This chapter will show you how to quickly create, build and test a minimal
-containerized ROFL app that authenticates and communicates with a confidential
-smart contract on [Oasis Sapphire]. We will build a TDX container-based ROFL
-app.
+containerized app that authenticates and communicates with a confidential smart
+contract on [Oasis Sapphire]. We will build a TDX container-based app.
 
 [Oasis Sapphire]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/docs/README.mdx
 
-## How do ROFL Apps Work?
+## How do Apps in ROFL Work?
 
 ![ROFL diagram](images/rofl.svg)
 
-Each ROFL app runs in its own Trusted Execution Environment (TEE) which is
-provisioned by an Oasis Node from its _ORC bundle_ (a zip archive containing the
-program binaries and metadata required for execution). ROFL apps register to
-the Oasis Network in order to be able to easily authenticate to on-chain smart
-contracts and transparently gain access to the decentralized per-app key
-management system.
+Each app running in ROFL runs in its own Trusted Execution Environment (TEE)
+which is provisioned by an Oasis Node from its _ORC bundle_ (a zip archive
+containing the program binaries and metadata required for execution). Apps in
+ROFL register to the Oasis Network in order to be able to easily authenticate to
+on-chain smart contracts and transparently gain access to the decentralized
+per-app key management system.
 
-Inside the TEE, the ROFL app performs important functions that ensure its
-security and enable secure communication with the outside world. This includes
-using a light client to establish a fresh view of the Oasis consensus layer
-which provides a source of rough time and integrity for verification of all
-on-chain state. The ROFL app also generates a set of ephemeral cryptographic
-keys which are used in the process of remote attestation and on-chain
-registration. These processes ensure that the ROFL app can authenticate to
-on-chain modules (e.g. smart contracts running on [Sapphire]) by
-signing and submitting special transactions.
+Inside the TEE, the app performs important functions that ensure its security
+and enable secure communication with the outside world. This includes using a
+light client to establish a fresh view of the Oasis consensus layer which
+provides a source of rough time and integrity for verification of all on-chain
+state. The app also generates a set of ephemeral cryptographic keys which are
+used in the process of remote attestation and on-chain registration. These
+processes ensure that the app can authenticate to on-chain modules (e.g. smart
+contracts running on [Sapphire]) by signing and submitting special
+transactions.
 
-The ROFL app can then perform arbitrary work and interact with the outside world
+The app can then perform arbitrary work and interact with the outside world
 through (properly authenticated) network connections. Connections can be
 authenticated via HTTPS/TLS or use other methods (e.g. light clients for other
 chains).
@@ -52,15 +51,14 @@ chains).
 
 ## App Directory and Manifest
 
-First we create the basic directory structure for the ROFL app using the [Oasis
-CLI]:
+First we create the basic directory structure for the app using the [Oasis CLI]:
 
 ```shell
 oasis rofl init myapp
 ```
 
 This will create the `myapp` directory and initialize some boilerplate needed to
-build a TDX container-based ROFL app. The rest of the guide assumes that you are
+build a TDX container-based app. The rest of the guide assumes that you are
 executing commands from within this directory.
 
 The command will output a summary of what is being created:
@@ -73,7 +71,7 @@ TEE:      tdx
 Kind:     container
 Git repository initialized.
 Created manifest in 'rofl.yaml'.
-Run `oasis rofl create` to register your ROFL app and configure an app ID.
+Run `oasis rofl create` to register your app and configure an app ID.
 ```
 
 The directory structure (omitting git artifacts) will look as follows:
@@ -81,12 +79,11 @@ The directory structure (omitting git artifacts) will look as follows:
 ```
 myapp
 ├── compose.yaml        # Container compose file.
-└── rofl.yaml           # ROFL app manifest.
+└── rofl.yaml           # App manifest.
 ```
 
-The [manifest] contains things like ROFL app [metadata], [secrets],
-[requested resources] and can be modified either manually or by using the CLI
-commands.
+The [manifest] contains things like app [metadata], [secrets], [requested
+resources] and can be modified either manually or by using the CLI commands.
 
 [manifest]: features/manifest.md
 [metadata]: features/manifest.md#metadata
@@ -96,7 +93,7 @@ commands.
 
 ## Create
 
-Before the ROFL app can be built it needs to be created on chain to assign it a
+Before the app can be built it needs to be created on chain to assign it a
 unique identifier (the app ID) which can be used by on-chain smart contracts to
 ensure that they are talking to the right app and also gives the app access to a
 decentralized key management system.
@@ -106,9 +103,9 @@ tokens][stake-requirements].
 
 :::tip
 
-In order to obtain TEST tokens needed for creating and running your ROFL apps
-use [the faucet] or [ask on Discord]. To make things easier you should
-[create or import a `secp256k1-bip44` account] that you can also use with the
+In order to obtain TEST tokens needed for creating and running your apps use
+[the faucet] or [ask on Discord]. To make things easier you should [create or
+import a `secp256k1-bip44` account] that you can also use with the
 Ethereum-compatible tooling like Hardhat.
 
 <!-- markdownlint-disable line-length -->
@@ -120,9 +117,9 @@ Ethereum-compatible tooling like Hardhat.
 :::
 
 We also need to select the network (in this case `testnet`) and the account
-that will be the initial administrator of the ROFL app (in this case
-`myaccount`). The CLI will automatically update the app manifest (`rofl.yaml`)
-with the assigned app identifier.
+that will be the initial administrator of the app (in this case `myaccount`). The
+CLI will automatically update the app manifest (`rofl.yaml`) with the assigned
+app identifier.
 
 ```shell
 oasis rofl create --network testnet --account myaccount
@@ -141,9 +138,9 @@ by the current admin.
 :::info
 
 While the CLI implements a simple governance mechanism where the admin of the
-ROFL app is a single account, even a smart contract can be the admin. This
-allows for implementation of advanced agent governance mechanisms, like using
-multi-sigs or DAOs with veto powers to control the upgrade process.
+app is a single account, even a smart contract can be the admin. This allows for
+implementation of advanced agent governance mechanisms, like using multi-sigs or
+DAOs with veto powers to control the upgrade process.
 
 :::
 
@@ -157,7 +154,7 @@ App ID is derived using one of the two schemes:
 - **Creator address + block round number + index of the `rofl.Create`
   transaction in the block**: This approach is non-deterministic and preferred
   in production environments so that the potential attacker cannot simply
-  determine ROFL app ID in advance, even if they knew what the creator address
+  determine the app ID in advance, even if they knew what the creator address
   is.
 
 You can select the app ID derivation scheme by passing the
@@ -185,21 +182,20 @@ part can be anything from a [WASM-based smart contract] to a dedicated
 
 We have prepared a simple oracle contract for this example. You can find it by
 checking out the [prepared example project]. It contains a simple [Oracle.sol]
-contract which collects observations from authenticated ROFL app instances,
-performs trivial aggregation and stores the final aggregated result. Read the
-[Sapphire quickstart] chapter to learn how to build and deploy Sapphire smart
-contracts, but to get you up and running for this part, simply copy the example
-project from above, install dependencies and compile the smart contract by
-executing:
+contract which collects observations from authenticated app instances, performs
+trivial aggregation and stores the final aggregated result. Read the [Sapphire
+quickstart] chapter to learn how to build and deploy Sapphire smart contracts,
+but to get you up and running for this part, simply copy the example project
+from above, install dependencies and compile the smart contract by executing:
 
 ```shell
 npm install
 npx hardhat compile
 ```
 
-Configure the `PRIVATE_KEY` of the deployment account and the ROFL app
-identifier (be sure to use the identifier that you received during
-registration), then deploy the contract by running, for example:
+Configure the `PRIVATE_KEY` of the deployment account and the app identifier (be
+sure to use the identifier that you received during registration), then deploy
+the contract by running, for example:
 
 ```shell
 PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" \
@@ -209,10 +205,10 @@ npx hardhat deploy rofl1qqn9xndja7e2pnxhttktmecvwzz0yqwxsquqyxdf --network sapph
 After successful deployment you will see a message like:
 
 ```
-Oracle for ROFL app rofl1qqn9xndja7e2pnxhttktmecvwzz0yqwxsquqyxdf deployed to 0x1234845aaB7b6CD88c7fAd9E9E1cf07638805b20
+Oracle for app rofl1qqn9xndja7e2pnxhttktmecvwzz0yqwxsquqyxdf deployed to 0x1234845aaB7b6CD88c7fAd9E9E1cf07638805b20
 ```
 
-You can now proceed to building and deploying the ROFL app itself. Remember the
+You can now proceed to building and deploying the app itself. Remember the
 address where the oracle contract was deployed to as you will need it in the
 next step.
 
@@ -224,10 +220,10 @@ next step.
 
 ## Define Containerized Services
 
-What the core of the ROFL app does is defined with services running in Podman
+What the core of the app does is defined with services running in Podman
 containers defined in [the compose file]. Anything that can run as a bunch of
-containers can also be run as a ROFL app. This includes exposing web services
-to the internet using the [ROFL Proxy].
+containers can also be run as an app in ROFL. This includes exposing web
+services to the internet using the [ROFL Proxy].
 
 For an easier start, we will use the `docker.io/oasisprotocol/demo-rofl` image
 defined in [the `demo-rofl` repository] and which implements [a trivial oracle]
@@ -265,17 +261,15 @@ name e.g. `docker.io/ollama/ollama` and not just `ollama/ollama`.
 
 ## Build
 
-Whenever you make changes to your ROFL app and want to deploy it, you first need
-to build it. The build process takes the compose file together with other ROFL
-app artifacts and deterministically generates a bundle that can later be
-deployed.
+Whenever you make changes to your app and want to deploy it, you first need to
+build it. The build process takes the compose file together with other app
+artifacts and deterministically generates a bundle that can later be deployed.
 
 The build process also computes the _enclave identity_ of the bundle which is
 used during the process of remote attestation to authenticate the app instances
 before granting them access to the key management system and [other features].
 
-To build a ROFL app and update the enclave identity in the app manifest, simply
-run:
+To build an app and update the enclave identity in the app manifest, simply run:
 
 <Tabs>
     <TabItem value="Native Linux">
@@ -290,19 +284,19 @@ run:
     </TabItem>
 </Tabs>
 
-This will generate the resulting ROFL app bundle which can be used for later
+This will generate the resulting app bundle which can be used for later
 deployment and output something like:
 
 ```
-ROFL app built and bundle written to 'myapp.default.orc'.
+App built and bundle written to 'myapp.default.orc'.
 ```
 
 [other features]: features/
 
 ## Update On-chain App Config
 
-After any changes to the ROFL app policy defined in the manifest, the on-chain
-app config needs to be updated in order for the changes to take effect.
+After any changes to the app policy defined in the manifest, the on-chain app
+config needs to be updated in order for the changes to take effect.
 
 The designated admin account is able to update this policy by issuing an update
 transaction which can be done via the CLI by running:

--- a/docs/rofl/deployment.mdx
+++ b/docs/rofl/deployment.mdx
@@ -9,14 +9,14 @@ required functionality.
 
 [sapphire]: https://github.com/oasisprotocol/docs/blob/main/docs/build/sapphire/network.mdx
 
-Your ROFL app will be deployed to a [ROFL node]. This is a light Oasis Node with
+Your app will be deployed to a [ROFL node]. This is a light Oasis Node with
 support for TEE and configured Sapphire ParaTime. There are two ways to deploy your app:
 
 1. The preferred option is to rent a ROFL node using the [ROFL
    marketplace](#deploy-on-rofl-marketplace) and deploy your app directly via
    the [Oasis CLI].
 2. Alternatively, you can copy over the ROFL bundle to your ROFL node manually
-   and configure it. In this case, consult the [ROFL node &rightarrow; Hosting the ROFL app bundle directly][rofl-node-hosting] section.
+   and configure it. In this case, consult the [ROFL node &rightarrow; Hosting the app bundle directly][rofl-node-hosting] section.
 
 [ROFL node]: https://github.com/oasisprotocol/docs/blob/main/docs/node/run-your-node/rofl-node.mdx
 [rofl-node-hosting]: https://github.com/oasisprotocol/docs/blob/main/docs/node/run-your-node/rofl-node.mdx#hosting-the-rofl-app-bundle-directly
@@ -126,9 +126,9 @@ the standard or error outputs!
 [ROFL marketplace]: ./features/marketplace.mdx
 [oasis-rofl-deploy]: https://github.com/oasisprotocol/cli/blob/master/docs/rofl.md#deploy
 
-## Check That the ROFL App is Running
+## Check That the App is Running
 
-To check out all active ROFL app replicas regardless of the
+To check out all active app replicas regardless of the
 deployment procedure, use the following command:
 
 ```shell
@@ -167,14 +167,14 @@ Policy:
   Expiration: 9
 ```
 
-Here you can see that a single instance of the ROFL app is running on the given
-node, its public runtime attestation key (RAK) and the epoch at which its
-registration will expire if not refreshed. ROFL apps must periodically refresh
-their registrations to ensure they don't expire.
+Here you can see that a single instance of the app is running on the given node,
+its public runtime attestation key (RAK) and the epoch at which its
+registration will expire if not refreshed. Apps in ROFL must periodically
+refresh their registrations to ensure they don't expire.
 
-You can also check out the status of your ROFL app on the [Oasis Explorer]:
+You can also check out the status of your app on the [Oasis Explorer]:
 
-![Oasis Explorer - ROFL app](./images/demo-rofl-tgbot-explorer.png)
+![Oasis Explorer - App](./images/demo-rofl-tgbot-explorer.png)
 
 [Oasis Explorer]: https://explorer.oasis.io
 

--- a/docs/rofl/features/manifest.md
+++ b/docs/rofl/features/manifest.md
@@ -4,10 +4,10 @@
 
 The following fields are valid in your yaml root:
 
-- `name`: A short, human-readabe name for your ROFL app. e.g. `my-rofl-app`
+- `name`: A short, human-readabe name for your app. e.g. `my-app`
 - `version`: ROFL version. e.g. `0.1.1`
 - `repository`: A path to the git repository. e.g.
-  `https://github.com/user/my-rofl-app`
+  `https://github.com/user/my-app`
 - `author`: The author name and their e-mail address. e.g.
   `John Doe <john@doe.com>`
 - `license`: The ROFL license in [SPDX] format. e.g. `Apache-2.0`
@@ -20,9 +20,9 @@ The following fields are valid in your yaml root:
 
 ## App Resources (`resources`) {#resources}
 
-Each containerized ROFL app must define what kind of resources it needs for its
-execution. This includes the number of assigned vCPUs, amount of memory, storage
-requirements, GPUs, etc.
+Each containerized app running in ROFL must define what kind of resources it
+needs for its execution. This includes the number of assigned vCPUs, amount of
+memory, storage requirements, GPUs, etc.
 
 Resources are specified in the app manifest file under the `resources` section
 as follows:
@@ -41,7 +41,7 @@ This chapter describes the set of supported resources.
 :::warning
 
 Changing the requested resources will result in a different enclave identity of
-the ROFL app and will require the policy to be updated!
+the app and will require the policy to be updated!
 
 :::
 
@@ -57,9 +57,9 @@ The number of vCPUs allocated to the VM. By default this value is initialized to
 
 ### Storage (`storage`) {#resources-storage}
 
-Each ROFL app can request different storage options, depending on its use case.
-The storage kind is specified in the `kind` field with the following values
-currently supported:
+Each app running in ROFL can request different storage options, depending on its
+use case. The storage kind is specified in the `kind` field with the following
+values currently supported:
 
 - `disk-persistent` provisions a persistent disk of the given size. The disk is
   encrypted and authenticated using a key derived by the decentralized on-chain
@@ -85,17 +85,17 @@ This section contains ROFL deployments on specific networks.
 
 #### `policy`
 
-Contains the policy under which the ROFL app will be allowed to spin up:
+Contains the policy under which the app will be allowed to spin up:
 
 - `quotes`: defines a TEE-specific policy requirements such as the TCB validity
   period, and the minimum TCB-R number which indicates what security updates
   must be applied to the given platform.
-- `enclaves`: defines the allowed enclave IDs for running this ROFL app.
-- `endorsements`: a list of nodes which can run this ROFL app.
-  - `- any: {}`: any node is allowed to run this ROFL app.
+- `enclaves`: defines the allowed enclave IDs for running this app.
+- `endorsements`: a list of nodes which can run this app.
+  - `- any: {}`: any node is allowed to run this app.
   - `- node: <node_id>`: node with a specific node ID is allowed to run this
-    ROFL app. You can provide multiple `node` entries to allow the execution by
+    app. You can provide multiple `node` entries to allow the execution by
     any of the listed nodes.
 - `fees: <fee_policy>`: who pays for the registration and other fees:
-  - `endorsing_node`: the node running ROFL app pays the fees.
-  - `instance`: ROFL app instance pays the fees.
+  - `endorsing_node`: the node running the app pays the fees.
+  - `instance`: The app instance pays the fees.

--- a/docs/rofl/features/marketplace.mdx
+++ b/docs/rofl/features/marketplace.mdx
@@ -7,7 +7,7 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 
 # The ROFL Marketplace
 
-The ROFL marketplace is an on-chain protocol that allows ROFL app developers to
+The ROFL marketplace is an on-chain protocol that allows app developers to
 easily and safely deploy their apps for a small fee on one side and on the
 other enables ROFL node providers to lend their ROFL nodes for computation.
 
@@ -15,14 +15,14 @@ other enables ROFL node providers to lend their ROFL nodes for computation.
 
 The ROFL marketplace consists of three entities:
 
-- **ROFL app developers**: Build a ROFL app, register it on-chain and rent a
-machine from the ROFL provider where they can deploy their ROFL to.
+- **App developers**: Build an app, register it on-chain and rent a
+machine from the ROFL provider where they can deploy their app to.
 - **ROFL provider**: Is an on-chain entity that bills and assigns **machines**
 to ROFL developers. Each machine has a hosting plan called an **offer**.
 - **ROFL node**: Is a server that runs the Oasis node and instantiates one or
-more **machines** which then host a ROFL app.
+more **machines** which then host an app.
 
-## Instructions for ROFL app developers
+## Instructions for App Developers
 
 <DocCard item={
     findSidebarItem('/build/rofl/deployment')

--- a/docs/rofl/features/proxy.mdx
+++ b/docs/rofl/features/proxy.mdx
@@ -1,10 +1,10 @@
 # ROFL Proxy
 
 The ROFL proxy automatically generates public HTTPS URLs for services in your
-ROFL app. Simply publish a port in your `compose.yaml` and the proxy handles
+app. Simply publish a port in your `compose.yaml` and the proxy handles
 TLS certificates and routing.
 
-TLS is terminated inside the ROFL app, providing end-to-end encryption so that
+TLS is terminated inside the app, providing end-to-end encryption so that
 even the provider cannot see the traffic.
 
 ## Enabling the Proxy
@@ -20,7 +20,7 @@ services:
       - "5678:5678" # Expose container port 5678 on host port 5678
 ```
 
-After deploying your ROFL app, you can find the generated URL by
+After deploying your app, you can find the generated URL by
 running `oasis rofl machine show`:
 
 ```shell

--- a/docs/rofl/features/rest.md
+++ b/docs/rofl/features/rest.md
@@ -1,9 +1,9 @@
 # `appd` REST API
 
-Each containerized ROFL app runs a special daemon (called `rofl-appd`) that
-exposes additional functions via a simple HTTP REST API. In order to make it
-easier to isolate access, the API is exposed via a UNIX socket located at
-`/run/rofl-appd.sock` which can be passed to containers via volumes.
+Each containerized app running in ROFL runs a special daemon (called
+`rofl-appd`) that exposes additional functions via a simple HTTP REST API. In
+order to make it easier to isolate access, the API is exposed via a UNIX socket
+located at `/run/rofl-appd.sock` which can be passed to containers via volumes.
 
 An example using the [short syntax for Compose volumes][compose-volumes]:
 
@@ -30,7 +30,7 @@ format.
 
 ## App Identifier
 
-This endpoint can be used to retrieve the current ROFL app's identifier.
+This endpoint can be used to retrieve the current app's identifier.
 
 **Endpoint:** `/rofl/v1/app/id` (`GET`)
 
@@ -42,12 +42,12 @@ rofl1qqn9xndja7e2pnxhttktmecvwzz0yqwxsquqyxdf
 
 ## Key Generation
 
-Each registered ROFL app automatically gets access to a decentralized on-chain
-key management system.
+Each registered app automatically gets access to a decentralized on-chain key
+management system.
 
-All generated keys can only be generated inside properly attested ROFL app
-instances and will remain the same even in case the app is deployed somewhere
-else or its state is erased.
+All generated keys can only be generated inside properly attested app instances
+and will remain the same even in case the app is deployed somewhere else or its
+state is erased.
 
 **Endpoint:** `/rofl/v1/keys/generate` (`POST`)
 
@@ -85,13 +85,13 @@ The generated `key` is returned as a hexadecimal string.
 
 ## Authenticated Transaction Submission
 
-A ROFL app can also submit _authenticated transactions_ to the chain where it is
-registered at. The special feature of these transactions is that they are signed
-by an endorsed key and are therefore automatically authenticated as coming from
-the ROFL app itself.
+An app running in ROFL can also submit _authenticated transactions_ to the chain
+where it is registered at. The special feature of these transactions is that
+they are signed by an endorsed key and are therefore automatically authenticated
+as coming from the app itself.
 
-This makes it possible to easily authenticate ROFL apps in smart contracts by
-simply invoking an [appropriate subcall], for example:
+This makes it possible to easily authenticate apps in smart contracts by simply
+invoking an [appropriate subcall], for example:
 
 ```solidity
 Subcall.roflEnsureAuthorizedOrigin(roflAppID);

--- a/docs/rofl/features/secrets.md
+++ b/docs/rofl/features/secrets.md
@@ -2,9 +2,9 @@
 
 Sometimes containers need access to data that should not be disclosed publicly,
 for example API keys to access certain services. This data can be passed to
-containers running inside ROFL apps via _secrets_. Secrets are arbitrary
-key-value pairs which are end-to-end encrypted so that they can only be
-decrypted inside a correctly attested ROFL app instance.
+containers running in ROFL via _secrets_. Secrets are arbitrary key-value pairs
+which are end-to-end encrypted so that they can only be decrypted inside a
+correctly attested app instance.
 
 Secrets can be easily managed via the Oasis CLI, for example to create a secret
 called `mysecret` you can use:
@@ -34,7 +34,7 @@ end-to-end encrypted and cannot be read even by the administrator who set them.
 
 When a secret is created, a new ephemeral key is generated that is used in the
 encryption process. The ephemeral key is then immediately discarded so only the
-ROFL app itself can decrypt the secret.
+app itself can decrypt the secret.
 
 :::
 
@@ -68,7 +68,7 @@ services:
 
 Each secret is also defined as a [container secret] and can be passed to the
 container as such. Note that the secret needs to be defined as an _external_
-secret as it is created by the ROFL app during boot.
+secret as it is created by the app during boot.
 
 ```yaml
 services:

--- a/docs/rofl/features/storage.md
+++ b/docs/rofl/features/storage.md
@@ -11,13 +11,13 @@ local persistent storage with the following settings:
 
 This type of a storage is particularly useful for caching. Docker images defined
 in the `compose.yaml` file are automatically stored to persistent storage. This
-way they are fetched only the first time a ROFL app is deployed, otherwise
+way they are fetched only the first time an app is deployed, otherwise
 a cached version is considered.
 
 All non-external container volumes will automatically reside in persistent
 storage. In the example below, we [define a new volume] called `my-volume` and
 make `.ollama` in the home folder persistent. This way we avoid downloading
-ollama models each time a machine hosting the ROFL app is restarted:
+ollama models each time a machine hosting the app is restarted:
 
 ```yaml title="compose.yaml"
 services:

--- a/docs/rofl/features/testing.md
+++ b/docs/rofl/features/testing.md
@@ -2,9 +2,9 @@
 
 ## SGX ROFL
 
-SGX ROFL apps are fully supported by the [`sapphire-localnet`] Docker image.
-Simply bind-mount your ROFL app folder and any ORC bundles will automatically be
-registered and executed on startup:
+Apps running in SGX ROFL are fully supported by the [`sapphire-localnet`] Docker
+image. Simply bind-mount your app folder and any ORC bundles will automatically
+be registered and executed on startup:
 
 ```shell
 docker run -it -p8544-8548:8544-8548 -v .:/rofls ghcr.io/oasisprotocol/sapphire-localnet

--- a/docs/rofl/prerequisites.mdx
+++ b/docs/rofl/prerequisites.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to build your first ROFL app
+description: How to build your first ROFL-Powered App
 ---
 
 import Tabs from '@theme/Tabs';
@@ -10,8 +10,8 @@ import TabItem from '@theme/TabItem';
 The following tools are used for ROFL development and deployment:
 
 - **Oasis CLI**: The [`oasis`][oasis-cli] command will be used to manage your
-  wallet and your ROFL app, including registering, building, deploying and
-  managing your ROFL instances.
+  wallet and your app, including registering, building, deploying and managing
+  your ROFL instances.
 - **Docker**: Docker is perfect for building your ROFLs without installing a
   handful of Intel-specific libraries and dependencies on your system. Also,
   Docker compose is ideal for testing your ROFLs locally before deploying them
@@ -28,8 +28,7 @@ locally.
 
 For building your ROFLs, the Oasis team prepared the
 [`ghcr.io/oasisprotocol/rofl-dev`][rofl-dev] Docker image. It contains all the
-tools needed to compile any flavor of your ROFL app. You can test it out by
-running:
+tools needed to compile any flavor of your app. You can test it out by running:
 
 <Tabs>
     <TabItem value="Linux">

--- a/docs/rofl/quickstart.mdx
+++ b/docs/rofl/quickstart.mdx
@@ -18,7 +18,7 @@ If you already have a working containerized app, you should run the following
 [Oasis CLI][oasis-cli-dl] commands to ROFLize it:
 
 1. [`oasis rofl init`] to initialize the ROFL manifest in the existing folder.
-2. [`oasis rofl create`] to register a new ROFL app on the selected chain.
+2. [`oasis rofl create`] to register a new app on the selected chain.
 3. [`oasis rofl build`] to compile a ROFL bundle.
 4. [`oasis rofl secret set`] to encrypt and store any secrets required by your
    app.
@@ -181,8 +181,7 @@ official [Oasis Testnet faucet] or reach out to us on the
 [discord]: https://oasis.io/discord
 
 Next, inside our project folder, run the following command to generate the
-initial `rofl.yaml` manifest file and to register a new ROFL app on Sapphire
-Testnet:
+initial `rofl.yaml` manifest file and to register a new app on Sapphire Testnet:
 
 ```shell
 oasis rofl init
@@ -222,19 +221,19 @@ components on-chain run:
 oasis rofl update
 ```
 
-Finally, we deploy our ROFL app to a Testnet node instance offered by one of the
-ROFL providers:
+Finally, we deploy our app to a Testnet node instance offered by one of the ROFL
+providers:
 
 ```shell
 oasis rofl deploy
 ```
 
-Congratulations, you have just deployed your first ROFL app! 🎉
+Congratulations, you have just deployed your first app in ROFL! 🎉
 
 Go ahead and test it by sending the `/hello` message in the Telegram app. You
-can also check out your ROFL app on the [Oasis Explorer]:
+can also check out your app on the [Oasis Explorer]:
 
-![Oasis Explorer - ROFL app](./images/demo-rofl-tgbot-explorer.png)
+![Oasis Explorer - App](./images/demo-rofl-tgbot-explorer.png)
 
 :::info Example: demo-rofl-tgbot
 

--- a/docs/rofl/troubleshooting.mdx
+++ b/docs/rofl/troubleshooting.mdx
@@ -99,7 +99,7 @@ service will be triggered to restart `oracle` and try again.
 
 If you have exposed a port in your `compose.yaml` but the proxy URL shown
 by `oasis rofl machine show` is not accessible, it is likely that your
-ROFL app is using outdated artifacts.
+app is using outdated artifacts.
 
 To fix this, update to the latest Oasis CLI version, then
 run `oasis rofl upgrade` in your project directory to update the


### PR DESCRIPTION
closes https://github.com/oasisprotocol/oasis-sdk/issues/2323

Replaced  "ROFL app" terms with "app", "app running in ROFL", and "ROFL-Powered" for titles