### PR TITLE
rofl-scheduler: Release 0.9.0

### DIFF
--- a/.github/workflows/release-rofl-scheduler.yml
+++ b/.github/workflows/release-rofl-scheduler.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Oasis CLI
         uses: oasisprotocol/setup-cli-action@0.0.2
         with:
-          version: '0.19.0'
+          version: '0.19.1'
 
       - name: Build rofl-scheduler for Testnet
         working-directory: rofl-scheduler

--- a/rofl-scheduler/rofl.yaml
+++ b/rofl-scheduler/rofl.yaml
@@ -1,5 +1,5 @@
 name: rofl-scheduler
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/oasisprotocol/oasis-sdk
 description: Schedules and manages machines so you don't have to! Deploy your ROFL app today.
 tee: tdx
@@ -22,8 +22,8 @@ deployments:
     paratime: sapphire
     admin: rofl_scheduler_admin
     trust_root:
-      height: 30157369
-      hash: fe1e78fcb0767cc6ea716ec461e0febddf82bcf4d7e77e66469cd4ed30e35385
+      height: 31208487
+      hash: 73c3bf6ca2d32669a8936ca503b526a8489e2e3c3ef422331288c9447c33e621
     policy:
       quotes:
         pcs:
@@ -56,7 +56,11 @@ deployments:
         - id: 1e+03hCIHJ1iRjob3cRJMrzj8Rd6S4jXxBMa93tSPp0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 0.7.1
         - id: sOebCE4o7Ab3xbknAUirwNojIBRBf4vVqgYaCYy5c2EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 0.8.0
         - id: xU+f/6yYn7SsqVJ6AOE7mNUUbUk7A0MwEYoQtqhR4mEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 0.8.0
+        - id: YHFQokpc6o8c91PBzlTnu/l8f9Or77uwg2RgnY5czhkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        - id: 1BS188B3BnB7hcN7+ZmXx1ac7RObZXMcvbEUp7EUnoYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       endorsements:
         - any: {}
       fees: endorsing_node
@@ -67,8 +71,8 @@ deployments:
     paratime: sapphire
     admin: test_a
     trust_root:
-      height: 32257726
-      hash: d66ecb3715143705010fdee13a6487291e88fdce15ef464cd5b201a9f8965f27
+      height: 33330279
+      hash: 256e407e2d9c7f2ff0b240434ace6351d8780b6f53489f302bcfcb6a52d3815e
     policy:
       quotes:
         pcs:
@@ -101,10 +105,14 @@ deployments:
         - id: TtqGUQ868crT1Wci8oIVJm6Y87tqPyWApyjDiyfx0YwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 0.7.1
         - id: a5rt/zQnCMYahzvkUeFtBLYfZN6cn11GtiFey9IjRbIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 0.8.0
         - id: F9dwGzNniA3qn9N+81oZiOrkieRPSTL8MLp6sjG/42wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 0.8.0
+        - id: TLBptFRlUgr+EcC7owRl7gP1CyYb2otKBN7yYWsiDAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        - id: Say1bW082RK9hkajQE3MEoa/GpMqzkR2+mspGTZAN9kAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       endorsements:
         - any: {}
       fees: endorsing_node
       max_expiration: 3
 tooling:
-  version: 0.19.0
+  version: 0.19.1


### PR DESCRIPTION
Preparing for a new release `0.9.0` of the ROFL Scheduler.
Also updating the trust root for ROFL Scheduler and the Oasis CLI version used in the release pipeline.