### PR TITLE
docker/rofl-dev: Bump Oasis Core to 25.6.x

### DIFF
--- a/docker/rofl-dev/Dockerfile.full
+++ b/docker/rofl-dev/Dockerfile.full
@@ -1,4 +1,4 @@
-FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.5.x AS oasis-core-dev
+FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.6.x AS oasis-core-dev
 
 ARG OASIS_CLI_VERSION=0.16.0
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Upgrading Oasis Core to `25.6.x` for `rofl-dev` Docker image.