### PR TITLE
Support non-encrypted variables in ROFL manifest yaml

### DIFF
--- a/rofl-containers/src/containers.rs
+++ b/rofl-containers/src/containers.rs
@@ -87,6 +87,32 @@ pub async fn start() -> Result<()> {
     Ok(())
 }
 
+/// Extract environment variables from deployment metadata.
+pub fn env_from_metadata(metadata: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    metadata
+        .iter()
+        .filter_map(|(key, value)| {
+            parse_env_metadata_key(key).map(|name| (name.to_string(), value.clone()))
+        })
+        .collect()
+}
+
+/// Parse a metadata key that follows the environment variable convention.
+///
+/// The canonical format is `env.<VAR>`, where `<VAR>` environment variable
+/// consists of a non-empty ASCII alphanumeric characters or `_`.
+///
+/// Dotted forms are intentionally rejected so `env.<SERVICE>.<VAR>` can be added
+/// later without being breaking.
+fn parse_env_metadata_key(key: &str) -> Option<&str> {
+    let name = key.strip_prefix("env.")?;
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+
+    Some(name)
+}
+
 static GLOBAL_ENVIRONMENT: LazyLock<Environment> = LazyLock::new(Environment::new);
 
 /// Management of environment variables to expose to the compose file.
@@ -115,5 +141,65 @@ impl Environment {
     fn get(&self) -> BTreeMap<String, String> {
         let vars = self.vars.lock().unwrap();
         vars.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_env_metadata_key() {
+        let tcs = vec![
+            ("foo", None),
+            ("env.", None),
+            ("env.MY_VAR", Some("MY_VAR")),
+            ("env.MY_VAR_1", Some("MY_VAR_1")),
+            ("env.service_A.MY_VAR", None),
+            ("env.MY-VAR", None),
+            ("env.MY VAR", None),
+            ("env.my_var", Some("my_var")),
+        ];
+        for tc in tcs {
+            assert_eq!(parse_env_metadata_key(tc.0), tc.1);
+        }
+    }
+
+    #[test]
+    fn test_env_from_empty_metadata() {
+        assert_eq!(env_from_metadata(&BTreeMap::new()), BTreeMap::new());
+    }
+
+    #[test]
+    fn test_env_from_metadata_with_non_env_keys() {
+        let metadata = BTreeMap::from([
+            (".env".to_string(), "ignored".to_string()),
+            ("env.MY_VAR".to_string(), "my value".to_string()),
+        ]);
+
+        assert_eq!(
+            env_from_metadata(&metadata),
+            BTreeMap::from([("MY_VAR".to_string(), "my value".to_string())])
+        );
+    }
+
+    #[test]
+    fn test_env_from_metadata() {
+        let metadata = BTreeMap::from([
+            ("env.".to_string(), "ignored".to_string()),
+            ("env.MY_VAR".to_string(), "my value".to_string()),
+            ("env.OTHER_VAR".to_string(), "other value".to_string()),
+            ("env.service_A.MY_VAR".to_string(), "reserved".to_string()),
+            ("env.MY-VAR".to_string(), "ignored".to_string()),
+            ("net.oasis.foo".to_string(), "ignored".to_string()),
+        ]);
+
+        assert_eq!(
+            env_from_metadata(&metadata),
+            BTreeMap::from([
+                ("MY_VAR".to_string(), "my value".to_string()),
+                ("OTHER_VAR".to_string(), "other value".to_string()),
+            ])
+        );
     }
 }

--- a/rofl-containers/src/main.rs
+++ b/rofl-containers/src/main.rs
@@ -158,9 +158,25 @@ impl App for ContainersApp {
             }
         }
 
-        // Initialize secrets.
+        // Fetch app config.
+        let app_cfg = match env.client().app_cfg().await {
+            Ok(cfg) => cfg,
+            Err(err) => {
+                slog::error!(logger, "failed to fetch app config"; "err" => ?err);
+                process::abort();
+            }
+        };
+
+        // Initialize environment variables from deployment metadata (env.* keys).
+        slog::info!(logger, "initializing container environment variables");
+        for (name, value) in containers::env_from_metadata(&app_cfg.metadata) {
+            containers::env().set(&name, &value);
+            slog::info!(logger, "provisioned environment variable"; "name" => name);
+        }
+
+        // Initialize secrets (runs after env vars so secrets take precedence on collision).
         slog::info!(logger, "initializing container secrets");
-        if let Err(err) = secrets::init(env.clone(), kms.clone()).await {
+        if let Err(err) = secrets::init(&app_cfg.secrets, kms.clone()).await {
             slog::error!(logger, "failed to initialize container secrets"; "err" => ?err);
             process::abort();
         }

--- a/rofl-containers/src/secrets.rs
+++ b/rofl-containers/src/secrets.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Result;
 use cmd_lib::run_cmd;
@@ -10,24 +10,21 @@ use rofl_appd::services::{self, kms::OpenSecretRequest};
 use crate::containers;
 
 /// Initialize secrets available to containers.
-pub async fn init<A: App>(
-    env: Environment<A>,
+pub async fn init(
+    encrypted_secrets: &BTreeMap<String, Vec<u8>>,
     kms: Arc<dyn services::kms::KmsService>,
 ) -> Result<()> {
     let logger = get_logger("secrets");
 
-    // Query own app cfg to get encrypted secrets.
-    let encrypted_secrets = env.client().app_cfg().await?.secrets;
-
     // Ensure all secrets are removed.
     run_cmd!(podman secret rm --all)?;
     // Create all requested secrets.
-    for (pub_name, value) in encrypted_secrets {
+    for (pub_name, encrypted_value) in encrypted_secrets {
         // Decrypt and authenticate secret. In case of failures, the secret is skipped.
         let (name, value) = match kms
             .open_secret(&OpenSecretRequest {
-                name: &pub_name,
-                value: &value,
+                name: pub_name,
+                value: encrypted_value,
                 context: None,
             })
             .await


### PR DESCRIPTION
Part of #2248.

## What
Keys that are part of the rofl instance metadata and start with `.env` prefix are passed as part of the env file during rofl containers init, like is currently done for the rofl secrets.

## E2E testing
Created simple tdx instance that printed container secrets, normal secrets, and "public" variable using `.env` metadata convention above. Used local build of rofl containers, and tested on the Sapphire testnet.

## Consideration
Like with secrets we expect the admin to not shoot itself by e.g.:
- Setting values that contains new line character.
- Non posix compliant variables.

## Follow-up
_Alternative solution_ from https://github.com/oasisprotocol/oasis-sdk/issues/2248#issuecomment-4826995846 can be done as follow-up without being breaking, and will be in fact complementary.