### PR TITLE
Rename EUROe token to EURAU (on Pontus-X)

### DIFF
--- a/client-sdk/go/config/default.go
+++ b/client-sdk/go/config/default.go
@@ -108,7 +108,7 @@ var DefaultNetworks = Networks{
 						ID:          "0000000000000000000000000000000000000000000000004febe52eb412b421",
 						Denominations: map[string]*DenominationInfo{
 							NativeDenominationKey: {
-								Symbol:   "EUROe",
+								Symbol:   "EURAU",
 								Decimals: 18,
 							},
 							// The consensus layer denomination when deposited into the runtime.
@@ -126,7 +126,7 @@ var DefaultNetworks = Networks{
 						ID:          "00000000000000000000000000000000000000000000000004a6f9071c007069",
 						Denominations: map[string]*DenominationInfo{
 							NativeDenominationKey: {
-								Symbol:   "EUROe",
+								Symbol:   "EURAU",
 								Decimals: 18,
 							},
 							// The consensus layer denomination when deposited into the runtime.


### PR DESCRIPTION
Pontus-X is replacing the stablecoin they use, so we also need to rename the native token of those paratimes.