### PR TITLE
examples: Remove nix dependency

### DIFF
--- a/examples/runtime-sdk/rofl-oracle-tdx-raw/Cargo.toml
+++ b/examples/runtime-sdk/rofl-oracle-tdx-raw/Cargo.toml
@@ -12,9 +12,6 @@ module-evm = { path = "../../../runtime-sdk/modules/evm", package = "oasis-runti
 # Third-party dependencies.
 anyhow = "1.0"
 async-trait = "0.1.77"
-nix = { version = "0.29.0", features = [
-    "ioctl",
-] } # Remove once Oasis Core is upgraded beyond v25.7.
 solabi = "0.3.0"
 tokio = { version = "1.38", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
Merge once Oasis Core is upgraded beyond v25.7.