### PR TITLE
rofl-client-py: Prepare 0.1.7 release

### DIFF
--- a/rofl-client/py/CHANGELOG.md
+++ b/rofl-client/py/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.7 - 2025-12-03
+
+### Added
+- Support for `get_app_id` endpoint
+- Support for `sign_submit` endpoint (requires `web3` dependency)
+
+### Changed
+- Use sphinx pydoc format for documentation consistency
+
+### Fixed
+- Release workflow when multiple tags exist on the same commit
+- `sign_submit` now sends `value` as string (required by rofl-container 0.8.5+)
+
+## 0.1.6 - 2025-11-06
+
+### Fixed
+- Don't try to parse `set_metadata` response
+
+## 0.1.5 - 2025-11-01
+
+### Added
+- Queries support
+- Appd metadata support (`get_metadata`, `set_metadata`)
+
 ## 0.1.4 - 2025-09-25
 
 ### Fixed

--- a/rofl-client/py/README.md
+++ b/rofl-client/py/README.md
@@ -105,6 +105,16 @@ This replaces all existing app-provided metadata. Will trigger a registration re
   - `metadata`: Dictionary of metadata key-value pairs to set
 - **Raises:** `httpx.HTTPStatusError` if the request fails
 
+##### `async query(method: str, args: bytes) -> bytes`
+
+Query the on-chain paratime state.
+
+- **Parameters:**
+  - `method`: The query method name
+  - `args`: CBOR-encoded query arguments
+- **Returns:** CBOR-encoded response data
+- **Raises:** `httpx.HTTPStatusError` if the request fails
+
 ## Examples
 
 For a complete working example, see [`examples/basic_usage.py`](examples/basic_usage.py).

--- a/rofl-client/py/src/oasis_rofl_client/rofl_client.py
+++ b/rofl-client/py/src/oasis_rofl_client/rofl_client.py
@@ -147,7 +147,7 @@ class RoflClient:
                 "kind": "eth",
                 "data": {
                     "gas_limit": tx["gas"],
-                    "value": tx["value"],
+                    "value": str(tx["value"]),
                     "data": tx["data"][2:]
                     if tx["data"].startswith("0x")
                     else tx["data"],

--- a/rofl-client/py/tests/test_client.py
+++ b/rofl-client/py/tests/test_client.py
@@ -289,7 +289,7 @@ class TestRoflClient(unittest.IsolatedAsyncioTestCase):
                     "kind": "eth",
                     "data": {
                         "gas_limit": 21000,
-                        "value": 1000000000,
+                        "value": "1000000000",
                         "data": "dae1ee1f00000000000000000000000000000000000000000000000000002695a9e649b2",
                         "to": "0987654321098765432109876543210987654321",
                     },


### PR DESCRIPTION
Add changelog entries for three releases:
- 0.1.7: app_id endpoint, sign_submit endpoint, sphinx pydoc format, release workflow fix
- 0.1.6: set_metadata response parsing fix
- 0.1.5: queries support, appd metadata endpoints

fixes:
- Add missing query method to README
- send value as string in sign_submit