### PR TITLE
examples/contract-sdk: Bump oasis-contract-sdk to 0.4.2

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
 	"RUSTSEC-2023-0071", # Does not affect our current use of the library.
+	"RUSTSEC-2026-0049", # Vulnerable crate is only used in rofl-oracle-sgx example.
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5381,7 +5381,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -5468,7 +5468,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5494,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",

--- a/examples/contract-sdk/c10l-hello-world/Cargo.toml
+++ b/examples/contract-sdk/c10l-hello-world/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cbor = { version = "0.5.1", package = "oasis-cbor" }
-oasis-contract-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.1" }
-oasis-contract-sdk-storage = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.1" }
+oasis-contract-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.2" }
+oasis-contract-sdk-storage = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.2" }
 
 # Third party.
 thiserror = "1.0.30"

--- a/examples/contract-sdk/hello-world/Cargo.toml
+++ b/examples/contract-sdk/hello-world/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cbor = { version = "0.5.1", package = "oasis-cbor" }
-oasis-contract-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.1" }
-oasis-contract-sdk-storage = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.1" }
+oasis-contract-sdk = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.2" }
+oasis-contract-sdk-storage = { git = "https://github.com/oasisprotocol/oasis-sdk", tag = "contract-sdk/v0.4.2" }
 
 # Third party.
 thiserror = "1.0.30"


### PR DESCRIPTION
```
Crate:     aws-lc-sys
Version:   0.38.0
Title:     CRL Distribution Point Scope Check Logic Error in AWS-LC
Date:      2026-03-19
ID:        RUSTSEC-2026-0048
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0048
Severity:  7.4 (high)
Solution:  Upgrade to >=0.39.0
```

```
Crate:     rustls-webpki
Version:   0.102.8
Title:     CRLs not considered authoritative by Distribution Point due to faulty matching logic
Date:      2026-03-20
ID:        RUSTSEC-2026-0049
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
Solution:  Upgrade to >=0.103.10
Dependency tree:
rustls-webpki 0.102.8
└── rustls-mbedcrypto-provider 0.1.1
    └── rofl-utils 0.1.1
```