### PR TITLE
ci: Use Buildkite REST API for artifacts

### DIFF
--- a/.github/workflows/benchmarking-image.yml
+++ b/.github/workflows/benchmarking-image.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Build benchmarks
         working-directory: tests/benchmark
         run: ./build-benchmarks.sh
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
       # Build and push benchmarks docker image.
       - name: Set up Docker Buildx

--- a/.github/workflows/ci-longtest.yaml
+++ b/.github/workflows/ci-longtest.yaml
@@ -34,6 +34,7 @@ jobs:
         run: ./download-artifacts.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
       - name: Run long end-to-end tests
         run: |
@@ -41,3 +42,5 @@ jobs:
             --e2e/test-runtime-simple-keyvalue.txgen.coins_per_acct=100000 \
             --e2e/test-runtime-simple-keyvalue.txgen.num_accounts=100 \
             --e2e/test-runtime-simple-keyvalue.txgen.duration=15m
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -276,6 +276,7 @@ jobs:
         run: ./download-artifacts.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
       - name: "testnet: Start"
         working-directory: client-sdk/ts-web/core/playground
@@ -398,6 +399,7 @@ jobs:
         run: ./download-artifacts.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
       - name: "testnet: Build runtime"
         working-directory: client-sdk/ts-web/rt/playground
@@ -467,9 +469,12 @@ jobs:
         run: ./download-artifacts.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
       - name: Run end-to-end tests
         run: ./tests/run-e2e.sh
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
       - name: Upload logs
         if: failure()
@@ -618,6 +623,8 @@ jobs:
       - name: Run end-to-end benchmarks
         working-directory: tests/benchmark
         run: ./run-benchmarks.sh
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
 
   test-python-rofl-client:
     name: test-python-rofl-client

--- a/tests/download-artifacts.sh
+++ b/tests/download-artifacts.sh
@@ -51,11 +51,19 @@ if [ -n "$BUILD_NUMBER" ]; then
 
     type jq >/dev/null
 
+    if [ -z "${BUILDKITE_API_TOKEN-}" ]; then
+        echo "Need Buildkite artifacts, but BUILDKITE_API_TOKEN environment variable is not set."
+        exit 1
+    fi
+
+    BUILDKITE_API_BASE="https://api.buildkite.com/v2/organizations/$ORGANIZATION/pipelines/$PIPELINE/builds/$BUILD_NUMBER"
+    BK_AUTH=(-H "Authorization: Bearer $BUILDKITE_API_TOKEN")
+
     if [ ! -e "$TESTS_DIR/untracked/buildkite-$BUILD_NUMBER/$BUILD_NUMBER.json" ]; then
         mkdir -p "$TESTS_DIR/untracked/buildkite-$BUILD_NUMBER"
         (
             cd "$TESTS_DIR/untracked/buildkite-$BUILD_NUMBER"
-            curl -sfO "https://buildkite.com/$ORGANIZATION/$PIPELINE/builds/$BUILD_NUMBER.json"
+            curl -sf "${BK_AUTH[@]}" "$BUILDKITE_API_BASE" -o "$BUILD_NUMBER.json"
         )
     fi
 
@@ -64,22 +72,22 @@ if [ -n "$BUILD_NUMBER" ]; then
         (
             cd "$TESTS_DIR/untracked/buildkite-$BUILD_NUMBER"
             NODE_JOB_ID=$(jq <"$BUILD_NUMBER.json" -r '.jobs[] | select(.name == "Build Go") | .id')
-            NODE_ARTIFACTS_JSON=$(curl -sf "https://buildkite.com/organizations/$ORGANIZATION/pipelines/$PIPELINE/builds/$BUILD_NUMBER/jobs/$NODE_JOB_ID/artifacts")
-            OASIS_NODE_URL=$(printf '%s' "$NODE_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "oasis-node") | .url')
-            OASIS_NET_RUNNER_URL=$(printf '%s' "$NODE_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "oasis-net-runner") | .url')
+            NODE_ARTIFACTS_JSON=$(curl -sf "${BK_AUTH[@]}" "$BUILDKITE_API_BASE/jobs/$NODE_JOB_ID/artifacts")
+            OASIS_NODE_URL=$(printf '%s' "$NODE_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "oasis-node") | .download_url')
+            OASIS_NET_RUNNER_URL=$(printf '%s' "$NODE_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "oasis-net-runner") | .download_url')
 
             RUNTIME_LOADER_JOB_ID=$(jq <"$BUILD_NUMBER.json" -r '.jobs[] | select(.name == "Build Rust runtime loader") | .id')
-            RUNTIME_LOADER_ARTIFACTS_JSON=$(curl -sf "https://buildkite.com/organizations/$ORGANIZATION/pipelines/$PIPELINE/builds/$BUILD_NUMBER/jobs/$RUNTIME_LOADER_JOB_ID/artifacts")
-            OASIS_CORE_RUNTIME_LOADER_URL=$(printf '%s' "$RUNTIME_LOADER_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "oasis-core-runtime-loader") | .url')
+            RUNTIME_LOADER_ARTIFACTS_JSON=$(curl -sf "${BK_AUTH[@]}" "$BUILDKITE_API_BASE/jobs/$RUNTIME_LOADER_JOB_ID/artifacts")
+            OASIS_CORE_RUNTIME_LOADER_URL=$(printf '%s' "$RUNTIME_LOADER_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "oasis-core-runtime-loader") | .download_url')
 
             echo "### Downloading oasis-node from Buildkite build $BUILD_NUMBER..."
-            curl -fLo oasis-node "https://buildkite.com$OASIS_NODE_URL"
+            curl -fLo oasis-node "${BK_AUTH[@]}" "$OASIS_NODE_URL"
             chmod +x oasis-node
             echo "### Downloading oasis-net-runner from Buildkite build $BUILD_NUMBER..."
-            curl -fLo oasis-net-runner "https://buildkite.com$OASIS_NET_RUNNER_URL"
+            curl -fLo oasis-net-runner "${BK_AUTH[@]}" "$OASIS_NET_RUNNER_URL"
             chmod +x oasis-net-runner
             echo "### Downloading oasis-runtime-loader from Buildkite build $BUILD_NUMBER..."
-            curl -fLo oasis-runtime-loader "https://buildkite.com$OASIS_CORE_RUNTIME_LOADER_URL"
+            curl -fLo oasis-runtime-loader "${BK_AUTH[@]}" "$OASIS_CORE_RUNTIME_LOADER_URL"
             chmod +x oasis-runtime-loader
         )
 
@@ -90,14 +98,14 @@ if [ -n "$BUILD_NUMBER" ]; then
         (
             cd "$TESTS_DIR/untracked/buildkite-$BUILD_NUMBER"
             KEY_MANAGER_RUNTIME_JOB_ID=$(jq <"$BUILD_NUMBER.json" -r '.jobs[] | select(.name == "Build runtimes") | .id')
-            KEY_MANAGER_RUNTIME_ARTIFACTS_JSON=$(curl -sf "https://buildkite.com/organizations/$ORGANIZATION/pipelines/$PIPELINE/builds/$BUILD_NUMBER/jobs/$KEY_MANAGER_RUNTIME_JOB_ID/artifacts")
-            SIMPLE_KEYMANAGER_URL=$(printf '%s' "$KEY_MANAGER_RUNTIME_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "simple-keymanager.mocksgx") | .url')
-            SIMPLE_KEYMANAGER_SGXS_URL=$(printf '%s' "$KEY_MANAGER_RUNTIME_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "simple-keymanager.sgxs") | .url')
+            KEY_MANAGER_RUNTIME_ARTIFACTS_JSON=$(curl -sf "${BK_AUTH[@]}" "$BUILDKITE_API_BASE/jobs/$KEY_MANAGER_RUNTIME_JOB_ID/artifacts")
+            SIMPLE_KEYMANAGER_URL=$(printf '%s' "$KEY_MANAGER_RUNTIME_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "simple-keymanager.mocksgx") | .download_url')
+            SIMPLE_KEYMANAGER_SGXS_URL=$(printf '%s' "$KEY_MANAGER_RUNTIME_ARTIFACTS_JSON" | jq -r '.[] | select(.path == "simple-keymanager.sgxs") | .download_url')
 
             echo "### Downloading simple-keymanager from Buildkite build $BUILD_NUMBER..."
-            curl -fLo simple-keymanager "https://buildkite.com$SIMPLE_KEYMANAGER_URL"
+            curl -fLo simple-keymanager "${BK_AUTH[@]}" "$SIMPLE_KEYMANAGER_URL"
             chmod +x simple-keymanager
-            curl -fLo simple-keymanager.sgxs "https://buildkite.com$SIMPLE_KEYMANAGER_SGXS_URL"
+            curl -fLo simple-keymanager.sgxs "${BK_AUTH[@]}" "$SIMPLE_KEYMANAGER_SGXS_URL"
         )
     fi
 fi


### PR DESCRIPTION
fixes https://github.com/oasisprotocol/oasis-sdk/issues/2440

Requires adding a `BUILDKITE_API_TOKEN` repository secret with `read_builds` and `read_artifacts` scopes.