### PR TITLE
runtime-sdk/modules/evm/src/precompile/confidential: Validate nonce

### DIFF
--- a/runtime-sdk/modules/evm/fuzz/precompile_corpus.rs
+++ b/runtime-sdk/modules/evm/fuzz/precompile_corpus.rs
@@ -16,7 +16,7 @@ fn gen_test_vectors(fixture: &str) -> Box<dyn Iterator<Item = Vec<u8>>> {
 
 fn gen_x25519() -> Box<dyn Iterator<Item = Vec<u8>>> {
     let key = b"this must be the excelentest key";
-    let nonce = b"complete noncence, and too long.";
+    let nonce = b"short nonce\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
     let plaintext = b"0123456789";
     let ad = b"additional data";
 

--- a/runtime-sdk/modules/evm/src/precompile/confidential.rs
+++ b/runtime-sdk/modules/evm/src/precompile/confidential.rs
@@ -185,6 +185,12 @@ fn decode_deoxysii_call_args(
     let text = text.to_vec();
     let ad = ad.to_vec();
 
+    if nonce_bytes[NONCE_SIZE..].iter().any(|&x| x != 0) {
+        return Err(PrecompileFailure::Error {
+            exit_status: ExitError::Other("invalid nonce size".into()),
+        });
+    }
+
     let mut nonce = [0u8; NONCE_SIZE];
     nonce.copy_from_slice(&nonce_bytes[..NONCE_SIZE]);
     let mut key = [0u8; KEY_SIZE];
@@ -499,7 +505,7 @@ mod test {
     #[test]
     fn test_deoxysii() {
         let key = b"this must be the excelentest key";
-        let nonce = b"complete noncence, and too long.";
+        let nonce = b"short nonce\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
         let plaintext = b"0123456789";
         let ad = b"additional data";
         let ret_ct = call_contract(
@@ -536,6 +542,28 @@ mod test {
     }
 
     #[test]
+    fn test_deoxysii_invalid_nonce() {
+        let key = b"this must be the excelentest key";
+        let nonce = b"invalid nonce, which is too long";
+        let plaintext = b"0123456789";
+        let ad = b"additional data";
+        let _ = call_contract(
+            H160([
+                0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x03,
+            ]),
+            &solabi::encode(&(
+                solabi::Bytes::<[u8; 32]>(*key),
+                solabi::Bytes::<[u8; 32]>(*nonce),
+                solabi::Bytes(plaintext.to_vec()),
+                solabi::Bytes(ad.to_vec()),
+            )),
+            10_000_000,
+        )
+        .expect("call should return something")
+        .expect_err("call should fail");
+    }
+
+    #[test]
     fn test_random_bytes() {
         let ret = call_contract(
             H160([
@@ -551,7 +579,7 @@ mod test {
     #[bench]
     fn bench_deoxysii_short(b: &mut Bencher) {
         let key = b"this must be the excelentest key";
-        let nonce = b"complete noncence, and too long.";
+        let nonce = b"short nonce\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
         let plaintext = b"01234567890123456789";
         let ad = b"additional data";
         b.iter(|| {
@@ -575,7 +603,7 @@ mod test {
     #[bench]
     fn bench_deoxysii_long(b: &mut Bencher) {
         let key = b"this must be the excelentest key";
-        let nonce = b"complete noncence, and too long.";
+        let nonce = b"short nonce\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
         let plaintext = b"0123456789".repeat(200);
         let ad = b"additional data";
         b.iter(|| {

--- a/runtime-sdk/modules/evm/src/precompile/confidential.rs
+++ b/runtime-sdk/modules/evm/src/precompile/confidential.rs
@@ -507,8 +507,8 @@ mod test {
                 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x03,
             ]),
             &solabi::encode(&(
-                solabi::Bytes(key.to_vec()),
-                solabi::Bytes(nonce.to_vec()),
+                solabi::Bytes::<[u8; 32]>(*key),
+                solabi::Bytes::<[u8; 32]>(*nonce),
                 solabi::Bytes(plaintext.to_vec()),
                 solabi::Bytes(ad.to_vec()),
             )),
@@ -523,8 +523,8 @@ mod test {
                 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x04,
             ]),
             &solabi::encode(&(
-                solabi::Bytes(key.to_vec()),
-                solabi::Bytes(nonce.to_vec()),
+                solabi::Bytes::<[u8; 32]>(*key),
+                solabi::Bytes::<[u8; 32]>(*nonce),
                 solabi::Bytes(ret_ct.output.to_vec()),
                 solabi::Bytes(ad.to_vec()),
             )),
@@ -560,8 +560,8 @@ mod test {
                     0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x03,
                 ]),
                 &solabi::encode(&(
-                    solabi::Bytes(key.to_vec()),
-                    solabi::Bytes(nonce.to_vec()),
+                    solabi::Bytes::<[u8; 32]>(*key),
+                    solabi::Bytes::<[u8; 32]>(*nonce),
                     solabi::Bytes(plaintext.to_vec()),
                     solabi::Bytes(ad.to_vec()),
                 )),
@@ -584,8 +584,8 @@ mod test {
                     0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x03,
                 ]),
                 &solabi::encode(&(
-                    solabi::Bytes(key.to_vec()),
-                    solabi::Bytes(nonce.to_vec()),
+                    solabi::Bytes::<[u8; 32]>(*key),
+                    solabi::Bytes::<[u8; 32]>(*nonce),
                     solabi::Bytes(plaintext.to_vec()),
                     solabi::Bytes(ad.to_vec()),
                 )),


### PR DESCRIPTION
Encoding key and nonce as vectors and decoding them as arrays doesn't work as expected.