### PR TITLE
rofl-scheduler: Per-offer allowed_creators and allowed_artifacts

### DIFF
--- a/rofl-scheduler/src/config.rs
+++ b/rofl-scheduler/src/config.rs
@@ -20,8 +20,21 @@ use oasis_runtime_sdk_rofl_market as market;
 const ROFL_SCHEDULER_CONFIG_KEY: &str = "rofl_scheduler";
 
 /// Raw per-offer configuration as serialized.
-#[derive(Clone, Debug, Default, cbor::Decode)]
+///
+/// Each element of the `offers` sequence is either a plain string (old format, no overrides) or
+/// a map with an `id` field and optional per-offer config overrides:
+///
+/// ```yaml
+/// offers:
+///   - public               # plain string — global defaults apply
+///   - id: internal         # map entry — per-offer overrides
+///     allowed_creators:
+///       - "oasis1..."
+/// ```
+#[derive(Clone, Debug, Default)]
 pub struct RawOfferConfig {
+    /// Offer identifier (value of the `net.oasis.scheduler.offer` metadata key).
+    pub id: String,
     /// Allowed instance creator addresses for this offer.
     ///
     /// When set, overrides the global `allowed_creators`. An empty list means all creators are
@@ -34,60 +47,52 @@ pub struct RawOfferConfig {
     pub allowed_artifacts: Option<BTreeMap<String, Vec<String>>>,
 }
 
-/// A map entry with an explicit `id` field and optional per-offer config overrides.
-#[derive(Clone, Debug, Default, cbor::Decode)]
-struct RawOfferEntry {
-    pub id: String,
-    pub allowed_creators: Option<Vec<String>>,
-    pub allowed_artifacts: Option<BTreeMap<String, Vec<String>>>,
-}
-
-/// Backwards-compatible wrapper for the `offers` field in [`RawLocalConfig`].
-///
-/// Each element of the sequence is either a plain string (old format, no overrides) or a
-/// map with an `id` field and optional per-offer config overrides:
-///
-/// ```yaml
-/// offers:
-///   - playground_short             # plain string — global defaults apply
-///   - id: oasis_internal           # map entry — per-offer overrides
-///     allowed_creators:
-///       - "oasis1..."
-/// ```
-#[derive(Clone, Debug, Default)]
-pub(crate) struct RawOffersField(BTreeMap<String, RawOfferConfig>);
-
-impl cbor::Decode for RawOffersField {
+impl cbor::Decode for RawOfferConfig {
     fn try_default() -> Result<Self, cbor::DecodeError> {
-        Ok(Self(BTreeMap::new()))
+        Ok(Self::default())
     }
 
     fn try_from_cbor_value(value: cbor::Value) -> Result<Self, cbor::DecodeError> {
-        let cbor::Value::Array(items) = value else {
-            return Err(cbor::DecodeError::UnexpectedType);
-        };
-        let mut map = BTreeMap::new();
-        for item in items {
-            match item {
-                // Plain string: "offer-name" → empty config (global defaults apply).
-                cbor::Value::TextString(key) => {
-                    map.insert(key, RawOfferConfig::default());
+        match value {
+            // Plain string: the offer name with no overrides (global defaults apply).
+            cbor::Value::TextString(id) => Ok(Self {
+                id,
+                allowed_creators: None,
+                allowed_artifacts: None,
+            }),
+            // Map with an `id` field and optional overrides.
+            cbor::Value::Map(entries) => {
+                let mut id = None;
+                let mut allowed_creators = None;
+                let mut allowed_artifacts = None;
+                for (k, v) in entries {
+                    let cbor::Value::TextString(key) = k else {
+                        return Err(cbor::DecodeError::UnexpectedType);
+                    };
+                    match key.as_str() {
+                        "id" => {
+                            id = Some(<String as cbor::Decode>::try_from_cbor_value(v)?);
+                        }
+                        "allowed_creators" => {
+                            allowed_creators =
+                                Some(<Vec<String> as cbor::Decode>::try_from_cbor_value(v)?);
+                        }
+                        "allowed_artifacts" => {
+                            allowed_artifacts = Some(
+                                <BTreeMap<String, Vec<String>> as cbor::Decode>::try_from_cbor_value(v)?,
+                            );
+                        }
+                        _ => {}
+                    }
                 }
-                // Map with an `id` field and optional overrides.
-                cbor::Value::Map(_) => {
-                    let entry = RawOfferEntry::try_from_cbor_value(item)?;
-                    map.insert(
-                        entry.id,
-                        RawOfferConfig {
-                            allowed_creators: entry.allowed_creators,
-                            allowed_artifacts: entry.allowed_artifacts,
-                        },
-                    );
-                }
-                _ => return Err(cbor::DecodeError::UnexpectedType),
+                Ok(Self {
+                    id: id.ok_or(cbor::DecodeError::MissingField)?,
+                    allowed_creators,
+                    allowed_artifacts,
+                })
             }
+            _ => Err(cbor::DecodeError::UnexpectedType),
         }
-        Ok(Self(map))
     }
 }
 
@@ -98,11 +103,9 @@ pub struct RawLocalConfig {
     pub provider_address: String,
     /// Offers that the scheduler should accept. If no offers are configured, all are accepted.
     ///
-    /// Each key is the value of the `net.oasis.scheduler.offer` metadata key. The value is an
-    /// optional per-offer configuration that overrides the global defaults.
-    ///
-    /// Accepts the legacy plain-string array form (backwards compatible) or the new map-entry form.
-    pub(crate) offers: RawOffersField,
+    /// Each entry is either a plain string (legacy form, no overrides) or a map with an `id`
+    /// field and optional per-offer config overrides.
+    pub offers: Vec<RawOfferConfig>,
     /// Allowed artifact hashes.
     ///
     /// Key is the artifact kind and value is a list of artifact SHA256 hashes. If a key doesn't
@@ -291,9 +294,9 @@ impl LocalConfig {
 
         let offers = cfg
             .offers
-            .0
             .into_iter()
-            .map(|(key, raw_cfg)| -> Result<(String, OfferConfig)> {
+            .map(|raw_cfg| -> Result<(String, OfferConfig)> {
+                let key = raw_cfg.id;
                 let offer_creators = raw_cfg
                     .allowed_creators
                     .map(|creators| {
@@ -376,7 +379,7 @@ impl LocalConfig {
             .unwrap_or(&self.allowed_artifacts);
 
         match artifacts.get(kind) {
-            None => Ok(()), // all artifacts of this kind are allowed
+            None => Ok(()), // All artifacts of this kind are allowed.
             Some(allowed_hashes) => {
                 if !allowed_hashes.contains(hash) {
                     Err(anyhow!("{kind} artifact not allowed"))
@@ -408,38 +411,37 @@ impl LocalConfig {
 
 #[cfg(test)]
 mod test {
+    use oasis_runtime_sdk::testing;
+
     use super::*;
 
-    fn make_raw(offers_cbor: cbor::Value) -> RawLocalConfig {
-        let mut raw = RawLocalConfig::default();
-        raw.offers = cbor::Decode::try_from_cbor_value(offers_cbor).unwrap();
-        raw
+    fn decode_offers(cbor: cbor::Value) -> Vec<RawOfferConfig> {
+        <Vec<RawOfferConfig> as cbor::Decode>::try_from_cbor_value(cbor).unwrap()
     }
 
     #[test]
     fn test_offers_legacy_array_format() {
-        // Old format: plain array of strings. Each becomes a key with empty OfferConfig.
-        let raw = make_raw(cbor::Value::Array(vec![
-            cbor::Value::TextString("playground_short".into()),
-            cbor::Value::TextString("playground_short_sgx".into()),
+        // Old format: plain array of strings. Each becomes a RawOfferConfig with no overrides.
+        let offers = decode_offers(cbor::Value::Array(vec![
+            cbor::Value::TextString("small".into()),
+            cbor::Value::TextString("large".into()),
         ]));
-        assert!(raw.offers.0.contains_key("playground_short"));
-        assert!(raw.offers.0.contains_key("playground_short_sgx"));
-        assert_eq!(raw.offers.0.len(), 2);
-        // No per-offer overrides — both fields are None (global fallback applies).
-        assert!(raw.offers.0["playground_short"].allowed_creators.is_none());
+        assert_eq!(offers.len(), 2);
+        assert_eq!(offers[0].id, "small");
+        assert!(offers[0].allowed_creators.is_none());
+        assert_eq!(offers[1].id, "large");
     }
 
     #[test]
     fn test_offers_mixed_format() {
         // Mixed: plain strings alongside a map entry with an explicit `id` field and overrides.
-        let raw = make_raw(cbor::Value::Array(vec![
-            cbor::Value::TextString("playground_short".into()),
-            cbor::Value::TextString("playground_short_sgx".into()),
+        let offers = decode_offers(cbor::Value::Array(vec![
+            cbor::Value::TextString("small".into()),
+            cbor::Value::TextString("large".into()),
             cbor::Value::Map(vec![
                 (
                     cbor::Value::TextString("id".into()),
-                    cbor::Value::TextString("oasis_internal".into()),
+                    cbor::Value::TextString("internal".into()),
                 ),
                 (
                     cbor::Value::TextString("allowed_creators".into()),
@@ -449,10 +451,12 @@ mod test {
                 ),
             ]),
         ]));
-        assert!(raw.offers.0.contains_key("playground_short"));
-        assert!(raw.offers.0["playground_short"].allowed_creators.is_none());
-        assert!(raw.offers.0.contains_key("oasis_internal"));
-        assert!(raw.offers.0["oasis_internal"].allowed_creators.is_some());
+        assert_eq!(offers[0].id, "small");
+        assert!(offers[0].allowed_creators.is_none());
+        assert_eq!(offers[1].id, "large");
+        assert!(offers[1].allowed_creators.is_none());
+        assert_eq!(offers[2].id, "internal");
+        assert!(offers[2].allowed_creators.is_some());
     }
 
     #[test]
@@ -463,16 +467,14 @@ mod test {
             allowed_creators: BTreeSet::new(), // global: allow all
             ..Default::default()
         };
-        let addr = Address::from_bech32("oasis1qp0cnmkjl22gky6p7q0tgkwmsc6g4c5er6x0hsk7").unwrap();
+        let addr = testing::keys::alice::address();
         assert!(cfg.is_creator_allowed("public", &addr));
     }
 
     #[test]
     fn test_is_creator_allowed_per_offer_override() {
-        let allowed =
-            Address::from_bech32("oasis1qp0cnmkjl22gky6p7q0tgkwmsc6g4c5er6x0hsk7").unwrap();
-        let blocked =
-            Address::from_bech32("oasis1qrad7s7nqm4gvyzr8yt48jkrjxuqc6d7pvjm4ze").unwrap();
+        let allowed = testing::keys::alice::address();
+        let blocked = testing::keys::bob::address();
 
         let cfg = LocalConfig {
             offers: BTreeMap::from([(

--- a/rofl-scheduler/src/config.rs
+++ b/rofl-scheduler/src/config.rs
@@ -47,7 +47,7 @@ pub struct RawOfferConfig {
 ///         - "oasis1..."
 /// ```
 #[derive(Clone, Debug, Default)]
-struct RawOffersField(BTreeMap<String, RawOfferConfig>);
+pub(crate) struct RawOffersField(BTreeMap<String, RawOfferConfig>);
 
 impl cbor::Decode for RawOffersField {
     fn try_default() -> Result<Self, cbor::DecodeError> {
@@ -91,7 +91,7 @@ pub struct RawLocalConfig {
     /// optional per-offer configuration that overrides the global defaults.
     ///
     /// Accepts the legacy array form `["offer-a"]` (backwards compatible) or the new map form.
-    pub offers: RawOffersField,
+    pub(crate) offers: RawOffersField,
     /// Allowed artifact hashes.
     ///
     /// Key is the artifact kind and value is a list of artifact SHA256 hashes. If a key doesn't

--- a/rofl-scheduler/src/config.rs
+++ b/rofl-scheduler/src/config.rs
@@ -19,6 +19,21 @@ use oasis_runtime_sdk_rofl_market as market;
 /// Local configuration key that contains the ROFL scheduler configuration.
 const ROFL_SCHEDULER_CONFIG_KEY: &str = "rofl_scheduler";
 
+/// Raw per-offer configuration as serialized.
+#[derive(Clone, Debug, Default, cbor::Decode)]
+pub struct RawOfferConfig {
+    /// Allowed instance creator addresses for this offer.
+    ///
+    /// When set, overrides the global `allowed_creators`. An empty list means all creators are
+    /// allowed. When not set (`None`), the global `allowed_creators` is used as a fallback.
+    pub allowed_creators: Option<Vec<String>>,
+    /// Allowed artifact hashes for this offer.
+    ///
+    /// When set, overrides the global `allowed_artifacts` entirely. When not set (`None`), the
+    /// global `allowed_artifacts` is used as a fallback.
+    pub allowed_artifacts: Option<BTreeMap<String, Vec<String>>>,
+}
+
 /// Raw local configuration as serialized.
 #[derive(Clone, Debug, Default, cbor::Decode)]
 pub struct RawLocalConfig {
@@ -26,8 +41,9 @@ pub struct RawLocalConfig {
     pub provider_address: String,
     /// Offers that the scheduler should accept. If no offers are configured, all are accepted.
     ///
-    /// Each offer identifier is the value of the `net.oasis.scheduler.offer` metadata key.
-    pub offers: BTreeSet<String>,
+    /// Each key is the value of the `net.oasis.scheduler.offer` metadata key. The value is an
+    /// optional per-offer configuration that overrides the global defaults.
+    pub offers: BTreeMap<String, RawOfferConfig>,
     /// Allowed artifact hashes.
     ///
     /// Key is the artifact kind and value is a list of artifact SHA256 hashes. If a key doesn't
@@ -135,16 +151,34 @@ impl Resources {
     }
 }
 
+/// Per-offer configuration.
+#[derive(Clone, Debug, Default)]
+pub struct OfferConfig {
+    /// Allowed instance creator addresses.
+    ///
+    /// When `Some`, overrides the global `allowed_creators`. An empty set means all creators are
+    /// allowed. When `None`, the global `allowed_creators` is used as a fallback.
+    pub allowed_creators: Option<BTreeSet<Address>>,
+    /// Allowed artifact hashes.
+    ///
+    /// When `Some`, overrides the global `allowed_artifacts` entirely. When `None`, the global
+    /// `allowed_artifacts` is used as a fallback.
+    pub allowed_artifacts: Option<BTreeMap<String, BTreeSet<Hash>>>,
+}
+
 /// Local scheduler configuration.
 #[derive(Clone, Debug, Default)]
 pub struct LocalConfig {
     /// Address of the provider.
     pub provider_address: Address,
-    /// Offers that the scheduler should accept.
-    pub offers: BTreeSet<String>,
-    /// Allowed artifact hashes.
+    /// Offers that the scheduler should accept, with optional per-offer configuration.
+    ///
+    /// Each key is the value of the `net.oasis.scheduler.offer` metadata key. If the map is
+    /// empty, all offers are accepted using the global defaults.
+    pub offers: BTreeMap<String, OfferConfig>,
+    /// Allowed artifact hashes (global default, may be overridden per offer).
     pub allowed_artifacts: BTreeMap<String, BTreeSet<Hash>>,
-    /// Allowed instance creator addresses.
+    /// Allowed instance creator addresses (global default, may be overridden per offer).
     pub allowed_creators: BTreeSet<Address>,
     /// Resource capacity.
     pub capacity: Resources,
@@ -196,6 +230,48 @@ impl LocalConfig {
             .collect::<Result<BTreeSet<_>, _>>()
             .map_err(|_| anyhow!("bad allowed creators value"))?;
 
+        let offers = cfg
+            .offers
+            .into_iter()
+            .map(|(key, raw_cfg)| -> Result<(String, OfferConfig)> {
+                let offer_creators = raw_cfg
+                    .allowed_creators
+                    .map(|creators| {
+                        creators
+                            .into_iter()
+                            .map(|raw| Address::from_bech32(&raw))
+                            .collect::<Result<BTreeSet<_>, _>>()
+                            .map_err(|_| anyhow!("bad allowed_creators in offer '{key}'"))
+                    })
+                    .transpose()?;
+                let offer_artifacts = raw_cfg
+                    .allowed_artifacts
+                    .map(|artifacts| {
+                        artifacts
+                            .into_iter()
+                            .map(|(kind, hashes)| -> Result<(String, BTreeSet<Hash>)> {
+                                Ok((
+                                    kind,
+                                    hashes
+                                        .into_iter()
+                                        .map(|h| -> Result<Hash> { Ok(h.parse::<Hash>()?) })
+                                        .collect::<Result<BTreeSet<_>>>()?,
+                                ))
+                            })
+                            .collect::<Result<_>>()
+                            .map_err(|_| anyhow!("bad allowed_artifacts in offer '{key}'"))
+                    })
+                    .transpose()?;
+                Ok((
+                    key,
+                    OfferConfig {
+                        allowed_creators: offer_creators,
+                        allowed_artifacts: offer_artifacts,
+                    },
+                ))
+            })
+            .collect::<Result<_>>()?;
+
         let transfer_instances_from = cfg
             .transfer_instances_from
             .into_iter()
@@ -211,7 +287,7 @@ impl LocalConfig {
 
         Ok(LocalConfig {
             provider_address,
-            offers: cfg.offers,
+            offers,
             allowed_artifacts,
             allowed_creators,
             capacity: cfg.capacity,
@@ -229,23 +305,38 @@ impl LocalConfig {
     }
 
     /// Validate the given artifact hash against the set of allowed artifacts.
-    pub fn ensure_artifact_allowed(&self, kind: &str, hash: &Hash) -> Result<()> {
-        let allowed_hashes = match self.allowed_artifacts.get(kind) {
-            None => {
-                // All artifacts of this kind are allowed.
-                return Ok(());
-            }
-            Some(allowed_hashes) => allowed_hashes,
-        };
+    ///
+    /// Uses the per-offer artifact list when the offer has one configured; otherwise falls back
+    /// to the global `allowed_artifacts`.
+    pub fn ensure_artifact_allowed(&self, offer_key: &str, kind: &str, hash: &Hash) -> Result<()> {
+        let artifacts = self
+            .offers
+            .get(offer_key)
+            .and_then(|cfg| cfg.allowed_artifacts.as_ref())
+            .unwrap_or(&self.allowed_artifacts);
 
-        if !allowed_hashes.contains(hash) {
-            return Err(anyhow!("{kind} artifact not allowed"));
+        match artifacts.get(kind) {
+            None => Ok(()), // all artifacts of this kind are allowed
+            Some(allowed_hashes) => {
+                if !allowed_hashes.contains(hash) {
+                    Err(anyhow!("{kind} artifact not allowed"))
+                } else {
+                    Ok(())
+                }
+            }
         }
-        Ok(())
     }
 
-    /// Check whether the given creator is among the allowed creators.
-    pub fn is_creator_allowed(&self, address: &Address) -> bool {
+    /// Check whether the given creator is among the allowed creators for the given offer.
+    ///
+    /// Uses the per-offer creator list when the offer has one configured; otherwise falls back to
+    /// the global `allowed_creators`. An empty list means all creators are allowed.
+    pub fn is_creator_allowed(&self, offer_key: &str, address: &Address) -> bool {
+        if let Some(offer_cfg) = self.offers.get(offer_key) {
+            if let Some(ref creators) = offer_cfg.allowed_creators {
+                return creators.is_empty() || creators.contains(address);
+            }
+        }
         self.allowed_creators.is_empty() || self.allowed_creators.contains(address)
     }
 

--- a/rofl-scheduler/src/config.rs
+++ b/rofl-scheduler/src/config.rs
@@ -35,7 +35,7 @@ pub struct RawOfferConfig {
 }
 
 /// A map entry with an explicit `id` field and optional per-offer config overrides.
-#[derive(Clone, Debug, cbor::Decode)]
+#[derive(Clone, Debug, Default, cbor::Decode)]
 struct RawOfferEntry {
     pub id: String,
     pub allowed_creators: Option<Vec<String>>,

--- a/rofl-scheduler/src/config.rs
+++ b/rofl-scheduler/src/config.rs
@@ -34,17 +34,25 @@ pub struct RawOfferConfig {
     pub allowed_artifacts: Option<BTreeMap<String, Vec<String>>>,
 }
 
+/// A map entry with an explicit `id` field and optional per-offer config overrides.
+#[derive(Clone, Debug, cbor::Decode)]
+struct RawOfferEntry {
+    pub id: String,
+    pub allowed_creators: Option<Vec<String>>,
+    pub allowed_artifacts: Option<BTreeMap<String, Vec<String>>>,
+}
+
 /// Backwards-compatible wrapper for the `offers` field in [`RawLocalConfig`].
 ///
 /// Each element of the sequence is either a plain string (old format, no overrides) or a
-/// single-key map whose key is the offer name and whose value is a [`RawOfferConfig`]:
+/// map with an `id` field and optional per-offer config overrides:
 ///
 /// ```yaml
 /// offers:
 ///   - playground_short             # plain string — global defaults apply
-///   - oasis_internal:              # map entry — per-offer overrides
-///       allowed_creators:
-///         - "oasis1..."
+///   - id: oasis_internal           # map entry — per-offer overrides
+///     allowed_creators:
+///       - "oasis1..."
 /// ```
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RawOffersField(BTreeMap<String, RawOfferConfig>);
@@ -65,13 +73,16 @@ impl cbor::Decode for RawOffersField {
                 cbor::Value::TextString(key) => {
                     map.insert(key, RawOfferConfig::default());
                 }
-                // Single-key map: {"offer-name": {config}} → offer with overrides.
-                cbor::Value::Map(entries) if entries.len() == 1 => {
-                    let (k, v) = entries.into_iter().next().unwrap();
-                    let cbor::Value::TextString(key) = k else {
-                        return Err(cbor::DecodeError::UnexpectedType);
-                    };
-                    map.insert(key, RawOfferConfig::try_from_cbor_value(v)?);
+                // Map with an `id` field and optional overrides.
+                cbor::Value::Map(_) => {
+                    let entry = RawOfferEntry::try_from_cbor_value(item)?;
+                    map.insert(
+                        entry.id,
+                        RawOfferConfig {
+                            allowed_creators: entry.allowed_creators,
+                            allowed_artifacts: entry.allowed_artifacts,
+                        },
+                    );
                 }
                 _ => return Err(cbor::DecodeError::UnexpectedType),
             }
@@ -90,7 +101,7 @@ pub struct RawLocalConfig {
     /// Each key is the value of the `net.oasis.scheduler.offer` metadata key. The value is an
     /// optional per-offer configuration that overrides the global defaults.
     ///
-    /// Accepts the legacy array form `["offer-a"]` (backwards compatible) or the new map form.
+    /// Accepts the legacy plain-string array form (backwards compatible) or the new map-entry form.
     pub(crate) offers: RawOffersField,
     /// Allowed artifact hashes.
     ///
@@ -421,19 +432,22 @@ mod test {
 
     #[test]
     fn test_offers_mixed_format() {
-        // Mixed: plain strings alongside a single-key map entry with overrides.
+        // Mixed: plain strings alongside a map entry with an explicit `id` field and overrides.
         let raw = make_raw(cbor::Value::Array(vec![
             cbor::Value::TextString("playground_short".into()),
             cbor::Value::TextString("playground_short_sgx".into()),
-            cbor::Value::Map(vec![(
-                cbor::Value::TextString("oasis_internal".into()),
-                cbor::Value::Map(vec![(
+            cbor::Value::Map(vec![
+                (
+                    cbor::Value::TextString("id".into()),
+                    cbor::Value::TextString("oasis_internal".into()),
+                ),
+                (
                     cbor::Value::TextString("allowed_creators".into()),
                     cbor::Value::Array(vec![cbor::Value::TextString(
                         "oasis1qp0cnmkjl22gky6p7q0tgkwmsc6g4c5er6x0hsk7".into(),
                     )]),
-                )]),
-            )]),
+                ),
+            ]),
         ]));
         assert!(raw.offers.0.contains_key("playground_short"));
         assert!(raw.offers.0["playground_short"].allowed_creators.is_none());

--- a/rofl-scheduler/src/config.rs
+++ b/rofl-scheduler/src/config.rs
@@ -34,6 +34,52 @@ pub struct RawOfferConfig {
     pub allowed_artifacts: Option<BTreeMap<String, Vec<String>>>,
 }
 
+/// Backwards-compatible wrapper for the `offers` field in [`RawLocalConfig`].
+///
+/// Each element of the sequence is either a plain string (old format, no overrides) or a
+/// single-key map whose key is the offer name and whose value is a [`RawOfferConfig`]:
+///
+/// ```yaml
+/// offers:
+///   - playground_short             # plain string — global defaults apply
+///   - oasis_internal:              # map entry — per-offer overrides
+///       allowed_creators:
+///         - "oasis1..."
+/// ```
+#[derive(Clone, Debug, Default)]
+struct RawOffersField(BTreeMap<String, RawOfferConfig>);
+
+impl cbor::Decode for RawOffersField {
+    fn try_default() -> Result<Self, cbor::DecodeError> {
+        Ok(Self(BTreeMap::new()))
+    }
+
+    fn try_from_cbor_value(value: cbor::Value) -> Result<Self, cbor::DecodeError> {
+        let cbor::Value::Array(items) = value else {
+            return Err(cbor::DecodeError::UnexpectedType);
+        };
+        let mut map = BTreeMap::new();
+        for item in items {
+            match item {
+                // Plain string: "offer-name" → empty config (global defaults apply).
+                cbor::Value::TextString(key) => {
+                    map.insert(key, RawOfferConfig::default());
+                }
+                // Single-key map: {"offer-name": {config}} → offer with overrides.
+                cbor::Value::Map(entries) if entries.len() == 1 => {
+                    let (k, v) = entries.into_iter().next().unwrap();
+                    let cbor::Value::TextString(key) = k else {
+                        return Err(cbor::DecodeError::UnexpectedType);
+                    };
+                    map.insert(key, RawOfferConfig::try_from_cbor_value(v)?);
+                }
+                _ => return Err(cbor::DecodeError::UnexpectedType),
+            }
+        }
+        Ok(Self(map))
+    }
+}
+
 /// Raw local configuration as serialized.
 #[derive(Clone, Debug, Default, cbor::Decode)]
 pub struct RawLocalConfig {
@@ -43,7 +89,9 @@ pub struct RawLocalConfig {
     ///
     /// Each key is the value of the `net.oasis.scheduler.offer` metadata key. The value is an
     /// optional per-offer configuration that overrides the global defaults.
-    pub offers: BTreeMap<String, RawOfferConfig>,
+    ///
+    /// Accepts the legacy array form `["offer-a"]` (backwards compatible) or the new map form.
+    pub offers: RawOffersField,
     /// Allowed artifact hashes.
     ///
     /// Key is the artifact kind and value is a list of artifact SHA256 hashes. If a key doesn't
@@ -232,6 +280,7 @@ impl LocalConfig {
 
         let offers = cfg
             .offers
+            .0
             .into_iter()
             .map(|(key, raw_cfg)| -> Result<(String, OfferConfig)> {
                 let offer_creators = raw_cfg
@@ -343,5 +392,89 @@ impl LocalConfig {
     /// Check whether the given node identifier is among the list of nodes to transfer instances from.
     pub fn should_transfer_instance_from(&self, node_id: &PublicKey) -> bool {
         self.transfer_instances_from.contains(node_id)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn make_raw(offers_cbor: cbor::Value) -> RawLocalConfig {
+        let mut raw = RawLocalConfig::default();
+        raw.offers = cbor::Decode::try_from_cbor_value(offers_cbor).unwrap();
+        raw
+    }
+
+    #[test]
+    fn test_offers_legacy_array_format() {
+        // Old format: plain array of strings. Each becomes a key with empty OfferConfig.
+        let raw = make_raw(cbor::Value::Array(vec![
+            cbor::Value::TextString("playground_short".into()),
+            cbor::Value::TextString("playground_short_sgx".into()),
+        ]));
+        assert!(raw.offers.0.contains_key("playground_short"));
+        assert!(raw.offers.0.contains_key("playground_short_sgx"));
+        assert_eq!(raw.offers.0.len(), 2);
+        // No per-offer overrides — both fields are None (global fallback applies).
+        assert!(raw.offers.0["playground_short"].allowed_creators.is_none());
+    }
+
+    #[test]
+    fn test_offers_mixed_format() {
+        // Mixed: plain strings alongside a single-key map entry with overrides.
+        let raw = make_raw(cbor::Value::Array(vec![
+            cbor::Value::TextString("playground_short".into()),
+            cbor::Value::TextString("playground_short_sgx".into()),
+            cbor::Value::Map(vec![(
+                cbor::Value::TextString("oasis_internal".into()),
+                cbor::Value::Map(vec![(
+                    cbor::Value::TextString("allowed_creators".into()),
+                    cbor::Value::Array(vec![cbor::Value::TextString(
+                        "oasis1qp0cnmkjl22gky6p7q0tgkwmsc6g4c5er6x0hsk7".into(),
+                    )]),
+                )]),
+            )]),
+        ]));
+        assert!(raw.offers.0.contains_key("playground_short"));
+        assert!(raw.offers.0["playground_short"].allowed_creators.is_none());
+        assert!(raw.offers.0.contains_key("oasis_internal"));
+        assert!(raw.offers.0["oasis_internal"].allowed_creators.is_some());
+    }
+
+    #[test]
+    fn test_is_creator_allowed_fallback() {
+        // Per-offer None → global fallback.
+        let cfg = LocalConfig {
+            offers: BTreeMap::from([("public".into(), OfferConfig::default())]),
+            allowed_creators: BTreeSet::new(), // global: allow all
+            ..Default::default()
+        };
+        let addr = Address::from_bech32("oasis1qp0cnmkjl22gky6p7q0tgkwmsc6g4c5er6x0hsk7").unwrap();
+        assert!(cfg.is_creator_allowed("public", &addr));
+    }
+
+    #[test]
+    fn test_is_creator_allowed_per_offer_override() {
+        let allowed =
+            Address::from_bech32("oasis1qp0cnmkjl22gky6p7q0tgkwmsc6g4c5er6x0hsk7").unwrap();
+        let blocked =
+            Address::from_bech32("oasis1qrad7s7nqm4gvyzr8yt48jkrjxuqc6d7pvjm4ze").unwrap();
+
+        let cfg = LocalConfig {
+            offers: BTreeMap::from([(
+                "internal".into(),
+                OfferConfig {
+                    allowed_creators: Some(BTreeSet::from([allowed])),
+                    allowed_artifacts: None,
+                },
+            )]),
+            allowed_creators: BTreeSet::new(), // global: allow all (should not apply here)
+            ..Default::default()
+        };
+
+        assert!(cfg.is_creator_allowed("internal", &allowed));
+        assert!(!cfg.is_creator_allowed("internal", &blocked));
+        // Unknown offer key → global fallback (allow all).
+        assert!(cfg.is_creator_allowed("public", &blocked));
     }
 }

--- a/rofl-scheduler/src/manager.rs
+++ b/rofl-scheduler/src/manager.rs
@@ -494,9 +494,12 @@ impl Manager {
                             .get(&instance.offer)
                             .cloned()
                             .unwrap_or_default();
-                        local_state
-                            .pending_start
-                            .push((instance, desired, wipe_storage, offer_key));
+                        local_state.pending_start.push((
+                            instance,
+                            desired,
+                            wipe_storage,
+                            offer_key,
+                        ));
                     }
                 }
                 (None, Some(desired)) => {

--- a/rofl-scheduler/src/manager.rs
+++ b/rofl-scheduler/src/manager.rs
@@ -109,8 +109,11 @@ struct LocalState {
     accepted: BTreeMap<InstanceId, Instance>,
     /// A list of our bundles running locally.
     running: BTreeMap<InstanceId, bundle_manager::BundleInfo>,
+    /// Map from on-chain offer ID to its metadata key (`net.oasis.scheduler.offer` value).
+    offer_key_by_id: BTreeMap<market::types::OfferId, String>,
     /// A list of deployments that should already be running but are not.
-    pending_start: Vec<(Instance, Deployment, bool)>,
+    /// Tuple: (instance, deployment, wipe_storage, offer_key).
+    pending_start: Vec<(Instance, Deployment, bool, String)>,
     /// A list of instance identifiers that should have no running deployments.
     pending_stop: Vec<(InstanceId, bool)>,
     /// A map of instance updates.
@@ -251,6 +254,7 @@ impl Manager {
             client,
             accepted: BTreeMap::new(),
             running: BTreeMap::new(),
+            offer_key_by_id: BTreeMap::new(),
             pending_start: Vec::new(),
             pending_stop: Vec::new(),
             instance_updates: BTreeMap::new(),
@@ -303,6 +307,17 @@ impl Manager {
             .collect();
         let mut running_unknown =
             BTreeSet::from_iter(local_state.running.keys().copied().chain(volumes));
+
+        // Build a map from offer ID to offer metadata key, used when populating pending_start so
+        // that per-offer config (allowed_creators, allowed_artifacts) can be applied later.
+        let offers = local_state.client.offers().await?;
+        local_state.offer_key_by_id = offers
+            .into_iter()
+            .filter_map(|offer| {
+                let key = offer.metadata.get(METADATA_KEY_OFFER)?.clone();
+                Some((offer.id, key))
+            })
+            .collect();
 
         // Discover desired instance state.
         let instances: Vec<Instance> = local_state.client.instances().await?;
@@ -474,16 +489,26 @@ impl Manager {
                     if actual_hash != desired_hash || force_restart {
                         // Note that any old instances will be restarted in case they are already
                         // running and we add them to `pending_start`.
+                        let offer_key = local_state
+                            .offer_key_by_id
+                            .get(&instance.offer)
+                            .cloned()
+                            .unwrap_or_default();
                         local_state
                             .pending_start
-                            .push((instance, desired, wipe_storage));
+                            .push((instance, desired, wipe_storage, offer_key));
                     }
                 }
                 (None, Some(desired)) => {
                     // Instance is not running and should be started.
+                    let offer_key = local_state
+                        .offer_key_by_id
+                        .get(&instance.offer)
+                        .cloned()
+                        .unwrap_or_default();
                     local_state
                         .pending_start
-                        .push((instance, desired, wipe_storage));
+                        .push((instance, desired, wipe_storage, offer_key));
                 }
                 (Some(_), None) => {
                     // Instance is running and should be stopped.
@@ -533,20 +558,17 @@ impl Manager {
         local_node_id: PublicKey,
         local_state: &mut LocalState,
     ) -> Result<()> {
-        let offers = local_state.client.offers().await?;
         let instances = local_state.client.instances().await?;
 
-        let acceptable_offers: BTreeSet<market::types::OfferId> = offers
-            .into_iter()
-            .filter_map(|offer| {
-                let offer_key = offer.metadata.get(METADATA_KEY_OFFER)?;
-
-                if self.cfg.offers.is_empty() || self.cfg.offers.contains(offer_key) {
-                    Some(offer.id)
-                } else {
-                    None
-                }
+        // Build a map from offer ID to offer key for offers this scheduler accepts.
+        // `offer_key_by_id` was populated by discover(); no second network call needed.
+        let acceptable_offers: BTreeMap<market::types::OfferId, String> = local_state
+            .offer_key_by_id
+            .iter()
+            .filter(|(_, key)| {
+                self.cfg.offers.is_empty() || self.cfg.offers.contains_key(key.as_str())
             })
+            .map(|(id, key)| (*id, key.clone()))
             .collect();
 
         for instance in instances {
@@ -586,22 +608,26 @@ impl Manager {
                 "transfer" => transfer_instance,
             );
 
-            // Check if creator is among the allowed creators.
-            if !self.cfg.is_creator_allowed(&instance.creator) {
+            // Check if offer is among the configured offers (and retrieve its key for per-offer
+            // policy lookups that follow).
+            let offer_key = match acceptable_offers.get(&instance.offer) {
+                Some(key) => key.as_str(),
+                None => {
+                    slog::info!(self.logger, "offer not acceptable for this instance";
+                        "id" => ?instance.id,
+                        "offer" => ?instance.offer,
+                        "transfer" => transfer_instance,
+                    );
+                    maybe_remove();
+                    continue;
+                }
+            };
+
+            // Check if creator is among the allowed creators for this offer (falls back to global).
+            if !self.cfg.is_creator_allowed(offer_key, &instance.creator) {
                 slog::info!(self.logger, "creator not allowed";
                     "id" => ?instance.id,
                     "creator" => instance.creator,
-                    "transfer" => transfer_instance,
-                );
-                maybe_remove();
-                continue;
-            }
-
-            // Check if offer is among the configured offers.
-            if !acceptable_offers.contains(&instance.offer) {
-                slog::info!(self.logger, "offer not acceptable for this instance";
-                    "id" => ?instance.id,
-                    "offer" => ?instance.offer,
                     "transfer" => transfer_instance,
                 );
                 maybe_remove();
@@ -664,12 +690,13 @@ impl Manager {
         let start_jobs: Vec<_> = local_state
             .pending_start
             .iter()
-            .map(|(instance, deployment, wipe_storage)| {
+            .map(|(instance, deployment, wipe_storage, offer_key)| {
                 self.clone().start_instance(
                     local_state.client.clone(),
                     instance.clone(),
                     deployment.clone(),
                     *wipe_storage,
+                    offer_key.clone(),
                 )
             })
             .collect();
@@ -861,6 +888,7 @@ impl Manager {
         instance: Instance,
         deployment: Deployment,
         wipe_storage: bool,
+        offer_key: String,
     ) -> Result<()> {
         if !self.should_start_instance(instance.id, &deployment) {
             return Ok(());
@@ -875,7 +903,7 @@ impl Manager {
         self.set_last_instance_deployment(instance.id, &deployment);
 
         match self
-            .pull_and_deploy_instance(client, &instance, &deployment)
+            .pull_and_deploy_instance(client, &instance, &deployment, &offer_key)
             .await
         {
             Ok(_) => {
@@ -965,9 +993,10 @@ impl Manager {
         client: Arc<MarketQueryClient>,
         instance: &Instance,
         deployment: &Deployment,
+        offer_key: &str,
     ) -> Result<()> {
         let deployment_info = self
-            .pull_and_validate_deployment(instance, deployment)
+            .pull_and_validate_deployment(instance, deployment, offer_key)
             .await?;
         self.deploy_instance(client, instance, deployment, deployment_info)
             .await
@@ -1102,6 +1131,7 @@ impl Manager {
         self: &Arc<Self>,
         instance: &Instance,
         deployment: &Deployment,
+        offer_key: &str,
     ) -> Result<DeploymentInfo> {
         slog::info!(self.logger, "pulling deployment bundle";
             "instance_id" => ?instance.id,
@@ -1214,28 +1244,31 @@ impl Manager {
                     .get(&tdx.firmware)
                     .ok_or(anyhow!("ORC is missing firmware digest"))?;
                 self.cfg
-                    .ensure_artifact_allowed("firmware", firmware_digest)?;
+                    .ensure_artifact_allowed(offer_key, "firmware", firmware_digest)?;
 
                 if !tdx.kernel.is_empty() {
                     let kernel_digest = orc_manifest
                         .digests
                         .get(&tdx.kernel)
                         .ok_or(anyhow!("ORC is missing kernel digest"))?;
-                    self.cfg.ensure_artifact_allowed("kernel", kernel_digest)?;
+                    self.cfg
+                        .ensure_artifact_allowed(offer_key, "kernel", kernel_digest)?;
 
                     if !tdx.initrd.is_empty() {
                         let initrd_digest = orc_manifest
                             .digests
                             .get(&tdx.initrd)
                             .ok_or(anyhow!("ORC is missing initrd digest"))?;
-                        self.cfg.ensure_artifact_allowed("initrd", initrd_digest)?;
+                        self.cfg
+                            .ensure_artifact_allowed(offer_key, "initrd", initrd_digest)?;
                     }
                     if !tdx.stage2_image.is_empty() {
                         let stage2_digest = orc_manifest
                             .digests
                             .get(&tdx.stage2_image)
                             .ok_or(anyhow!("ORC is missing stage2 digest"))?;
-                        self.cfg.ensure_artifact_allowed("stage2", stage2_digest)?;
+                        self.cfg
+                            .ensure_artifact_allowed(offer_key, "stage2", stage2_digest)?;
 
                         qcow2_names.insert(tdx.stage2_image.clone());
 


### PR DESCRIPTION
Adds per-offer overrides for `allowed_creators` and `allowed_artifacts`, making it possible to mix public and internal workloads on the same scheduler instance without repeating the global allowlist for every offer.

## What changed

- `offers` is now a `BTreeMap<String, OfferConfig>` internally. Each entry carries optional `allowed_creators` and `allowed_artifacts` overrides; when absent, the top-level value is used as a fallback. Empty list = allow all.
- `offer_key_by_id` is built once per scheduling round in `discover()` and reused in `process_pending()`, avoiding a redundant on-chain fetch.
- **Fully backwards compatible** — the existing plain-string array format is still accepted. New entries can optionally carry per-offer config using a map with an `id` field.

## Config

```yaml
# Global fallback — applies to all offers that don't override it
allowed_creators: []

offers:
  - playground_short            # plain string — global defaults apply
  - playground_short_sgx
  - id: oasis_internal          # map entry — per-offer overrides
    allowed_creators:
      - "oasis1abc..."
```
