### PR TITLE
docs/rofl: Fix testnet typo in quickstart.mdx

### DIFF
--- a/docs/rofl/quickstart.mdx
+++ b/docs/rofl/quickstart.mdx
@@ -119,7 +119,7 @@ artifacts:
 ## Create
 
 Create a new app on-chain with [`oasis rofl create`]. By default, the app will
-be registered on Sapphire Mainnet. Pass `--network tesnet` parameter to use
+be registered on Sapphire Mainnet. Pass `--network testnet` parameter to use
 Testnet:
 
 ```shell


### PR DESCRIPTION
Fixing a typo.