### PR TITLE
runtime-sdk/src/modules/rofl: Bump MAX_METADATA_PAIRS to 128

### DIFF
--- a/rofl-client/ts/src/roflClient.ts
+++ b/rofl-client/ts/src/roflClient.ts
@@ -311,8 +311,7 @@ export class RoflClient {
      * it will trigger an automatic on-chain registration refresh. Keys are automatically
      * namespaced with 'net.oasis.app.' when published on-chain.
      *
-     * Metadata is validated against runtime-configured limits (typically max 64 pairs,
-     * max key size 1024 bytes, max value size 16KB).
+     * Metadata is validated against runtime-configured limits.
      *
      * @param metadata - Dictionary of metadata key-value pairs to set
      * @returns Promise that resolves when metadata is successfully updated

--- a/runtime-sdk/src/modules/rofl/config.rs
+++ b/runtime-sdk/src/modules/rofl/config.rs
@@ -26,7 +26,9 @@ pub trait Config: 'static {
     const GAS_COST_CALL_DERIVE_KEY: u64 = 10_000;
 
     /// Maximum number of metadata key-value pairs.
-    const MAX_METADATA_PAIRS: usize = 64;
+    /// TODO: Enforce cumulative metadata size limit instead of fixed per-pair sizes.
+    /// See https://github.com/oasisprotocol/oasis-sdk/issues/2489.
+    const MAX_METADATA_PAIRS: usize = 128;
     /// Maximum metadata key size.
     const MAX_METADATA_KEY_SIZE: usize = 1024;
     /// Maximum metadata value size.


### PR DESCRIPTION
Part of https://github.com/oasisprotocol/oasis-sdk/issues/2489.

As noted inside the issue, the rofl metadata limits are actually already way above the current max transaction size `128KiB`, so this change should be "safe".

We might consider bumping to 256, given that privana services app is already ~64 variables.