### PR TITLE
docker/rofl-dev: Bump Oasis Core to 26.0.x and CLI to 0.18.6

### DIFF
--- a/docker/rofl-dev/Dockerfile.full
+++ b/docker/rofl-dev/Dockerfile.full
@@ -1,6 +1,6 @@
-FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.9.x AS oasis-core-dev
+FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-26.0.x AS oasis-core-dev
 
-ARG OASIS_CLI_VERSION=0.17.1
+ARG OASIS_CLI_VERSION=0.18.6
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV RUSTFLAGS="-C target-feature=+aes,+ssse3"

--- a/docker/rofl-dev/Dockerfile.minimal
+++ b/docker/rofl-dev/Dockerfile.minimal
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG OASIS_CLI_VERSION=0.17.1
+ARG OASIS_CLI_VERSION=0.18.6
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends curl ca-certificates squashfs-tools cryptsetup-bin qemu-utils && apt-get clean && \


### PR DESCRIPTION
Upgrading Oasis Core to `26.0.x` and Oasis CLI to `0.18.6` for the `rofl-dev` Docker image.