### PR TITLE
runtime-sdk: Fix typo in modules/evm/README.md

### DIFF
--- a/runtime-sdk/modules/evm/README.md
+++ b/runtime-sdk/modules/evm/README.md
@@ -5,10 +5,11 @@ of EVM-compatible smart contracts.
 
 ## Known Divergence from Ethereum
 
-* `SELFDISTRUCT` op code is unsupported. Invoking `SELFDESTRUCT` will result in
+* `SELFDESTRUCT` op code is disabled. Invoking `SELFDESTRUCT` will result in
   a transaction being reverted. Solving this would require either inefficient
   iteration over all storage keys, a special storage operation for removing
-  prefixes or some form of generational storage.
+  prefixes or some form of generational storage. This behavior is also in line
+  with the Ethereum Dencun upgrade.
 
 * `COINBASE` op code always returns an all-zero address.
 


### PR DESCRIPTION
Also mention the behavior is in line with Ethereum Dencun upgrade.

Disabled `SELFDESTRUCT` is also required to prevent simulated upgrade attacks, see https://github.com/oasisprotocol/privana/pull/228#discussion_r3696524335