### PR TITLE
ci: bind determine-tag inputs via env before shell

### DIFF
--- a/.github/actions/determine-tag/action.yml
+++ b/.github/actions/determine-tag/action.yml
@@ -34,7 +34,7 @@ runs:
           branch=${GITHUB_REF_NAME}
 
           if [[ -n "$TRIM_PREFIX" ]]; then
-        branch=${branch//\//-}
+            branch=${branch#"$TRIM_PREFIX"}
           fi
         elif [[ "$USE_BASE_FOR_PR" == "yes" ]]; then
           # Use base branch.

--- a/.github/actions/determine-tag/action.yml
+++ b/.github/actions/determine-tag/action.yml
@@ -25,15 +25,18 @@ runs:
   steps:
     - shell: bash
       id: determine-tag
+      env:
+        TRIM_PREFIX: ${{ inputs.trim_prefix }}
+        USE_BASE_FOR_PR: ${{ inputs.use_base_for_pr }}
       run: |
         if [[ -z $GITHUB_BASE_REF ]]; then
           # On master/stable branches or tags.
           branch=${GITHUB_REF_NAME}
 
-          if [[ -n "${{ inputs.trim_prefix }}" ]]; then
-            branch=${branch#"${{ inputs.trim_prefix }}"}
+          if [[ -n "$TRIM_PREFIX" ]]; then
+        branch=${branch//\//-}
           fi
-        elif [[ "${{ inputs.use_base_for_pr }}" == "yes" ]]; then
+        elif [[ "$USE_BASE_FOR_PR" == "yes" ]]; then
           # Use base branch.
           branch=$GITHUB_BASE_REF
         else


### PR DESCRIPTION
## Summary
Bind composite-action `inputs.trim_prefix` and `inputs.use_base_for_pr` into step `env:` before shell use in `.github/actions/determine-tag`.

Keeps `${{ }}` expansions out of the `run:` script.

## Test plan
- [ ] Confirm action YAML still validates
- [ ] Optional: re-run a workflow that uses determine-tag

Made with [Cursor](https://cursor.com)