### PR TITLE
docs(): add reference to GitHub action

### DIFF
--- a/docs/rofl/workflow/prerequisites.mdx
+++ b/docs/rofl/workflow/prerequisites.mdx
@@ -101,3 +101,8 @@ accounts.
    corresponding libraries.
 
 [Oasis Core prerequisites]: https://github.com/oasisprotocol/oasis-core/blob/master/docs/development-setup/prerequisites.md
+
+### Other: GitHub Action Install
+
+The Oasis CLI can also be installed in CI/CD workflows using the Oasis provided
+[GitHub Action](https://github.com/oasisprotocol/setup-cli-action).


### PR DESCRIPTION
Documenting GitHub Action, not sure how to reference it inside the [ROFL Build](https://docs.oasis.io/build/rofl/workflow/build) section, since it doesnt even talk about installing the CLI, so I just mentioned it in the prerequisits. @matevz 

Resolves https://github.com/oasisprotocol/docs/issues/1638