### PR TITLE
rofl-client/py: Fix release when multiple tags on the same commit

### DIFF
--- a/rofl-client/py/pyproject.toml
+++ b/rofl-client/py/pyproject.toml
@@ -45,8 +45,11 @@ source = "vcs"
 fallback-version = "0.0.0"
 
 [tool.hatch.version.raw-options]
-root = "../.." 
+root = "../.."
 tag_regex = '^rofl-client/py/v(?P<version>\d+\.\d+\.\d+(?:[\w.-]*)?)$'
+
+[tool.hatch.version.raw-options.scm.git]
+describe_command = "git describe --dirty --tags --long --match 'rofl-client/py/v*'"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/oasis_rofl_client/_version.py"


### PR DESCRIPTION
It failed to release in https://github.com/oasisprotocol/oasis-sdk/actions/runs/19138314243/job/54696104648 because it picked the `rofl-containers/v0.8.3` tag instead of the `rofl-client/py/v0.1.6`. The commit was tagged with both tags.

```
Building source distribution...
/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmpOFUa79/lib/python3.12/site-packages/setuptools_scm/version.py:108: UserWarning: tag 'rofl-containers/v0.8.3' no version found
  warnings.warn(f"tag {tag!r} no version found")
Traceback (most recent call last):
  File "<string>", line 11, in <module>
  File "/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmpOFUa79/lib/python3.12/site-packages/hatchling/build.py", line 34, in build_sdist
    return os.path.basename(next(builder.build(directory=sdist_directory, versions=['standard'])))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

As a workaround, I tagged a different commit with `rofl-client/py/v0.1.6`. This fix should fix it for future releases.