### PR TITLE
rofl-client-py: Perpare 0.1.3 release

### DIFF
--- a/.github/workflows/release-rofl-client-py.yml
+++ b/.github/workflows/release-rofl-client-py.yml
@@ -22,8 +22,10 @@ jobs:
     - name: Get version info
       id: version
       run: |
-        echo "version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
-    
+        TAG=${{ github.ref_name }}
+        VERSION=${TAG##*/}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/rofl-client/py/CHANGELOG.md
+++ b/rofl-client/py/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 - 2025-09-24
+
+### Fixed
+- stripping namespace correctly from version tag in workflow and hatch versioning
+
 ## 0.1.2 - 2025-09-22
 
 ### Fixed

--- a/rofl-client/py/pyproject.toml
+++ b/rofl-client/py/pyproject.toml
@@ -44,6 +44,9 @@ build-backend = "hatchling.build"
 source = "vcs"
 fallback-version = "0.0.0"
 
+[tool.hatch.version.raw-options]
+tag_regex = '^rofl-client/py/v(?P<version>\d+\.\d+\.\d+(?:[\w.-]*)?)$'
+
 [tool.hatch.build.hooks.vcs]
 version-file = "src/oasis_rofl_client/_version.py"
 


### PR DESCRIPTION
- fixed namespace stripping for correct version in workflow and hatch versioning