### PR TITLE
rofl-proxy: Use modified ts for file expiry instead of created

### DIFF
--- a/rofl-proxy/src/http/tls.rs
+++ b/rofl-proxy/src/http/tls.rs
@@ -568,7 +568,7 @@ where
     P: AsRef<Path>,
 {
     let metadata = fs::metadata(&path)?;
-    let age = metadata.created()?.elapsed()?;
+    let age = metadata.modified()?.elapsed()?;
     if age > Duration::from_secs(expiry) {
         return Err(anyhow!("existing file expired"));
     }


### PR DESCRIPTION
Alternative, we could recreate the file on update.