### PR TITLE
docs: Explicitly use "encrypt" field in appd

### DIFF
--- a/docs/rofl/features/appd.md
+++ b/docs/rofl/features/appd.md
@@ -105,6 +105,7 @@ Subcall.roflEnsureAuthorizedOrigin(roflAppID);
 
 ```json
 {
+  "encrypt" true,
   "tx": {
     "kind": "eth",
     "data": {


### PR DESCRIPTION
This field is currently required by mistake