### PR TITLE
CODEOWNERS updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # Default code owners.
-* @kostko @pro-wh @ptrus @peternose
-/docs/ @matevz @kostko @pro-wh @ptrus @peternose
+* @kostko @ptrus @peternose
+/docs/ @matevz @kostko @ptrus @peternose
+/rofl-client/ @matevz @lukaw3d @rube-de @kostko @ptrus @peternose
+/client-sdk/ts-web/ @lukaw3d @kostko @ptrus @peternose


### PR DESCRIPTION
Proposing we add some more codeowners for `rofl-client` packages and typescript code.

Removing @pro-wh due to 😢
> Unknown owner on line 2: make sure @pro-wh exists and has write access to the repository 

