### PR TITLE
docker/rofl-dev: Bump Oasis CLI to 0.17.1

### DIFF
--- a/docker/rofl-dev/Dockerfile.full
+++ b/docker/rofl-dev/Dockerfile.full
@@ -1,6 +1,6 @@
 FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.7.x AS oasis-core-dev
 
-ARG OASIS_CLI_VERSION=0.17.0
+ARG OASIS_CLI_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV RUSTFLAGS="-C target-feature=+aes,+ssse3"

--- a/docker/rofl-dev/Dockerfile.minimal
+++ b/docker/rofl-dev/Dockerfile.minimal
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG OASIS_CLI_VERSION=0.16.0
+ARG OASIS_CLI_VERSION=0.17.1
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends curl ca-certificates squashfs-tools cryptsetup-bin qemu-utils && apt-get clean && \


### PR DESCRIPTION
Need it for: https://github.com/oasisprotocol/oasis-sdk/pull/2402