### PR TITLE
rofl-client-py: Prepare 0.1.4 release

### DIFF
--- a/rofl-client/py/CHANGELOG.md
+++ b/rofl-client/py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 - 2025-09-25
+
+### Fixed
+- set hatch root, to see git tags correctly.
+- remove publish badge from README.md
+
 ## 0.1.3 - 2025-09-24
 
 ### Fixed

--- a/rofl-client/py/README.md
+++ b/rofl-client/py/README.md
@@ -1,6 +1,5 @@
 # oasis-rofl-client
 
-[![Publish to PyPI](https://github.com/oasisprotocol/oasis-rofl-client/actions/workflows/publish.yml/badge.svg)](https://github.com/oasisprotocol/oasis-rofl-client/actions/workflows/publish.yml)
 [![PyPI version](https://badge.fury.io/py/oasis-rofl-client.svg)](https://badge.fury.io/py/oasis-rofl-client)
 
 Python client SDK for Oasis ROFL.

--- a/rofl-client/py/pyproject.toml
+++ b/rofl-client/py/pyproject.toml
@@ -45,6 +45,7 @@ source = "vcs"
 fallback-version = "0.0.0"
 
 [tool.hatch.version.raw-options]
+root = "../.." 
 tag_regex = '^rofl-client/py/v(?P<version>\d+\.\d+\.\d+(?:[\w.-]*)?)$'
 
 [tool.hatch.build.hooks.vcs]


### PR DESCRIPTION
- fix root for hatch, that hatch can see git tags
(was before not seeing tags and falling back to 0.0.0)

(works now correctly on my [fork](https://github.com/rube-de/oasis-sdk/actions/runs/18011169927))