### PR TITLE
rofl-client-py: Prepare 0.1.2 release

### DIFF
--- a/.github/workflows/release-rofl-client-py.yml
+++ b/.github/workflows/release-rofl-client-py.yml
@@ -38,10 +38,9 @@ jobs:
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
-      working-directory: rofl-client/py
       with:
         name: python-package-distributions
-        path: dist/
+        path: rofl-client/py/dist/
 
   publish-to-pypi:
     needs: build
@@ -53,10 +52,9 @@ jobs:
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4
-      working-directory: rofl-client/py
       with:
         name: python-package-distributions
-        path: dist/
+        path: rofl-client/py/dist/
     
     - name: Install uv
       uses: astral-sh/setup-uv@v4

--- a/rofl-client/py/CHANGELOG.md
+++ b/rofl-client/py/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 - 2025-09-22
+
+### Fixed
+- Release workflow validation error: removed invalid `working-directory` from `uses:` steps and set artifact `path` to `rofl-client/py/dist/`.
+
+
 ## 0.1.1 - 2025-09-18
 
 ### Fixed 
-- Missing working directory in github workflow
+- Missing working directory in GitHub workflow
 
 
 ## 0.1.0 - 2025-09-17


### PR DESCRIPTION
- uses path instead of working-directory for use artifact github actions