### PR TITLE
fix(rofl-appd): improve transaction field deserialization flexibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5058,6 +5058,7 @@ name = "rofl-appd"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "hex",
  "oasis-cbor",
  "oasis-runtime-sdk",
  "oasis-runtime-sdk-evm",
@@ -5065,6 +5066,7 @@ dependencies = [
  "rofl-app-core",
  "rustc-hex",
  "serde",
+ "serde_json",
  "serde_with",
  "sp800-185",
  "thiserror 1.0.69",

--- a/docs/rofl/features/appd.md
+++ b/docs/rofl/features/appd.md
@@ -105,7 +105,7 @@ Subcall.roflEnsureAuthorizedOrigin(roflAppID);
 
 ```json
 {
-  "encrypt" true,
+  "encrypt": true,
   "tx": {
     "kind": "eth",
     "data": {
@@ -124,9 +124,20 @@ Subcall.roflEnsureAuthorizedOrigin(roflAppID);
   supported (as defined by the `kind` field):
 
   - Ethereum-compatible calls (`eth`) use standard fields (`gas_limit`, `to`,
-    `value` and `data`) to define the transaction content. `value` must be a
-    decimal string (or `0x` hex string) representing a non-negative integer
-    up to 256 bits.
+    `value` and `data`) to define the transaction content.
+
+    - `gas_limit` may be provided either as a JSON number (e.g. `21000`) or as
+      a decimal string or `0x`-prefixed hex string. All forms are interpreted
+      as a non-negative 64-bit integer and must not contain whitespace.
+    - `value` must represent a non-negative integer up to 256 bits and may be
+      provided as a decimal string, a `0x`-prefixed hex string, or as a JSON
+      number up to `2^64 - 1`. String forms must not contain whitespace.
+    - Hex-encoded fields such as `to` and `data` accept strings with or without
+      a leading `0x` prefix, must not contain whitespace, and must not be
+      prefix-only (`"0x"`). Use an empty string (`""`) to represent empty bytes
+      (e.g. `to: ""` for contract creation, `data: ""` for empty calldata).
+      When `to` is non-empty it must decode to exactly 20 bytes (an Ethereum
+      address).
 
   - Oasis SDK calls (`std`) support CBOR-serialized hex-encoded `Transaction`s
     to be specified.

--- a/rofl-appd/Cargo.toml
+++ b/rofl-appd/Cargo.toml
@@ -18,6 +18,7 @@ rocket = { git = "https://github.com/rwf2/Rocket", rev = "28891e8072136f4641a33f
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.12.0", features = ["hex"] }
+hex = "0.4"
 sp800-185 = "0.2.0"
 thiserror = "1.0"
 tokio = { version = "1.38", features = [
@@ -32,6 +33,7 @@ zeroize = "1.7"
 
 [dev-dependencies]
 rustc-hex = "2.0.1"
+serde_json = "1.0"
 
 [features]
 default = ["tx"]

--- a/rofl-appd/src/routes/tx.rs
+++ b/rofl-appd/src/routes/tx.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use rocket::{http::Status, serde::json::Json, State};
+use serde::Deserialize;
 use serde_with::serde_as;
 
 use oasis_runtime_sdk::types::transaction;
@@ -53,21 +54,63 @@ pub enum Transaction {
     /// Ethereum transaction.
     #[serde(rename = "eth")]
     Eth {
-        gas_limit: u64,
-        #[serde_as(as = "serde_with::hex::Hex")]
+        gas_limit: GasLimitInput,
+        #[serde(deserialize_with = "deserialize_hex_bytes")]
         to: Vec<u8>,
         value: TransactionValue,
-        #[serde_as(as = "serde_with::hex::Hex")]
+        #[serde(deserialize_with = "deserialize_hex_bytes")]
         data: Vec<u8>,
     },
 }
 
+/// Gas limit input that can be provided either as a JSON number or as a string
+/// (decimal or 0x-prefixed hex) and normalized into a `u64`.
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(untagged)]
+pub enum GasLimitInput {
+    Number(u64),
+    String(String),
+}
+
+impl GasLimitInput {
+    fn into_u64(self, field: &'static str) -> Result<u64, String> {
+        match self {
+            GasLimitInput::Number(n) => Ok(n),
+            GasLimitInput::String(s) => Self::parse_string(&s, field),
+        }
+    }
+
+    fn parse_string(value: &str, field: &'static str) -> Result<u64, String> {
+        if value.is_empty() {
+            return Err(format!("{field} string must not be empty"));
+        }
+        if value.chars().any(|c| c.is_whitespace()) {
+            return Err(format!("{field} string must not contain whitespace"));
+        }
+        let (radix, digits) = match value
+            .strip_prefix("0x")
+            .or_else(|| value.strip_prefix("0X"))
+        {
+            Some(rest) => (16, rest),
+            None => (10, value),
+        };
+        if digits.is_empty() {
+            return Err(format!("{field} string must contain digits"));
+        }
+        u64::from_str_radix(digits, radix)
+            .map_err(|_| format!("{field} is not a valid unsigned 64-bit integer"))
+    }
+}
+
 /// Value representation that accepts either a string (decimal or 0x hex) or a JSON number.
+///
+/// Note: For large values, prefer the `String` variant to avoid issues with clients that may
+/// represent JSON numbers as floating point.
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(untagged)]
 pub enum TransactionValue {
     String(String),
-    Number(u128),
+    Number(u64),
 }
 
 impl TransactionValue {
@@ -80,22 +123,50 @@ impl TransactionValue {
 }
 
 fn parse_u256_string(value: String) -> Result<evm::types::U256, String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
+    if value.is_empty() {
         return Err("transaction value string must not be empty".to_string());
     }
-    let (radix, digits) = match trimmed
+    if value.chars().any(|c| c.is_whitespace()) {
+        return Err("transaction value string must not contain whitespace".to_string());
+    }
+    let (radix, digits) = match value
         .strip_prefix("0x")
-        .or_else(|| trimmed.strip_prefix("0X"))
+        .or_else(|| value.strip_prefix("0X"))
     {
         Some(rest) => (16, rest),
-        None => (10, trimmed),
+        None => (10, value.as_str()),
     };
     if digits.is_empty() {
         return Err("transaction value string must contain digits".to_string());
     }
     evm::types::U256::from_str_radix(digits, radix)
         .map_err(|_| "transaction value string is not a valid unsigned integer".to_string())
+}
+
+/// Deserialize a hex string (with optional 0x prefix) into bytes.
+fn deserialize_hex_bytes<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    if s.chars().any(|c| c.is_whitespace()) {
+        return Err(serde::de::Error::custom(
+            "invalid hex string: must not contain whitespace",
+        ));
+    }
+
+    let without_prefix = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(&s);
+    if matches!(s.as_str(), "0x" | "0X") {
+        return Err(serde::de::Error::custom(
+            "invalid hex string: prefix-only `0x` is not allowed (use empty string for empty bytes)",
+        ));
+    }
+
+    hex::decode(without_prefix)
+        .map_err(|e| serde::de::Error::custom(format!("invalid hex string: {e}")))
 }
 
 /// Transaction signing and submission request.
@@ -151,6 +222,9 @@ pub async fn sign_and_submit(
             value,
             data,
         } => {
+            let gas_limit = gas_limit
+                .into_u64("gas_limit")
+                .map_err(|err| (Status::BadRequest, err))?;
             let value = value.into_u256().map_err(|err| (Status::BadRequest, err))?;
             let (method, body) = if to.is_empty() {
                 // Create.
@@ -241,13 +315,14 @@ mod tests {
         let hex_lower = parse_u256_string("0x2a".to_string()).unwrap();
         assert_eq!(hex_lower, evm::types::U256::from(42u32));
 
-        let hex_upper = parse_u256_string("  0X2A  ".to_string()).unwrap();
+        let hex_upper = parse_u256_string("0X2A".to_string()).unwrap();
         assert_eq!(hex_upper, evm::types::U256::from(42u32));
     }
 
     #[test]
     fn parse_u256_string_rejects_invalid_inputs() {
         assert!(parse_u256_string("".to_string()).is_err());
+        assert!(parse_u256_string(" 0x2a ".to_string()).is_err());
         assert!(parse_u256_string("0x".to_string()).is_err());
         assert!(parse_u256_string("-1".to_string()).is_err());
         assert!(parse_u256_string("0xZZ".to_string()).is_err());
@@ -255,10 +330,10 @@ mod tests {
 
     #[test]
     fn transaction_value_into_u256_handles_number_variant() {
-        let value = TransactionValue::Number(10u128.pow(18));
+        let value = TransactionValue::Number(10u64.pow(18));
         assert_eq!(
             value.into_u256().unwrap(),
-            evm::types::U256::from(10u128.pow(18))
+            evm::types::U256::from(10u64.pow(18))
         );
     }
 
@@ -266,5 +341,254 @@ mod tests {
     fn transaction_value_into_u256_handles_string_variant() {
         let value = TransactionValue::String("1000".to_string());
         assert_eq!(value.into_u256().unwrap(), evm::types::U256::from(1000u32));
+    }
+
+    #[test]
+    fn transaction_value_json_deserializes_number() {
+        // Test JSON number deserialization.
+        let json = r#"0"#;
+        let value: TransactionValue = serde_json::from_str(json).unwrap();
+        assert_eq!(value.into_u256().unwrap(), evm::types::U256::from(0u32));
+
+        let json = r#"1000000000000000000"#;
+        let value: TransactionValue = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            value.into_u256().unwrap(),
+            evm::types::U256::from(10u64.pow(18))
+        );
+    }
+
+    #[test]
+    fn transaction_value_json_deserializes_string() {
+        // Test JSON string deserialization (decimal).
+        let json = r#""1000""#;
+        let value: TransactionValue = serde_json::from_str(json).unwrap();
+        assert_eq!(value.into_u256().unwrap(), evm::types::U256::from(1000u32));
+
+        // Test JSON string deserialization (hex).
+        let json = r#""0x3e8""#;
+        let value: TransactionValue = serde_json::from_str(json).unwrap();
+        assert_eq!(value.into_u256().unwrap(), evm::types::U256::from(1000u32));
+
+        // Test large values via string (exceeds u64::MAX).
+        let json = r#""340282366920938463463374607431768211455""#; // u128::MAX
+        let value: TransactionValue = serde_json::from_str(json).unwrap();
+        assert!(value.into_u256().is_ok());
+
+        // Test 20B ROSE in wei (requires 95 bits): 20_000_000_000 * 10^18.
+        let json = r#""20000000000000000000000000000""#;
+        let value: TransactionValue = serde_json::from_str(json).unwrap();
+        assert!(value.into_u256().is_ok());
+    }
+
+    #[test]
+    fn gas_limit_input_parsing_supports_decimal_and_hex() {
+        let decimal = GasLimitInput::String("21000".to_string())
+            .into_u64("gas_limit")
+            .unwrap();
+        assert_eq!(decimal, 21000u64);
+
+        let hex_lower = GasLimitInput::String("0x2290b0".to_string())
+            .into_u64("gas_limit")
+            .unwrap();
+        assert_eq!(hex_lower, 0x2290b0u64);
+
+        let hex_upper = GasLimitInput::String("0X2290B0".to_string())
+            .into_u64("gas_limit")
+            .unwrap();
+        assert_eq!(hex_upper, 0x2290b0u64);
+    }
+
+    #[test]
+    fn gas_limit_input_parsing_rejects_invalid_inputs() {
+        assert!(GasLimitInput::String("".to_string())
+            .into_u64("gas_limit")
+            .is_err());
+        assert!(GasLimitInput::String(" 0x2290b0 ".to_string())
+            .into_u64("gas_limit")
+            .is_err());
+        assert!(GasLimitInput::String("0x".to_string())
+            .into_u64("gas_limit")
+            .is_err());
+        assert!(GasLimitInput::String("-1".to_string())
+            .into_u64("gas_limit")
+            .is_err());
+        assert!(GasLimitInput::String("0xZZ".to_string())
+            .into_u64("gas_limit")
+            .is_err());
+    }
+
+    #[test]
+    fn eth_transaction_json_rejects_whitespace_in_hex_fields() {
+        let json = r#"{
+            "kind": "eth",
+            "data": {
+                "gas_limit": 21000,
+                "to": "0x0102 03",
+                "value": 0,
+                "data": "deadbeef"
+            }
+        }"#;
+        assert!(serde_json::from_str::<Transaction>(json).is_err());
+    }
+
+    #[test]
+    fn eth_transaction_json_rejects_prefix_only_hex_fields() {
+        let json = r#"{
+            "kind": "eth",
+            "data": {
+                "gas_limit": 21000,
+                "to": "0x0102030405060708091011121314151617181920",
+                "value": 0,
+                "data": "0x"
+            }
+        }"#;
+        assert!(serde_json::from_str::<Transaction>(json).is_err());
+    }
+
+    #[test]
+    fn eth_transaction_json_allows_contract_creation() {
+        let json = r#"{
+            "kind": "eth",
+            "data": {
+                "gas_limit": 21000,
+                "to": "",
+                "value": 0,
+                "data": "deadbeef"
+            }
+        }"#;
+        let tx: Transaction = serde_json::from_str(json).unwrap();
+        match tx {
+            Transaction::Eth { to, data, .. } => {
+                assert!(to.is_empty());
+                assert_eq!(data, hex::decode("deadbeef").unwrap());
+            }
+            _ => panic!("Expected Eth transaction"),
+        }
+    }
+
+    #[test]
+    fn eth_transaction_json_deserializes_with_value_variants() {
+        // Test full Transaction deserialization with numeric value.
+        let json = r#"{
+            "kind": "eth",
+            "data": {
+                "gas_limit": "0x5208",
+                "to": "0x0102030405060708091011121314151617181920",
+                "value": 0,
+                "data": ""
+            }
+        }"#;
+        let tx: Transaction = serde_json::from_str(json).unwrap();
+        match tx {
+            Transaction::Eth { value, .. } => {
+                assert_eq!(value.into_u256().unwrap(), evm::types::U256::from(0u32));
+            }
+            _ => panic!("Expected Eth transaction"),
+        }
+
+        // Test full Transaction deserialization with string value.
+        let json = r#"{
+            "kind": "eth",
+            "data": {
+                "gas_limit": 21000,
+                "to": "0102030405060708091011121314151617181920",
+                "value": "1000000000000000000",
+                "data": ""
+            }
+        }"#;
+        let tx: Transaction = serde_json::from_str(json).unwrap();
+        match tx {
+            Transaction::Eth { value, .. } => {
+                assert_eq!(
+                    value.into_u256().unwrap(),
+                    evm::types::U256::from(10u64.pow(18))
+                );
+            }
+            _ => panic!("Expected Eth transaction"),
+        }
+    }
+
+    #[test]
+    fn sign_and_submit_request_json_deserializes_with_encrypt_default() {
+        // Test that `encrypt` defaults to true when omitted.
+        let json = r#"{
+            "tx": {
+                "kind": "eth",
+                "data": {
+                    "gas_limit": "21000",
+                    "to": "0x0102030405060708091011121314151617181920",
+                    "value": "0",
+                    "data": ""
+                }
+            }
+        }"#;
+        let req: SignAndSubmitRequest = serde_json::from_str(json).unwrap();
+        assert!(req.encrypt, "encrypt should default to true");
+
+        // Test explicit encrypt: false.
+        let json = r#"{
+            "tx": {
+                "kind": "eth",
+                "data": {
+                    "gas_limit": 21000,
+                    "to": "0102030405060708091011121314151617181920",
+                    "value": "0",
+                    "data": ""
+                }
+            },
+            "encrypt": false
+        }"#;
+        let req: SignAndSubmitRequest = serde_json::from_str(json).unwrap();
+        assert!(!req.encrypt);
+    }
+
+    #[test]
+    fn sign_and_submit_request_json_deserializes_with_numeric_value() {
+        // Test: Ensure SignAndSubmitRequest deserializes when value is a JSON number
+        // (not just a string).
+        let json = r#"{
+            "tx": {
+                "kind": "eth",
+                "data": {
+                    "gas_limit": 21000,
+                    "to": "0x0102030405060708091011121314151617181920",
+                    "value": 0,
+                    "data": ""
+                }
+            }
+        }"#;
+        let req: SignAndSubmitRequest = serde_json::from_str(json).unwrap();
+        match req.tx {
+            Transaction::Eth { value, .. } => {
+                assert_eq!(value.into_u256().unwrap(), evm::types::U256::from(0u32));
+            }
+            _ => panic!("Expected Eth transaction"),
+        }
+
+        // Also test with a realistic wei amount as JSON number (1 ETH = 10^18 wei).
+        let json = r#"{
+            "tx": {
+                "kind": "eth",
+                "data": {
+                    "gas_limit": "0x30d40",
+                    "to": "0102030405060708091011121314151617181920",
+                    "value": 1000000000000000000,
+                    "data": "deadbeef"
+                }
+            },
+            "encrypt": true
+        }"#;
+        let req: SignAndSubmitRequest = serde_json::from_str(json).unwrap();
+        assert!(req.encrypt);
+        match req.tx {
+            Transaction::Eth { value, .. } => {
+                assert_eq!(
+                    value.into_u256().unwrap(),
+                    evm::types::U256::from(10u64.pow(18))
+                );
+            }
+            _ => panic!("Expected Eth transaction"),
+        }
     }
 }


### PR DESCRIPTION
Fix transaction deserialization issues causing 422 errors in ROFL appd
- Fix value field: Change `u128` to `u64` in `TransactionValue` enum (serde_json doesn't support `u128` in untagged enums). Large values must use string format.
- Fix hex field flexibility: to, data, and gas_limit now accept values with or without 0x prefix, and gas_limit accepts both numbers and strings.